### PR TITLE
Enable building Infinispan 6

### DIFF
--- a/plugins/infinispan52/pom.xml
+++ b/plugins/infinispan52/pom.xml
@@ -20,6 +20,18 @@
       <version.jbossts>4.16.3.Final</version.jbossts>
    </properties>
 
+   <profiles>
+      <profile>
+         <id>infinispan52-snapshot</id>
+         <activation>
+            <activeByDefault>false</activeByDefault>
+         </activation>
+         <properties>
+            <version.infinispan>5.2.0-SNAPSHOT</version.infinispan>
+         </properties>
+      </profile>
+   </profiles>
+
    <dependencies>
       <dependency>
          <groupId>org.infinispan</groupId>

--- a/plugins/infinispan53/pom.xml
+++ b/plugins/infinispan53/pom.xml
@@ -19,6 +19,30 @@
       <version.jbossts>4.16.3.Final</version.jbossts>
    </properties>
 
+   <profiles>
+      <profile>
+         <id>infinispan53-snapshot</id>
+         <activation>
+            <activeByDefault>false</activeByDefault>
+         </activation>
+         <properties>
+            <version.infinispan>5.3.0-SNAPSHOT</version.infinispan>
+         </properties>
+      </profile>
+      <profile>
+         <id>leveldb</id>
+         <activation>
+            <activeByDefault>false</activeByDefault>
+         </activation>
+         <dependencies>
+            <dependency>
+               <groupId>org.infinispan</groupId>
+               <artifactId>infinispan-cachestore-leveldb</artifactId>
+               <version>${version.infinispan}</version>
+            </dependency>
+         </dependencies>
+      </profile>
+   </profiles>
 
    <dependencies>
       <dependency>
@@ -72,21 +96,5 @@
       </dependency>
 
    </dependencies>
-
-   <profiles>
-      <profile>
-         <id>leveldb</id>
-         <activation>
-            <activeByDefault>false</activeByDefault>
-         </activation>
-         <dependencies>
-            <dependency>
-               <groupId>org.infinispan</groupId>
-               <artifactId>infinispan-cachestore-leveldb</artifactId>
-               <version>${version.infinispan}</version>
-            </dependency>
-         </dependencies>
-      </profile>
-   </profiles>
 
 </project>

--- a/plugins/infinispan60/pom.xml
+++ b/plugins/infinispan60/pom.xml
@@ -14,11 +14,36 @@
    <version>1.1.0-SNAPSHOT</version>
    <name>Infinispan 6.0.x plugin for RadarGun</name>
 
+   <profiles>
+      <profile>
+         <id>infinispan60-snapshot</id>
+         <activation>
+            <activeByDefault>false</activeByDefault>
+         </activation>
+         <properties>
+            <version.infinispan>6.0.0-SNAPSHOT</version.infinispan>
+         </properties>
+      </profile>
+      <profile>
+         <id>leveldb</id>
+         <activation>
+            <activeByDefault>false</activeByDefault>
+         </activation>
+         <dependencies>
+            <dependency>
+               <groupId>org.infinispan</groupId>
+               <artifactId>infinispan-cachestore-leveldb</artifactId>
+            	<!-- In Infinispan 6.0, cachestores can have independent versions -->
+               <version>6.0.0-SNAPSHOT</version>
+            </dependency>
+         </dependencies>
+      </profile>
+   </profiles>
+
    <properties>
-      <version.infinispan>6.0.0-SNAPSHOT</version.infinispan>
+      <version.infinispan>6.0.0.Alpha3</version.infinispan>
       <version.jbossts>4.16.3.Final</version.jbossts>
    </properties>
-
 
    <dependencies>
       <dependency>
@@ -82,21 +107,5 @@
       </dependency>
 
    </dependencies>
-
-   <profiles>
-      <profile>
-         <id>leveldb</id>
-         <activation>
-            <activeByDefault>false</activeByDefault>
-         </activation>
-         <dependencies>
-            <dependency>
-               <groupId>org.infinispan</groupId>
-               <artifactId>infinispan-cachestore-leveldb</artifactId>
-               <version>${version.infinispan}</version>
-            </dependency>
-         </dependencies>
-      </profile>
-   </profiles>
 
 </project>

--- a/pom-links.xml
+++ b/pom-links.xml
@@ -18,6 +18,7 @@
       <module>plugins/infinispan51</module>
       <module>plugins/infinispan52</module>
       <module>plugins/infinispan53</module>
+      <module>plugins/infinispan60</module>
       <module>plugins/jgroups</module>
       <module>plugins/jbosscache2</module>
       <module>plugins/jbosscache3</module>
@@ -40,53 +41,6 @@
    </properties>
 
    <profiles>
