### PR TITLE
Made Infinispan 6.0.x plugin to build

### DIFF
--- a/plugins/infinispan60/pom.xml
+++ b/plugins/infinispan60/pom.xml
@@ -14,7 +14,7 @@
    <name>Infinispan 6.0.x plugin for RadarGun</name>
 
    <properties>
-      <version.infinispan>6.0.0-SNAPSHOT</version.infinispan>
+      <version.infinispan>6.0.0.Alpha1</version.infinispan>
       <version.jbossts>4.16.3.Final</version.jbossts>
    </properties>
 

--- a/pom-links.xml
+++ b/pom-links.xml
@@ -17,6 +17,7 @@
       <module>plugins/infinispan51</module>
       <module>plugins/infinispan52</module>
       <module>plugins/infinispan53</module>
+      <module>plugins/infinispan60</module>
       <module>plugins/jgroups</module>
       <module>plugins/jbosscache2</module>
       <module>plugins/jbosscache3</module>

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
       <module>plugins/infinispan51</module>
       <module>plugins/infinispan52</module>
       <module>plugins/infinispan53</module>
+      <module>plugins/infinispan60</module>
       <module>plugins/jgroups</module>
       <module>plugins/jbosscache2</module>
       <module>plugins/jbosscache3</module>


### PR DESCRIPTION
Radargun building fails currently because the build process tries to copy files to a directory that doesn't exist because the Infinispan 6.0.x plugin is not built. The solutions would be to remove the file coping from the process or build the 6.0.x plugin. This is the latter.
