### PR TITLE
Performance tests are added for Infinispan-Query module.

### DIFF
--- a/framework/src/main/java/org/radargun/features/Queryable.java
+++ b/framework/src/main/java/org/radargun/features/Queryable.java
@@ -1,0 +1,51 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.radargun.features;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Allows running queries on the cache.
+ *
+ * @author Anna Manukyan
+ */
+public interface Queryable {
+
+   /**
+    * The parameter name, which value is the field name which should be queried.
+    */
+   public static final String QUERYABLE_FIELD = "onField";
+
+   /**
+    * The parameter name, which value is the string to which the specified field should match.
+    */
+   public static final String MATCH_STRING = "matching";
+
+   /**
+    * The parameter name, which value specifies whether the wildcard query should be executed or keyword.
+    */
+   public static final String IS_WILDCARD = "wildcard";
+
+   /**
+    * Executes keyword or wildcard queries based on the passed parameters.
+    * @param queryParameters        the map, which contains the queryable field name with it's expected value.
+    */
+   public List executeQuery(Map<String, Object> queryParameters);
+}

--- a/framework/src/main/java/org/radargun/local/LocalBenchmark.java
+++ b/framework/src/main/java/org/radargun/local/LocalBenchmark.java
@@ -54,7 +54,7 @@ public class LocalBenchmark {
          for (Properties configProps : product.getValue()) {
             final String config = configProps.getProperty("name");
             log.info("Processing " + product.getKey() + "-" + config);
-            CacheWrapper wrapper = getCacheWrapper(product.getKey());
+            CacheWrapper wrapper = getCacheWrapper(product.getKey(), configProps.getProperty("wrapper"));
             try {
                wrapper.setUp(config, true, -1, new TypedProperties(configProps));
 
@@ -159,11 +159,13 @@ public class LocalBenchmark {
       }
       writeLine(line.toString());
       for (ReportDesc reportDesc : reportDescs) {
-         long readsPerSec = (long) (double) (Double) results.get("READS_PER_SEC");
-         long noReads = (Long) results.get("READ_COUNT");
-         long writesPerSec = (long) (double) (Double) results.get("WRITES_PER_SEC");
-         long noWrites = (Long) results.get("WRITE_COUNT");
-         reportDesc.updateData(product, config, readsPerSec, noReads, writesPerSec, noWrites);
+         if(results.get("READS_PER_SEC") != null && results.get("WRITE_COUNT") != null) {
+            long readsPerSec = (long) (double) (Double) results.get("READS_PER_SEC");
+            long noReads = (Long) results.get("READ_COUNT");
+            long writesPerSec = (long) (double) (Double) results.get("WRITES_PER_SEC");
+            long noWrites = (Long) results.get("WRITE_COUNT");
+            reportDesc.updateData(product, config, readsPerSec, noReads, writesPerSec, noWrites);
+         }
       }
    }
 
@@ -183,8 +185,11 @@ public class LocalBenchmark {
       reportCsvContent.append('\n').append(line);
    }
 
-   private CacheWrapper getCacheWrapper(String product) throws Exception {
-      String fqnClass = Utils.getCacheWrapperFqnClass(product);
+   private CacheWrapper getCacheWrapper(String product, String fqnClass) throws Exception {
+      if(fqnClass == null) {
+         fqnClass = Utils.getCacheWrapperFqnClass(product);
+      }
+
       URLClassLoader loader = Utils.buildProductSpecificClassLoader(product, getClass().getClassLoader());
       Thread.currentThread().setContextClassLoader(loader);
       return (CacheWrapper) loader.loadClass(fqnClass).newInstance();

--- a/framework/src/main/java/org/radargun/local/LocalChartGenerator.java
+++ b/framework/src/main/java/org/radargun/local/LocalChartGenerator.java
@@ -33,21 +33,23 @@ public class LocalChartGenerator {
    public void generateChart(String dir) throws Exception {
       long nrReads = 0;
       long nrWrites = 0;
-      for (ReportItem item : reportDesc.getItems()) {
-         getData.addValue(item.getReadsPerSec(), item.description(), "GET");
-         nrReads += item.getNoReads();
-         putData.addValue(item.getWritesPerSec(), item.description(), "PUT");
-         nrWrites += item.getNoWrites();
+      if(reportDesc.getItems().size() > 0) {
+         for (ReportItem item : reportDesc.getItems()) {
+            getData.addValue(item.getReadsPerSec(), item.description(), "GET");
+            nrReads += item.getNoReads();
+            putData.addValue(item.getWritesPerSec(), item.description(), "PUT");
+            nrWrites += item.getNoWrites();
+         }
+         File localGetFile = new File(dir, "local_gets_" + reportDesc.getReportName() + ".png");
+         Utils.backupFile(localGetFile);
+
+         ChartUtilities.saveChartAsPNG(localGetFile, createChart("Report: Comparing Cache GET (READ) performance", getData, (int) (nrReads / reportDesc.getItems().size()), "(GETS)"), 800, 800);
+
+         File localPutFile = new File(dir, "local_puts_" + reportDesc.getReportName() + ".png");
+         Utils.backupFile(localPutFile);
+
+         ChartUtilities.saveChartAsPNG(localPutFile, createChart("Report: Comparing Cache PUT (WRITE) performance", putData, (int) (nrWrites / reportDesc.getItems().size()), "(PUTS)"), 800, 800);
       }
-      File localGetFile = new File(dir, "local_gets_" + reportDesc.getReportName() + ".png");
-      Utils.backupFile(localGetFile);
-
-      ChartUtilities.saveChartAsPNG(localGetFile, createChart("Report: Comparing Cache GET (READ) performance", getData, (int) (nrReads / reportDesc.getItems().size()), "(GETS)"), 800, 800);
-
-      File localPutFile = new File(dir, "local_puts_" + reportDesc.getReportName() + ".png");
-      Utils.backupFile(localPutFile);
-
-      ChartUtilities.saveChartAsPNG(localPutFile, createChart("Report: Comparing Cache PUT (WRITE) performance", putData, (int) (nrWrites / reportDesc.getItems().size()), "(PUTS)"), 800, 800);
    }
 
    private JFreeChart createChart(String title, DefaultCategoryDataset data, int numOperations, String operation) {

--- a/framework/src/main/java/org/radargun/stages/ClusterValidationStage.java
+++ b/framework/src/main/java/org/radargun/stages/ClusterValidationStage.java
@@ -177,7 +177,7 @@ public class ClusterValidationStage extends AbstractDistStage {
             continue;
          }
          Object data = tryGet(i);
-         if (data == null || !"true".equals(data)) {
+         if (data == null || !"true".equals(data.toString())) {
             log.trace("Cache with index " + i + " did *NOT* replicate");
          } else {
             log.trace("Cache with index " + i + " replicated here ");

--- a/framework/src/main/java/org/radargun/stages/DataForQueryStage.java
+++ b/framework/src/main/java/org/radargun/stages/DataForQueryStage.java
@@ -1,0 +1,55 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.radargun.stages;
+
+import org.radargun.config.Property;
+import org.radargun.config.PropertyHelper;
+import org.radargun.config.Stage;
+import org.radargun.stressors.DataForQueryStressor;
+
+import java.util.Map;
+
+/**
+ * Stage for inserting data into indexed cache for processing.
+ *
+ * @author Anna Manukyan
+ */
+@Stage(doc = "Stage which executes puts/gets indexed entries against index enabled cache.")
+public class DataForQueryStage extends StressTestStage {
+
+   @Property(doc = "The length of the generated indexed entry. Default is 100.")
+   private int propertyLength = 100;
+
+   @Property(doc = "Specifies whether the key generation should be done according to wildcard logic or no. Default is false.")
+   private boolean isWildCard = false;
+
+   @Property(doc = "Specifies the full path of the property file which contains different words for querying. No default value is provided. This property is mandatory.")
+   private String dataPath = null;
+
+   protected Map<String, Object> doWork() {
+      log.info("Starting "+getClass().getSimpleName()+": " + this);
+      DataForQueryStressor stressTestStressor = null;
+      stressTestStressor = new DataForQueryStressor();
+
+      stressTestStressor.setNodeIndex(getSlaveIndex(), getActiveSlaveCount());
+      PropertyHelper.copyProperties(this, stressTestStressor);
+
+      return stressTestStressor.stress(cacheWrapper);
+   }
+}

--- a/framework/src/main/java/org/radargun/stages/GenerateChartStage.java
+++ b/framework/src/main/java/org/radargun/stages/GenerateChartStage.java
@@ -101,7 +101,9 @@ public class GenerateChartStage extends AbstractMasterStage {
          StringTokenizer tokenizer = new StringTokenizer(Utils.fileName2Config(f.getName()), "_");
          productName = tokenizer.nextToken();
          configName = tokenizer.nextToken();
-         clusterSize = Integer.parseInt(tokenizer.nextToken());
+         if(tokenizer.hasMoreTokens()) {
+            clusterSize = Integer.parseInt(tokenizer.nextToken());
+         }
       } catch (Throwable e) {
          String fileName = f == null ? null : f.getAbsolutePath();
          log.error("unexpected exception while parsing filename: " + fileName, e);

--- a/framework/src/main/java/org/radargun/stages/QueryStage.java
+++ b/framework/src/main/java/org/radargun/stages/QueryStage.java
@@ -1,0 +1,55 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.radargun.stages;
+
+import org.radargun.config.Property;
+import org.radargun.config.PropertyHelper;
+import org.radargun.config.Stage;
+import org.radargun.stressors.QueryStressor;
+
+import java.util.Map;
+
+/**
+ * Executes Queries using Infinispan-Query API against the cache.
+ *
+ * @author Anna Manukyan
+ */
+@Stage(doc = "Stage which executes a Query using Infinispan-query API against all keys in the cache.")
+public class QueryStage extends StressTestStage {
+
+   @Property(optional = false, doc = "Boolean variable which shows whether the keyword query should be done or wildcard.")
+   private boolean isWildcardQuery;
+
+   @Property(optional = false, doc = "The name of the field for which the query should be executed.")
+   private String onField;
+
+   @Property(optional = false, doc = "The matching string which should be used for querying.")
+   private String matching;
+
+   protected Map<String, Object> doWork() {
+      log.info("Starting "+getClass().getSimpleName()+": " + this);
+
+      QueryStressor stressTestStressor = new QueryStressor();
+      stressTestStressor.setNodeIndex(getSlaveIndex(), getActiveSlaveCount());
+
+      PropertyHelper.copyProperties(this, stressTestStressor);
+
+      return stressTestStressor.stress(cacheWrapper);
+   }
+}

--- a/framework/src/main/java/org/radargun/stressors/DataForQueryStressor.java
+++ b/framework/src/main/java/org/radargun/stressors/DataForQueryStressor.java
@@ -1,0 +1,125 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.radargun.stressors;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.radargun.CacheWrapper;
+import org.radargun.config.Property;
+import org.radargun.config.Stressor;
+
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+/**
+ * Stressor which writes Queryable data into the cache.
+ *
+ * @author Anna Manukyan
+ */
+@Stressor(doc = "Executes put and get operations against the cache wrapper. The puts and gets are performed on indexed cache.")
+public class DataForQueryStressor extends StressTestStressor {
+
+   private static final Log log = LogFactory.getLog(DataForQueryStressor.class);
+
+   @Property(doc = "The length of the generated indexed entry. Default is 100.")
+   private int propertyLength = 100;
+
+   @Property(doc = "Specifies whether the key generation should be done according to wildcard logic or no. Default is false.")
+   private boolean isWildCard = false;
+
+   @Property(doc = "Specifies the full path of the property file which contains different words for querying. No default value is provided. This property is mandatory.")
+   private String dataPath = null;
+
+   private List<String> wordsFromFile = null;
+
+   @Override
+   protected void init(CacheWrapper wrapper) {
+      if(dataPath == null) {
+         throw new IllegalArgumentException("The path to the data file should be provided. The attribute 'dataPath' should be not empty.");
+      }
+
+      wordsFromFile = readDataFromFile();
+      super.init(wrapper);
+   }
+
+   @Override
+   public Object generateValue(int size) {
+      char[] letters = "abcdefghijklmnopqrstuvw 1234567890".toCharArray();
+      Random rand = new Random();
+      StringBuffer str = new StringBuffer();
+
+      if (isWildCard) {
+         str.append(wordsFromFile.get(rand.nextInt(wordsFromFile.size())));
+
+         while(str.length() < propertyLength) {
+            char symbol = letters[rand.nextInt(letters.length)];
+            str.append(symbol);
+         }
+      } else {
+         while(str.length() < propertyLength) {
+            str.append(wordsFromFile.get(rand.nextInt(wordsFromFile.size()))).append(" ");
+         }
+      }
+
+      return str.toString();
+   }
+
+   private List<String> readDataFromFile() {
+      List<String> wordsFromFile = new ArrayList<String>();
+      BufferedReader br = null;
+
+      try {
+         br = new BufferedReader(new FileReader(dataPath));
+         String line;
+         while ((line = br.readLine()) != null) {
+            wordsFromFile.add(line);
+         }
+      } catch(IOException ex) {
+         log.error("Error is thrown during file reading!", ex);
+         throw new RuntimeException(ex);
+      } finally {
+         try {
+            if(br != null) br.close();
+         } catch (IOException ex) {
+            log.error("Error is thrown during closing file stream!", ex);
+            throw new RuntimeException(ex);
+         }
+      }
+
+      return wordsFromFile;
+   }
+
+   @Override
+   public void destroy() {
+      //Do nothing
+   }
+
+   @Override
+   public String toString() {
+      return "DataForQueryStressor {" +
+            "isWildcard =" + isWildCard +
+            ", dataPath =" + dataPath +
+            ", propertyLength =" + propertyLength +
+            "}";
+   }
+}

--- a/framework/src/main/java/org/radargun/stressors/Operation.java
+++ b/framework/src/main/java/org/radargun/stressors/Operation.java
@@ -23,6 +23,7 @@ public enum Operation {
    PUT_ALL_VIA_ASYNC,
    REMOVE_ALL,
    REMOVE_ALL_VIA_ASYNC,
+   QUERY,
    TRANSACTION; /* stats for whole transaction */
 
    private String altName;

--- a/framework/src/main/java/org/radargun/stressors/QueryStressor.java
+++ b/framework/src/main/java/org/radargun/stressors/QueryStressor.java
@@ -1,0 +1,98 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.radargun.stressors;
+
+import org.radargun.config.Property;
+import org.radargun.config.Stressor;
+import org.radargun.features.Queryable;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Stressor for Local cache mode, which will execute queries on the cache.
+ *
+ * @author Anna Manukyan
+ */
+@Stressor(doc = "Executes queries using infinispan-query API against the cache wrapper.")
+public class QueryStressor extends StressTestStressor {
+   @Property(optional = false, doc = "Boolean variable which shows whether the keyword query should be done or wildcard.")
+   private boolean isWildcardQuery;
+
+   @Property(optional = false, doc = "The name of the field for which the query should be executed.")
+   private String onField;
+
+   @Property(optional = false, doc = "The matching string which should be used for querying.")
+   private String matching;
+
+   private List<Integer> resultObjects = null;
+
+   public OperationLogic getLogic() {
+      return new QueryRunnerLogic();
+   }
+
+   protected class QueryRunnerLogic implements OperationLogic {
+
+      @Override
+      public void init(String bucketId, int threadIndex) {
+         resultObjects = new ArrayList();
+      }
+
+      @Override
+      public Object run(Stressor stressor, int iteration) {
+         Map<String, Object> paramMap = new HashMap<String, Object>();
+         paramMap.put(Queryable.QUERYABLE_FIELD, onField);
+         paramMap.put(Queryable.MATCH_STRING, matching);
+         paramMap.put(Queryable.IS_WILDCARD, isWildcardQuery);
+
+         List obj = (List) stressor.makeRequest(iteration, Operation.QUERY, paramMap);
+         resultObjects.add(obj.size());
+
+         return obj;
+      }
+   }
+
+   protected Map<String, Object> processResults() {
+      compareQueryResults();
+
+      return super.processResults();
+   }
+
+   private void compareQueryResults() {
+      int previousResult = -1;
+      for (Integer queryResult : resultObjects) {
+         if (previousResult > 0) {
+            assert queryResult == previousResult : "The results are not the same for all queries.";
+         }
+
+         previousResult = queryResult;
+      }
+   }
+
+   @Override
+   public String toString() {
+      return "QueryStressor{" +
+            "isWildcardQuery=" + isWildcardQuery +
+            ", onField=" + onField +
+            ", matching=" + matching +
+            "}";
+   }
+}

--- a/framework/src/main/resources/radargun-1.1.xsd
+++ b/framework/src/main/resources/radargun-1.1.xsd
@@ -26,6 +26,7 @@
                         <element name="ClientStressTest" type="rg:ClientStressTest"/>
                         <element name="ClusterValidation" type="rg:ClusterValidation"/>
                         <element name="CsvReportGeneration" type="rg:CsvReportGeneration"/>
+                        <element name="DataForQuery" type="rg:DataForQuery"/>
                         <element name="DestroyWrapper" type="rg:DestroyWrapper"/>
                         <element name="GenerateChart" type="rg:GenerateChart"/>
                         <element name="IsolationLevelCheck" type="rg:IsolationLevelCheck"/>
@@ -36,6 +37,7 @@
                         <element name="LoadFile" type="rg:LoadFile"/>
                         <element name="MapReduce" type="rg:MapReduce"/>
                         <element name="ParallelStartKill" type="rg:ParallelStartKill"/>
+                        <element name="Query" type="rg:Query"/>
                         <element name="ReportBackgroundStats" type="rg:ReportBackgroundStats"/>
                         <element name="ReportJVMMonitor" type="rg:ReportJVMMonitor"/>
                         <element name="SetLogLevel" type="rg:SetLogLevel"/>
@@ -131,6 +133,7 @@
             <element name="ClientStressTest" type="rg:ClientStressTest"/>
             <element name="ClusterValidation" type="rg:ClusterValidation"/>
             <element name="CsvReportGeneration" type="rg:CsvReportGeneration"/>
+            <element name="DataForQuery" type="rg:DataForQuery"/>
             <element name="DestroyWrapper" type="rg:DestroyWrapper"/>
             <element name="GenerateChart" type="rg:GenerateChart"/>
             <element name="IsolationLevelCheck" type="rg:IsolationLevelCheck"/>
@@ -141,6 +144,7 @@
             <element name="LoadFile" type="rg:LoadFile"/>
             <element name="MapReduce" type="rg:MapReduce"/>
             <element name="ParallelStartKill" type="rg:ParallelStartKill"/>
+            <element name="Query" type="rg:Query"/>
             <element name="ReportBackgroundStats" type="rg:ReportBackgroundStats"/>
             <element name="ReportJVMMonitor" type="rg:ReportJVMMonitor"/>
             <element name="SetLogLevel" type="rg:SetLogLevel"/>
@@ -528,6 +532,30 @@
          </extension>
       </complexContent>
    </complexType>
+   <complexType name="DataForQuery">
+      <annotation>
+         <documentation>Stage which executes puts/gets indexed entries against index enabled cache.</documentation>
+      </annotation>
+      <complexContent>
+         <extension base="rg:StressTest">
+            <attribute name="dataPath" type="string">
+               <annotation>
+                  <documentation>Specifies the full path of the property file which contains different words for querying. No default value is provided. This property is mandatory.</documentation>
+               </annotation>
+            </attribute>
+            <attribute name="isWildCard" type="string">
+               <annotation>
+                  <documentation>Specifies whether the key generation should be done according to wildcard logic or no. Default is false.</documentation>
+               </annotation>
+            </attribute>
+            <attribute name="propertyLength" type="string">
+               <annotation>
+                  <documentation>The length of the generated indexed entry. Default is 100.</documentation>
+               </annotation>
+            </attribute>
+         </extension>
+      </complexContent>
+   </complexType>
    <complexType name="DestroyWrapper">
       <annotation>
          <documentation>Distributed stage that will stop the cache wrapper on each slave.</documentation>
@@ -814,6 +842,30 @@ Remember to set up JVM args: "-agentpath:/path/to/libjprofilerti.so=offline,id=1
             <attribute name="start" type="string">
                <annotation>
                   <documentation>Set of slaves which should be started in this stage. Default is empty.</documentation>
+               </annotation>
+            </attribute>
+         </extension>
+      </complexContent>
+   </complexType>
+   <complexType name="Query">
+      <annotation>
+         <documentation>Stage which executes a Query using Infinispan-query API against all keys in the cache.</documentation>
+      </annotation>
+      <complexContent>
+         <extension base="rg:StressTest">
+            <attribute name="isWildcardQuery" type="string">
+               <annotation>
+                  <documentation>Boolean variable which shows whether the keyword query should be done or wildcard.</documentation>
+               </annotation>
+            </attribute>
+            <attribute name="matching" type="string">
+               <annotation>
+                  <documentation>The matching string which should be used for querying.</documentation>
+               </annotation>
+            </attribute>
+            <attribute name="onField" type="string">
+               <annotation>
+                  <documentation>The name of the field for which the query should be executed.</documentation>
                </annotation>
             </attribute>
          </extension>

--- a/plugins/infinispan52/pom.xml
+++ b/plugins/infinispan52/pom.xml
@@ -13,11 +13,42 @@
    <version>1.1.0-SNAPSHOT</version>
    <name>Infinispan 5.2.x plugin for RadarGun</name>
 
+   <properties>
+      <version.infinispan>5.2.1.Final</version.infinispan>
+      <version.c3p0>0.9.1.2</version.c3p0>
+      <version.h2>1.3.171</version.h2>
+      <version.jbossts>4.16.3.Final</version.jbossts>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.infinispan</groupId>
          <artifactId>infinispan-core</artifactId>
-         <version>5.2.1.Final</version>
+         <version>${version.infinispan}</version>
+      </dependency>
+
+      <dependency>
+         <groupId>org.infinispan</groupId>
+         <artifactId>infinispan-query</artifactId>
+         <version>${version.infinispan}</version>
+      </dependency>
+
+      <dependency>
+         <groupId>org.infinispan</groupId>
+         <artifactId>infinispan-cachestore-jdbc</artifactId>
+         <version>${version.infinispan}</version>
+      </dependency>
+
+      <dependency>
+         <groupId>c3p0</groupId>
+         <artifactId>c3p0</artifactId>
+         <version>${version.c3p0}</version>
+      </dependency>
+
+      <dependency>
+         <groupId>com.h2database</groupId>
+         <artifactId>h2</artifactId>
+         <version>${version.h2}</version>
       </dependency>
 
       <dependency>
@@ -35,7 +66,7 @@
       <dependency>
          <groupId>org.jboss.jbossts</groupId>
          <artifactId>jbossjta</artifactId>
-         <version>4.16.3.Final</version>
+         <version>${version.jbossts}</version>
          <exclusions>
             <exclusion>
                <groupId>org.jboss.logging</groupId>

--- a/plugins/infinispan52/src/main/java/org/radargun/cachewrappers/InfinispanQueryWrapper.java
+++ b/plugins/infinispan52/src/main/java/org/radargun/cachewrappers/InfinispanQueryWrapper.java
@@ -1,0 +1,98 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.radargun.cachewrappers;
+
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.Indexed;
+import org.hibernate.search.annotations.Store;
+import org.hibernate.search.query.dsl.QueryBuilder;
+import org.hibernate.search.query.dsl.TermTermination;
+import org.infinispan.Cache;
+import org.infinispan.query.CacheQuery;
+import org.infinispan.query.Search;
+import org.infinispan.query.SearchManager;
+import org.radargun.features.Queryable;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Wrapper which will be able to run queries on Infinispan caches.
+ *
+ * @author Anna Manukyan
+ */
+public class InfinispanQueryWrapper extends InfinispanXSWrapper implements Queryable, Serializable {
+
+   @Override
+   public List executeQuery(Map<String, Object> queryParameters) {
+      Cache cache = cacheManager.getCache(getCacheName());
+
+      SearchManager searchManager = Search.getSearchManager(cache);
+      QueryBuilder queryBuilder = searchManager.buildQueryBuilderForClass(QueryableData.class).get();
+      TermTermination termTermination;
+      Boolean isWildcardQuery = (Boolean) queryParameters.get(IS_WILDCARD);
+      String onField = (String) queryParameters.get(QUERYABLE_FIELD);
+      String matching = (String) queryParameters.get(MATCH_STRING);
+
+      if (isWildcardQuery) {
+         termTermination = queryBuilder.keyword().wildcard().onField(onField).matching(matching);
+      } else {
+         termTermination = queryBuilder.keyword().onField(onField).matching(matching);
+      }
+
+      CacheQuery cacheQuery = searchManager.getQuery(termTermination.createQuery());
+
+      return cacheQuery.list();
+   }
+
+   public void empty() {
+      //Do nothing
+   }
+
+   public void put(String bucket, Object key, Object value) throws Exception {
+      QueryableData data = new QueryableData((String) value);
+
+      super.put(getCacheName(), key, data);
+   }
+
+   public Object get(String bucket, Object key) throws Exception {
+      return super.get(getCacheName(), key);
+   }
+
+   @Indexed(index = "query")
+   public class QueryableData implements Serializable {
+
+      @Field(store = Store.YES)
+      private String description;
+
+      public QueryableData(String description) {
+         this.description = description;
+      }
+
+      public String getDescription() {
+         return description;
+      }
+
+      public String toString() {
+         return description;
+      }
+
+   }
+}


### PR DESCRIPTION
New performance tests are added for infinispan-query module. 

In plugins/infinispan52 new wrapper class is created - org.radargun.cachewrappers.InfinispanQueryWrapper which is responsible for executing queries in infinispan cache, as well as the put is overridden for making possible insertion of non-string but indexed entries into the cache. 

New interface org.radargun.features.Queryable is created for marking queryable wrapper. 

As well as new Stressors and new Stages are created - org.radargun.stressors.DataForQueryStressor and org.radargun.stressors.QueryStressor for putting data into the cache and running queries on the cache correspondingly. The corresponding stages are created as well. 

Small changes are done in the existing StressTestStressor  as well as in chart generating code for proper work on queryies. 
