### PR TITLE
Remove throws clause from main methods, and exit on Exceptions

### DIFF
--- a/framework/src/main/java/org/radargun/LaunchMaster.java
+++ b/framework/src/main/java/org/radargun/LaunchMaster.java
@@ -15,7 +15,7 @@ public class LaunchMaster {
 
    private static Log log = LogFactory.getLog(LaunchMaster.class);
 
-   public static void main(String[] args) throws Exception {
+   public static void main(String[] args) {
 
       File currentDir = new File(".");
       String message = "Running in directory: " + currentDir.getAbsolutePath();
@@ -25,10 +25,15 @@ public class LaunchMaster {
 
       out("Configuration file is: " + config);
 
-      ConfigParser configParser = ConfigParser.getConfigParser();
-      MasterConfig masterConfig = configParser.parseConfig(config);
-      Master server = new Master(masterConfig);
-      server.start();
+      try {
+         ConfigParser configParser = ConfigParser.getConfigParser();
+         MasterConfig masterConfig = configParser.parseConfig(config);
+         Master server = new Master(masterConfig);
+         server.start();
+      } catch (Exception e) {
+         e.printStackTrace();
+         ShutDownHook.exit(10);
+      }
    }
 
    private static String getConfigOrExit(String[] args) {

--- a/framework/src/main/java/org/radargun/Slave.java
+++ b/framework/src/main/java/org/radargun/Slave.java
@@ -196,7 +196,7 @@ public class Slave {
       }
    }
 
-   public static void main(String[] args) throws Exception {
+   public static void main(String[] args) {
       String masterHost = null;
       int masterPort = Master.DEFAULT_PORT;
       int slaveIndex = -1;
@@ -227,7 +227,12 @@ public class Slave {
          printUsageAndExit();
       }
       Slave slave = new Slave(masterHost, masterPort, slaveIndex);
-      slave.start();
+      try {
+         slave.start();
+      } catch (Exception e) {
+         e.printStackTrace();
+         ShutDownHook.exit(10);
+      }
    }
 
    private static void printUsageAndExit() {


### PR DESCRIPTION
This causes the RadarGun processes to exit as soon as an exception is
thrown. I have had issues with the processes not exiting when run in
Jenkins.