-      <profile>
-         <id>infinispan60</id>
-         <activation>
-            <activeByDefault>false</activeByDefault>
-         </activation>
-         <modules>
-            <module>plugins/infinispan60</module>
-         </modules>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>org.apache.maven.plugins</groupId>
-                  <artifactId>maven-antrun-plugin</artifactId>
-                  <version>1.3</version>
-                  <executions>
-                     <execution>
-                        <id>prepare_infinispan60_plugin</id>
-                        <phase>verify</phase>
-                        <goals>
-                           <goal>run</goal>
-                        </goals>
-                        <configuration>
-                           <tasks>
-                              <echo message="Packaging the Infinispan 6.0.x snapshot plugin" />
-                              <copy todir="${distribution.artifact}/plugins/infinispan60">
-                                 <fileset dir="plugins/infinispan60/target/distribution/plugin-infinispan60-bin/plugin-infinispan60">
-                                    <include name="**/*" />
-                                    <exclude name="**/*.jar" />
-                                 </fileset>
-                              </copy>
-                              <copy todir="${distribution.artifact}/plugin-dependencies">
-                                 <fileset dir="plugins/infinispan60/target/distribution/plugin-infinispan60-bin/plugin-infinispan60/lib">
-                                    <include name="*.jar" />
-                                 </fileset>
-                              </copy>
-                              <exec executable="bash" failonerror="true">
-                                 <arg value="-c"/>
-                                 <arg value="for FILE in `ls plugins/infinispan60/target/distribution/plugin-infinispan60-bin/plugin-infinispan60/lib/`; do ln -s ../../../plugin-dependencies/$FILE ${distribution.artifact}/plugins/infinispan60/lib/; done;"/>
-                              </exec>
-                           </tasks>
-                        </configuration>
-                     </execution>
-                  </executions>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
       <profile>
          <id>coherence</id>
          <activation>
@@ -394,6 +348,22 @@
                         <exec executable="bash" failonerror="true">
                            <arg value="-c"/>
                            <arg value="for FILE in `ls plugins/infinispan53/target/distribution/plugin-infinispan53-bin/plugin-infinispan53/lib/`; do ln -s ../../../plugin-dependencies/$FILE ${distribution.artifact}/plugins/infinispan53/lib/; done;"/>
+                        </exec>
+
+                        <copy todir="${distribution.artifact}/plugins/infinispan60">
+                           <fileset dir="plugins/infinispan60/target/distribution/plugin-infinispan60-bin/plugin-infinispan60">
+                              <include name="**/*" />
+                              <exclude name="**/*.jar" />
+                           </fileset>
+                        </copy>
+                        <copy todir="${distribution.artifact}/plugin-dependencies">
+                           <fileset dir="plugins/infinispan60/target/distribution/plugin-infinispan60-bin/plugin-infinispan60/lib">
+                              <include name="*.jar" />
+                           </fileset>
+                        </copy>
+                        <exec executable="bash" failonerror="true">
+                           <arg value="-c"/>
+                           <arg value="for FILE in `ls plugins/infinispan60/target/distribution/plugin-infinispan60-bin/plugin-infinispan60/lib/`; do ln -s ../../../plugin-dependencies/$FILE ${distribution.artifact}/plugins/infinispan60/lib/; done;"/>
                         </exec>
 
                         <copy todir="${distribution.artifact}/plugins/jgroups">

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
       <module>plugins/infinispan51</module>
       <module>plugins/infinispan52</module>
       <module>plugins/infinispan53</module>
+      <module>plugins/infinispan60</module>
       <module>plugins/jgroups</module>
       <module>plugins/jbosscache2</module>
       <module>plugins/jbosscache3</module>
@@ -40,43 +41,6 @@
    </properties>
 
    <profiles>
-      <profile>
-         <id>infinispan60</id>
-         <activation>
-            <activeByDefault>false</activeByDefault>
-         </activation>
-         <modules>
-            <module>plugins/infinispan60</module>
-         </modules>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>org.apache.maven.plugins</groupId>
-                  <artifactId>maven-antrun-plugin</artifactId>
-                  <version>1.3</version>
-                  <executions>
-                     <execution>
-                        <id>prepare_infinispan60_plugin</id>
-                        <phase>verify</phase>
-                        <goals>
-                           <goal>run</goal>
-                        </goals>
-                        <configuration>
-                           <tasks>
-                              <echo message="Packaging the Infinispan 6.0.x snapshot plugin" />
-                              <copy todir="${distribution.artifact}/plugins/infinispan60">
-                                 <fileset dir="plugins/infinispan60/target/distribution/plugin-infinispan60-bin/plugin-infinispan60">
-                                    <include name="**/*" />
-                                 </fileset>
-                              </copy>
-                           </tasks>
-                        </configuration>
-                     </execution>
-                  </executions>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
       <profile>
          <id>coherence</id>
          <activation>
@@ -231,7 +195,7 @@
                         </java>
 
                         <echo
-                           message="Packaging the framework, and the following plugins: hazelcast2, hazelcast3, infinispan4, infinispan50, infinispan51, infinispan52, infinispan53, jbosscache2, jbosscache3, ehcache25, ehcache26, terracotta3" />
+                           message="Packaging the framework, and the following plugins: hazelcast2, hazelcast3, infinispan4, infinispan50, infinispan51, infinispan52, infinispan53, infinispan60, jbosscache2, jbosscache3, ehcache25, ehcache26, terracotta3" />
 
                         <copy todir="${distribution.artifact}/plugins/hazelcast2">
                            <fileset dir="plugins/hazelcast2/target/distribution/plugin-hazelcast2-bin/plugin-hazelcast2">
@@ -271,6 +235,12 @@
 
                         <copy todir="${distribution.artifact}/plugins/infinispan53">
                            <fileset dir="plugins/infinispan53/target/distribution/plugin-infinispan53-bin/plugin-infinispan53">
+                              <include name="**/*" />
+                           </fileset>
+                        </copy>
+
+                        <copy todir="${distribution.artifact}/plugins/infinispan60">
+                           <fileset dir="plugins/infinispan60/target/distribution/plugin-infinispan60-bin/plugin-infinispan60">
                               <include name="**/*" />
                            </fileset>
                         </copy>


### PR DESCRIPTION
Add profiles to build Infinispan 5.2, 5.3, and 6.0 snapshots and LevelDB
cachestore
