### PR TITLE
New background stressor logic

### DIFF
--- a/framework/src/main/java/org/radargun/stages/CheckBackgroundStressorsStage.java
+++ b/framework/src/main/java/org/radargun/stages/CheckBackgroundStressorsStage.java
@@ -1,0 +1,29 @@
+package org.radargun.stages;
+
+import org.radargun.DistStageAck;
+import org.radargun.config.Stage;
+import org.radargun.stressors.BackgroundOpsManager;
+
+/**
+ * @author Radim Vansa &lt;rvansa@redhat.com&gt;
+ */
+@Stage(doc = "Stage that checks the progress in background stressors and fails if something went wrong.")
+public class CheckBackgroundStressorsStage extends AbstractDistStage {
+   @Override
+   public DistStageAck executeOnSlave() {
+      DefaultDistStageAck ack = newDefaultStageAck();
+      if (slaves != null && !slaves.contains(slaveIndex)) {
+         return ack;
+      }
+      BackgroundOpsManager manager = BackgroundOpsManager.getInstance(slaveState);
+      if (manager != null) {
+         String error = manager.getError();
+         if (error != null) {
+            log.error(error);
+            ack.setError(true);
+            ack.setErrorMessage(error);
+         }
+      }
+      return ack;
+   }
+}

--- a/framework/src/main/java/org/radargun/stressors/BackgroundStressor.java
+++ b/framework/src/main/java/org/radargun/stressors/BackgroundStressor.java
@@ -3,11 +3,13 @@ package org.radargun.stressors;
 import java.util.List;
 import java.util.Random;
 
-import org.apache.log4j.Logger;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.radargun.CacheWrapper;
 import org.radargun.features.AtomicOperationsCapable;
 import org.radargun.stages.helpers.Range;
 import org.radargun.state.SlaveState;
+import org.radargun.utils.Utils;
 
 /**
 * Stressor thread running during many stages.
@@ -17,38 +19,40 @@ import org.radargun.state.SlaveState;
 */
 class BackgroundStressor extends Thread {
 
-   private static Logger log = Logger.getLogger(BackgroundStressor.class);
+   private static final Log log = LogFactory.getLog(BackgroundStressor.class);
+   private static final boolean trace = log.isTraceEnabled();
 
-   private final Random rand = new Random();
    private final int keyRangeStart;
    private final int keyRangeEnd;
    private final List<Range> deadSlavesRanges;
-   private final BackgroundOpsManager backgroundOpsManager;
+   private final BackgroundOpsManager manager;
    private final KeyGenerator keyGenerator;
 
-   private long lastOpStartTime;
    private final SynchronizedStatistics threadStats = new SynchronizedStatistics();
-   private int currentKey;
    private volatile boolean terminate = false;
    private int remainingTxOps;
    private boolean loaded;
+   private final BackgroundStressor.Logic logic;
+   private final int threadId;
 
-   public BackgroundStressor(BackgroundOpsManager backgroundOpsManager, SlaveState slaveState, Range myRange, List<Range> deadSlavesRanges, int idx) {
+   public BackgroundStressor(BackgroundOpsManager manager, SlaveState slaveState, Range myRange, List<Range> deadSlavesRanges, int slaveIndex, int idx) {
       super("StressorThread-" + idx);
-      this.backgroundOpsManager = backgroundOpsManager;
+      this.threadId = slaveIndex * manager.getNumThreads() + idx;
+      this.manager = manager;
       this.keyRangeStart = myRange.getStart();
       this.keyRangeEnd = myRange.getEnd();
       this.deadSlavesRanges = deadSlavesRanges;
-      KeyGenerator keyGenerator = (KeyGenerator) slaveState.get(KeyGenerator.KEY_GENERATOR);
-      if (keyGenerator != null) {
-         this.keyGenerator = keyGenerator;
+      this.keyGenerator = manager.getKeyGenerator();
+      if (manager.isUseLogValues()) {
+         if (manager.isSharedKeys()) {
+            logic = new SharedLogLogic(threadId);
+         } else {
+            logic = new PrivateLogLogic(threadId);
+         }
       } else {
-         this.keyGenerator = new StringKeyGenerator();
-         slaveState.put(KeyGenerator.KEY_GENERATOR, this.keyGenerator);
+         logic = new LegacyLogic(myRange.getStart());
       }
-
-      this.currentKey = myRange.getStart();
-      this.remainingTxOps = backgroundOpsManager.getTransactionSize();
+      this.remainingTxOps = manager.getTransactionSize();
    }
 
    private void loadData() {
@@ -60,20 +64,29 @@ class BackgroundStressor extends Thread {
             loadKeyRange(range.getStart(), range.getEnd());
          }
       }
-      currentKey = keyRangeStart;
       loaded = true;
    }
 
    private void loadKeyRange(int from, int to) {
       int loaded_keys = 0;
-      CacheWrapper cacheWrapper = backgroundOpsManager.getCacheWrapper();
-      for (currentKey = from; currentKey < to && !terminate; currentKey++, loaded_keys++) {
+      CacheWrapper cacheWrapper = manager.getCacheWrapper();
+      boolean loadWithPutIfAbsent = manager.getLoadWithPutIfAbsent();
+      AtomicOperationsCapable atomicWrapper = null;
+      if (loadWithPutIfAbsent && !(cacheWrapper instanceof AtomicOperationsCapable)) {
+         throw new IllegalArgumentException("This cache wrapper does not support atomic operations");
+      } else {
+         atomicWrapper = (AtomicOperationsCapable) cacheWrapper;
+      }
+      int entrySize = manager.getEntrySize();
+      Random rand = new Random();
+      for (long keyId = from; keyId < to && !terminate; keyId++, loaded_keys++) {
          while (!terminate) {
             try {
-               if (backgroundOpsManager.getLoadWithPutIfAbsent() && cacheWrapper instanceof AtomicOperationsCapable) {
-                  ((AtomicOperationsCapable) cacheWrapper).putIfAbsent(backgroundOpsManager.getBucketId(), keyGenerator.generateKey(currentKey), generateRandomEntry(backgroundOpsManager.getEntrySize()));
+               Object key = keyGenerator.generateKey(keyId);
+               if (loadWithPutIfAbsent) {
+                  atomicWrapper.putIfAbsent(manager.getBucketId(), key, generateRandomEntry(rand, entrySize));
                } else {
-                  cacheWrapper.put(backgroundOpsManager.getBucketId(), keyGenerator.generateKey(currentKey), generateRandomEntry(backgroundOpsManager.getEntrySize()));
+                  cacheWrapper.put(manager.getBucketId(), key, generateRandomEntry(rand, entrySize));
                }
                if (loaded_keys % 1000 == 0) {
                   log.debug("Loaded " + loaded_keys + " out of " + (to - from));
@@ -94,20 +107,20 @@ class BackgroundStressor extends Thread {
          if (!loaded) {
             loadData();
          }
-         if (backgroundOpsManager.getLoadOnly()) {
+         if (manager.getLoadOnly()) {
             log.info("The stressor has finished loading data and will terminate.");
             return;
          }
          while (!isInterrupted() && !terminate) {
-            makeRequest();
-            sleep(backgroundOpsManager.getDelayBetweenRequests());
+            logic.invoke();
+            sleep(manager.getDelayBetweenRequests());
          }
       } catch (InterruptedException e) {
          log.trace("Stressor interrupted.");
          // we should close the transaction, otherwise TX Reaper would find dead thread in tx
-         if (backgroundOpsManager.getTransactionSize() != -1) {
+         if (manager.getTransactionSize() != -1) {
             try {
-               CacheWrapper cacheWrapper = backgroundOpsManager.getCacheWrapper();
+               CacheWrapper cacheWrapper = manager.getCacheWrapper();
                if (cacheWrapper != null && cacheWrapper.isRunning()) {
                   cacheWrapper.endTransaction(false);
                }
@@ -115,73 +128,6 @@ class BackgroundStressor extends Thread {
                log.error("Error while ending transaction", e);
             }
          }
-      }
-   }
-
-   private void resetLastOpTime() {
-      lastOpStartTime = System.nanoTime();
-   }
-
-   private long lastOpTime() {
-      return System.nanoTime() - lastOpStartTime;
-   }
-
-   private void makeRequest() throws InterruptedException {
-      Object key = null;
-      Operation operation = backgroundOpsManager.getOperation(rand);
-      CacheWrapper cacheWrapper = backgroundOpsManager.getCacheWrapper();
-      try {
-         key = keyGenerator.generateKey(currentKey++);
-         if (currentKey == keyRangeEnd) {
-            currentKey = keyRangeStart;
-         }
-         int transactionSize = backgroundOpsManager.getTransactionSize();
-         if (transactionSize != -1 && remainingTxOps == transactionSize) {
-            cacheWrapper.startTransaction();
-         }
-         resetLastOpTime();
-         Object result;
-         switch (operation)
-         {
-         case GET:
-            result = cacheWrapper.get(backgroundOpsManager.getBucketId(), key);
-            if (result == null) operation = Operation.GET_NULL;
-            threadStats.registerRequest(lastOpTime(), 0, operation);
-            break;
-         case PUT:
-            cacheWrapper.put(backgroundOpsManager.getBucketId(), key, generateRandomEntry(backgroundOpsManager.getEntrySize()));
-            threadStats.registerRequest(lastOpTime(), 0, operation);
-            break;
-         case REMOVE:
-            cacheWrapper.remove(backgroundOpsManager.getBucketId(), key);
-            threadStats.registerRequest(lastOpTime(), 0, operation);
-            break;
-         }
-         if (transactionSize != -1) {
-            remainingTxOps--;
-            if (remainingTxOps == 0) {
-               cacheWrapper.endTransaction(true);
-               remainingTxOps = transactionSize;
-            }
-         }
-      } catch (Exception e) {
-         InterruptedException ie = findInterruptionCause(null, e);
-         if (ie != null) {
-            throw ie;
-         } else if (e.getClass().getName().contains("SuspectException")) {
-            log.error("Request failed due to SuspectException: " + e.getMessage());
-         } else {
-            log.error("Cache operation error", e);
-         }
-         if (backgroundOpsManager.getTransactionSize() != -1) {
-            try {
-               cacheWrapper.endTransaction(false);
-            } catch (Exception e1) {
-               log.error("Error while ending transaction", e);
-            }
-            remainingTxOps = backgroundOpsManager.getTransactionSize();
-         }
-         threadStats.registerError(lastOpTime(), 0, operation);
       }
    }
 
@@ -195,7 +141,7 @@ class BackgroundStressor extends Thread {
       }
    }
 
-   private byte[] generateRandomEntry(int size) {
+   private byte[] generateRandomEntry(Random rand, int size) {
       // each char is 2 bytes
       byte[] data = new byte[size];
       rand.nextBytes(data);
@@ -204,6 +150,10 @@ class BackgroundStressor extends Thread {
 
    public boolean isLoaded() {
       return loaded;
+   }
+
+   public void setLoaded(boolean loaded) {
+      this.loaded = loaded;
    }
 
    public void requestTerminate() {
@@ -215,7 +165,509 @@ class BackgroundStressor extends Thread {
       return snapshot;
    }
 
-   public void setLoaded(boolean loaded) {
-      this.loaded = loaded;
+   private interface Logic {
+      public void invoke() throws InterruptedException;
+   }
+
+   private class LegacyLogic implements Logic {
+      private final Random rand = new Random();
+      private long currentKey;
+
+      public LegacyLogic(long startKey) {
+         currentKey = startKey;
+      }
+
+      public void invoke() throws InterruptedException {
+         long startTime = 0;
+         Object key = null;
+         Operation operation = manager.getOperation(rand);
+         CacheWrapper cacheWrapper = manager.getCacheWrapper();
+         try {
+            key = keyGenerator.generateKey(currentKey++);
+            if (currentKey == keyRangeEnd) {
+               currentKey = keyRangeStart;
+            }
+            int transactionSize = manager.getTransactionSize();
+            if (transactionSize > 0 && remainingTxOps == transactionSize) {
+               cacheWrapper.startTransaction();
+            }
+            startTime = System.nanoTime();
+            Object result;
+            switch (operation)
+            {
+            case GET:
+               result = cacheWrapper.get(manager.getBucketId(), key);
+               if (result == null) operation = Operation.GET_NULL;
+               break;
+            case PUT:
+               cacheWrapper.put(manager.getBucketId(), key, generateRandomEntry(rand, manager.getEntrySize()));
+               break;
+            case REMOVE:
+               cacheWrapper.remove(manager.getBucketId(), key);
+               break;
+            }
+            threadStats.registerRequest(System.nanoTime() - startTime, 0, operation);
+            if (transactionSize > 0) {
+               remainingTxOps--;
+               if (remainingTxOps == 0) {
+                  cacheWrapper.endTransaction(true);
+                  remainingTxOps = transactionSize;
+               }
+            }
+         } catch (Exception e) {
+            InterruptedException ie = findInterruptionCause(null, e);
+            if (ie != null) {
+               throw ie;
+            } else if (e.getClass().getName().contains("SuspectException")) {
+               log.error("Request failed due to SuspectException: " + e.getMessage());
+            } else {
+               log.error("Cache operation error", e);
+            }
+            if (manager.getTransactionSize() != -1) {
+               try {
+                  cacheWrapper.endTransaction(false);
+               } catch (Exception e1) {
+                  log.error("Error while ending transaction", e);
+               }
+               remainingTxOps = manager.getTransactionSize();
+            }
+            threadStats.registerError(startTime <= 0 ? 0 : System.nanoTime() - startTime, 0, operation);
+         }
+      }
+   }
+
+   private abstract class AbstractLogLogic implements Logic {
+
+      protected final Random keySelectorRandom;
+      protected final Random operationTypeRandom = new Random();
+      protected final CacheWrapper cacheWrapper;
+      protected long operationId = 0;
+      private long txStartOperationId;
+      private long txStartKeyId = -1;
+      private long txStartRandSeed;
+      private boolean txRolledBack = false;
+
+      public AbstractLogLogic(long seed) {
+         cacheWrapper = manager.getCacheWrapper();
+         Random rand = null;
+         try {
+            Object last = cacheWrapper.get(manager.getBucketId(), LogChecker.lastOperationKey(threadId));
+            if (last != null) {
+               operationId = ((PrivateLogChecker.LastOperation) last).getOperationId() + 1;
+               rand = Utils.setRandomSeed(new Random(0), ((PrivateLogChecker.LastOperation) last).getSeed());
+               log.debug("Restarting operations from operation " + operationId);
+            }
+         } catch (Exception e) {
+            log.error("Failure getting last operation", e);
+         }
+         if (rand == null) {
+            log.trace("Initializing random with " + seed);
+            this.keySelectorRandom = new Random(seed);
+         } else {
+            this.keySelectorRandom = rand;
+         }
+      }
+
+      @Override
+      public void invoke() throws InterruptedException {
+         long keyId = nextKeyId();
+         do {
+            if (txRolledBack) {
+               keyId = txStartKeyId;
+               operationId = txStartOperationId;
+               Utils.setRandomSeed(keySelectorRandom, txStartRandSeed);
+               txRolledBack = false;
+            }
+            if (trace) {
+               log.trace("Operation " + operationId + " on key " + keyId);
+            }
+         } while (!invokeOn(keyId) && !isInterrupted() && !terminate);
+         operationId++;
+      }
+
+      protected abstract long nextKeyId();
+
+      protected boolean invokeOn(long keyId) throws InterruptedException {
+         try {
+            int transactionSize = manager.getTransactionSize();
+            if (transactionSize != -1 && remainingTxOps == transactionSize) {
+               txStartOperationId = operationId;
+               txStartKeyId = keyId;
+               // we could serialize & deserialize instead, but that's not much better
+               txStartRandSeed = Utils.getRandomSeed(keySelectorRandom);
+               cacheWrapper.startTransaction();
+            }
+
+            if (!invokeLogic(keyId)) return false;
+
+            // for non-transactional caches write the stressor last operation anytime (once in a while)
+            if (transactionSize < 0 && operationId % manager.getLogCounterUpdatePeriod() == 0) {
+               writeStressorLastOperation();
+            }
+
+            if (transactionSize != -1) {
+               remainingTxOps--;
+               if (remainingTxOps == 0) {
+                  try {
+                     cacheWrapper.endTransaction(true);
+                  } catch (Exception e) {
+                     log.trace("Transaction was rolled back, restarting from operation " + txStartOperationId);
+                     txRolledBack = true;
+                     return false;
+                  } finally {
+                     remainingTxOps = transactionSize;
+                  }
+                  // for non-transactional caches write the stressor last operation only after the transaction
+                  // has finished
+                  try {
+                     cacheWrapper.startTransaction();
+                     writeStressorLastOperation();
+                     cacheWrapper.endTransaction(true);
+                  } catch (Exception e) {
+                     log.error("Cannot write stressor last operation", e);
+                  }
+               }
+            }
+            return true;
+         } catch (Exception e) {
+            InterruptedException ie = findInterruptionCause(null, e);
+            if (ie != null) {
+               throw ie;
+            } else if (e.getClass().getName().contains("SuspectException")) {
+               log.error("Request failed due to SuspectException: " + e.getMessage());
+            } else {
+               log.error("Cache operation error", e);
+            }
+            if (manager.getTransactionSize() > 0) {
+               try {
+                  cacheWrapper.endTransaction(false);
+               } catch (Exception e1) {
+                  log.error("Error while ending transaction, restarting from operation " + txStartOperationId, e);
+                  txRolledBack = true;
+               }
+               remainingTxOps = manager.getTransactionSize();
+            }
+            return false; // on the same key
+         }
+      }
+
+      private void writeStressorLastOperation() {
+         try {
+            // we have to write down the keySelectorRandom as well in order to be able to continue work if this slave
+            // is restarted
+            cacheWrapper.put(manager.getBucketId(), LogChecker.lastOperationKey(threadId),
+                  new PrivateLogChecker.LastOperation(operationId, Utils.getRandomSeed(keySelectorRandom)));
+         } catch (Exception e) {
+            log.error("Error writing stressor last operation", e);
+         }
+      }
+
+      protected abstract boolean invokeLogic(long keyId) throws Exception;
+
+      protected long getLastCheckedOperation() {
+         long minReadOperationId = Long.MAX_VALUE;
+         for (int i = 0; i < manager.getNumSlaves(); ++i) {
+            Object lastCheck = null;
+            try {
+               lastCheck = cacheWrapper.get(manager.getBucketId(), LogChecker.checkerKey(i, threadId));
+            } catch (Exception e) {
+               log.error("Cannot read last checked operation id for slave " + i + " and thread " + threadId, e);
+            }
+            long readOperationId = lastCheck == null ? Long.MIN_VALUE : ((LogChecker.LastOperation) lastCheck).getOperationId();
+            minReadOperationId = Math.min(minReadOperationId, readOperationId);
+         }
+         return minReadOperationId;
+      }
+   }
+
+   private class PrivateLogLogic extends AbstractLogLogic {
+
+      private PrivateLogLogic(long seed) {
+         super(seed);
+      }
+
+      @Override
+      protected long nextKeyId() {
+         return keySelectorRandom.nextInt(keyRangeEnd - keyRangeStart) + keyRangeStart;
+      }
+
+      @Override
+      protected boolean invokeLogic(long keyId) throws Exception {
+         Operation operation = manager.getOperation(operationTypeRandom);
+         String bucketId = manager.getBucketId();
+
+         // first we have to get the value
+         PrivateLogValue prevValue = checkedGetValue(cacheWrapper, bucketId, keyId);
+         // now for modify operations, execute it
+         if (prevValue == null || operation == Operation.PUT) {
+            PrivateLogValue nextValue;
+            PrivateLogValue backupValue = null;
+            if (prevValue != null) {
+               nextValue = getNextValue(cacheWrapper, prevValue);
+            } else {
+               // the value may have been removed, look for backup
+                backupValue = checkedGetValue(cacheWrapper, bucketId, ~keyId);
+               if (backupValue == null) {
+                  nextValue = new PrivateLogValue(threadId, operationId);
+               } else {
+                  nextValue = getNextValue(cacheWrapper, backupValue);
+               }
+            }
+            if (nextValue == null) {
+               return false;
+            }
+            checkedPutValue(cacheWrapper, bucketId, keyId, nextValue);
+            if (backupValue != null) {
+               checkedRemoveValue(cacheWrapper, bucketId, ~keyId, backupValue);
+            }
+         } else if (operation == Operation.REMOVE) {
+            PrivateLogValue nextValue = getNextValue(cacheWrapper, prevValue);
+            if (nextValue == null) {
+               return false;
+            }
+            checkedPutValue(cacheWrapper, bucketId, ~keyId, nextValue);
+            checkedRemoveValue(cacheWrapper, bucketId, keyId, prevValue);
+         } else {
+            // especially GETs are not allowed here, because these would break the deterministic order
+            // - each operationId must be written somewhere
+            throw new UnsupportedOperationException("Only PUT and REMOVE operations are allowed for this logic.");
+         }
+         return true;
+      }
+
+      private PrivateLogValue getNextValue(CacheWrapper cacheWrapper, PrivateLogValue prevValue) throws InterruptedException {
+         if (prevValue.size() >= manager.getLogValueMaxSize()) {
+            int checkedValues;
+            // TODO some limit after which the stressor will terminate
+            for (;;) {
+               if (isInterrupted() || terminate) {
+                  return null;
+               }
+               long minReadOperationId = getLastCheckedOperation();
+               if (prevValue.getOperationId(0) <= minReadOperationId) {
+                  for (checkedValues = 1; checkedValues < prevValue.size() && prevValue.getOperationId(checkedValues) <= minReadOperationId; ++checkedValues);
+                  break;
+               } else {
+                  try {
+                     Thread.sleep(100);
+                  } catch (InterruptedException e) {
+                     Thread.currentThread().interrupt();
+                     return null;
+                  }
+               }
+            }
+            return prevValue.shift(checkedValues, operationId);
+         } else {
+            return prevValue.with(operationId);
+         }
+      }
+
+      private PrivateLogValue checkedGetValue(CacheWrapper cacheWrapper, String bucketId, long keyId) throws Exception {
+         Object prevValue;
+         long startTime = System.nanoTime();
+         try {
+            prevValue = cacheWrapper.get(bucketId, keyGenerator.generateKey(keyId));
+         } catch (Exception e) {
+            threadStats.registerError(System.nanoTime() - startTime, 0, Operation.GET);
+            throw e;
+         }
+         long endTime = System.nanoTime();
+         if (prevValue != null && !(prevValue instanceof PrivateLogValue)) {
+            threadStats.registerError(endTime - startTime, 0, Operation.GET);
+            log.error("Value is not an instance of PrivateLogValue: " + prevValue);
+            throw new IllegalStateException();
+         } else {
+            threadStats.registerRequest(endTime - startTime, 0, prevValue == null ? Operation.GET_NULL : Operation.GET);
+            return (PrivateLogValue) prevValue;
+         }
+      }
+
+      private PrivateLogValue checkedRemoveValue(CacheWrapper cacheWrapper, String bucketId, long keyId, PrivateLogValue expectedValue) throws Exception {
+         Object prevValue;
+         long startTime = System.nanoTime();
+         try {
+            prevValue = cacheWrapper.remove(bucketId, keyGenerator.generateKey(keyId));
+         } catch (Exception e) {
+            threadStats.registerError(System.nanoTime() - startTime, 0, Operation.REMOVE);
+            throw e;
+         }
+         long endTime = System.nanoTime();
+         boolean successful = false;
+         if (prevValue != null) {
+            if (!(prevValue instanceof PrivateLogValue)) {
+               log.error("Value is not an instance of PrivateLogValue: " + prevValue);
+            } else if (!prevValue.equals(expectedValue)) {
+               log.error("Value is not the expected one: expected=" + expectedValue + ", found=" + prevValue);
+            } else {
+               successful = true;
+            }
+         } else if (expectedValue == null) {
+            successful = true;
+         } else {
+            log.error("Expected to remove null-value but found " + prevValue);
+         }
+         if (successful) {
+            threadStats.registerRequest(endTime - startTime, 0, Operation.REMOVE);
+            return (PrivateLogValue) prevValue;
+         } else {
+            threadStats.registerError(endTime - startTime, 0, Operation.REMOVE);
+            throw new IllegalStateException();
+         }
+      }
+
+      private void checkedPutValue(CacheWrapper cacheWrapper, String bucketId, long keyId, PrivateLogValue value) throws Exception {
+         long startTime = System.nanoTime();
+         try {
+            cacheWrapper.put(bucketId, keyGenerator.generateKey(keyId), value);
+         } catch (Exception e) {
+            threadStats.registerError(System.nanoTime() - startTime, 0, Operation.PUT);
+            throw e;
+         }
+         long endTime = System.nanoTime();
+         threadStats.registerRequest(endTime - startTime, 0, Operation.PUT);
+      }
+   }
+
+   private class SharedLogLogic extends AbstractLogLogic {
+      private AtomicOperationsCapable cacheWrapper;
+
+      public SharedLogLogic(long seed) {
+         super(seed);
+         cacheWrapper = (AtomicOperationsCapable) manager.getCacheWrapper();
+      }
+
+      @Override
+      protected long nextKeyId() {
+         return keySelectorRandom.nextInt(manager.getNumEntries());
+      }
+
+      @Override
+      protected boolean invokeLogic(long keyId) throws Exception {
+         Operation operation = manager.getOperation(operationTypeRandom);
+         String bucketId = manager.getBucketId();
+
+         // In shared mode, we can't ever atomically modify the two keys (main and backup) to have only
+         // one of them with the actual value (this is not true even for private mode but there the moment
+         // when we move the value from main to backup or vice versa does not cause any problem, because the
+         // worst thing is to read slightly outdated value). However, here the invariant holds that the operation
+         // must be recorded in at least one of the entries, but the situation with both of these having
+         // some value is valid (although, we try to evade it be conditionally removing one of them in each
+         // logic step).
+         SharedLogValue prevValue = checkedGetValue(cacheWrapper, bucketId, keyId);
+         SharedLogValue backupValue = checkedGetValue(cacheWrapper, bucketId, ~keyId);
+         SharedLogValue nextValue = getNextValue(cacheWrapper, prevValue, backupValue);
+         // now for modify operations, execute it
+         if (operation == Operation.PUT) {
+            if (checkedPutValue(cacheWrapper, bucketId, keyId, prevValue, nextValue)) {
+               if (backupValue != null) {
+                  checkedRemoveValue(cacheWrapper, bucketId, ~keyId, backupValue);
+               }
+            } else {
+               return false;
+            }
+         } else if (operation == Operation.REMOVE) {
+            if (checkedPutValue(cacheWrapper, bucketId, ~keyId, backupValue, nextValue)) {
+               if (prevValue != null) {
+                  checkedRemoveValue(cacheWrapper, bucketId, keyId, prevValue);
+               }
+            } else {
+               return false;
+            }
+         } else {
+            // especially GETs are not allowed here, because these would break the deterministic order
+            // - each operationId must be written somewhere
+            throw new UnsupportedOperationException("Only PUT and REMOVE operations are allowed for this logic.");
+         }
+         return true;
+      }
+
+      private SharedLogValue getNextValue(AtomicOperationsCapable cacheWrapper, SharedLogValue prevValue, SharedLogValue backupValue) {
+         if (prevValue == null && backupValue == null) {
+            return new SharedLogValue(threadId, operationId);
+         } else if (prevValue != null && backupValue != null) {
+            SharedLogValue joinValue = prevValue.join(backupValue);
+            if (joinValue.size() >= manager.getLogValueMaxSize()) {
+               return filterAndAddOperation(joinValue);
+            } else {
+               return joinValue.with(threadId, operationId);
+            }
+         }
+         SharedLogValue value = prevValue != null ? prevValue : backupValue;
+         if (value.size() < manager.getLogValueMaxSize()) {
+            return value.with(threadId, operationId);
+         } else {
+            return filterAndAddOperation(value);
+         }
+      }
+
+      private SharedLogValue filterAndAddOperation(SharedLogValue value) {
+         // TODO some limit after which the stressor will terminate
+         while (!terminate && !isInterrupted()) {
+            long minReadOperationId = getLastCheckedOperation();
+            SharedLogValue filtered = value.with(threadId, operationId, minReadOperationId);
+            if (filtered.size() > manager.getLogValueMaxSize()) {
+               try {
+                  Thread.sleep(100);
+               } catch (InterruptedException e) {
+                  Thread.currentThread().interrupt();
+                  return null;
+               }
+            } else {
+               return filtered;
+            }
+         }
+         return null;
+      }
+
+      private SharedLogValue checkedGetValue(AtomicOperationsCapable cacheWrapper, String bucketId, long keyId) throws Exception {
+         Object prevValue;
+         long startTime = System.nanoTime();
+         try {
+            prevValue = cacheWrapper.get(bucketId, keyGenerator.generateKey(keyId));
+         } catch (Exception e) {
+            threadStats.registerError(System.nanoTime() - startTime, 0, Operation.GET);
+            throw e;
+         }
+         long endTime = System.nanoTime();
+         if (prevValue != null && !(prevValue instanceof SharedLogValue)) {
+            threadStats.registerError(endTime - startTime, 0, Operation.GET);
+            log.error("Value is not an instance of SharedLogValue: " + prevValue);
+            throw new IllegalStateException();
+         } else {
+            threadStats.registerRequest(endTime - startTime, 0, prevValue == null ? Operation.GET_NULL : Operation.GET);
+            return (SharedLogValue) prevValue;
+         }
+      }
+
+      private boolean checkedPutValue(AtomicOperationsCapable cacheWrapper, String bucketId, long keyId, SharedLogValue oldValue, SharedLogValue newValue) throws Exception {
+         boolean returnValue;
+         long startTime = System.nanoTime();
+         try {
+            if (oldValue == null) {
+               returnValue = cacheWrapper.putIfAbsent(bucketId, keyGenerator.generateKey(keyId), newValue) == null;
+            } else {
+               returnValue = cacheWrapper.replace(bucketId, keyGenerator.generateKey(keyId), oldValue, newValue);
+            }
+         } catch (Exception e) {
+            threadStats.registerError(System.nanoTime() - startTime, 0, Operation.PUT);
+            throw e;
+         }
+         long endTime = System.nanoTime();
+         threadStats.registerRequest(endTime - startTime, 0, Operation.PUT);
+         return returnValue;
+      }
+
+      private boolean checkedRemoveValue(AtomicOperationsCapable cacheWrapper, String bucketId, long keyId, SharedLogValue oldValue) throws Exception {
+         long startTime = System.nanoTime();
+         try {
+            boolean returnValue = cacheWrapper.remove(bucketId, keyGenerator.generateKey(keyId), oldValue);
+            long endTime = System.nanoTime();
+            threadStats.registerRequest(endTime - startTime, 0, Operation.REMOVE);
+            return returnValue;
+         } catch (Exception e) {
+            threadStats.registerError(System.nanoTime() - startTime, 0, Operation.REMOVE);
+            throw e;
+         }
+      }
    }
 }

--- a/framework/src/main/java/org/radargun/stressors/LogChecker.java
+++ b/framework/src/main/java/org/radargun/stressors/LogChecker.java
@@ -1,0 +1,244 @@
+package org.radargun.stressors;
+
+import java.io.Serializable;
+import java.util.Random;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.radargun.CacheWrapper;
+import org.radargun.utils.Utils;
+
+/**
+ * @author Radim Vansa &lt;rvansa@redhat.com&gt;
+ */
+public abstract class LogChecker extends Thread {
+   protected static final Log log = LogFactory.getLog(LogChecker.class);
+   protected static final boolean trace = log.isTraceEnabled();
+   protected static final long UNSUCCESSFUL_CHECK_MIN_DELAY_MS = 10;
+   protected final String bucketId;
+   protected final KeyGenerator keyGenerator;
+   protected final int slaveIndex;
+   protected final long logCounterUpdatePeriod;
+   protected final Pool pool;
+   protected final CacheWrapper cacheWrapper;
+   protected volatile boolean terminate = false;
+
+   public LogChecker(String name, BackgroundOpsManager manager, Pool logCheckerPool) {
+      super(name);
+      bucketId = manager.getBucketId();
+      keyGenerator = manager.getKeyGenerator();
+      slaveIndex = manager.getSlaveIndex();
+      logCounterUpdatePeriod = manager.getLogCounterUpdatePeriod();
+      pool = logCheckerPool;
+      cacheWrapper = manager.getCacheWrapper();
+   }
+
+   public static String checkerKey(int checkerSlaveId, int slaveAndThreadId) {
+      return String.format("checker_%d_%d", checkerSlaveId, slaveAndThreadId);
+   }
+
+   public static String lastOperationKey(int slaveAndThreadId) {
+      return String.format("stressor_%d", slaveAndThreadId);
+   }
+
+   public void requestTerminate() {
+      terminate = true;
+   }
+
+   @Override
+   public void run() {
+      while (!terminate) {
+         AbstractStressorRecord record = null;
+         int delayedKeys = 0;
+         try {
+            if (delayedKeys > pool.getTotalThreads()) {
+               Thread.sleep(UNSUCCESSFUL_CHECK_MIN_DELAY_MS);
+            }
+            record = pool.take();
+            if (System.currentTimeMillis() < record.getLastUnsuccessfulCheckTimestamp() + UNSUCCESSFUL_CHECK_MIN_DELAY_MS) {
+               delayedKeys++;
+               continue;
+            }
+            if (record.getLastUnsuccessfulCheckTimestamp() > Long.MIN_VALUE) {
+               // the last check was unsuccessful -> grab lastOperation BEFORE the value to check if we've lost that
+               Object last = cacheWrapper.get(bucketId, lastOperationKey(record.getThreadId()));
+               if (last != null) {
+                  record.setLastStressorOperation(((LastOperation) last).getOperationId());
+               }
+            }
+            if (record.getOperationId() == 0) {
+               Object last = cacheWrapper.get(bucketId, checkerKey(slaveIndex, record.getThreadId()));
+               if (last != null) {
+                  LastOperation lastCheck = (LastOperation) last;
+                  log.debug(String.format("Check for thread %d continues from operation %d",
+                        record.getThreadId(), lastCheck.getOperationId() + 1));
+                  record = newRecord(record, lastCheck.getOperationId(), lastCheck.getSeed());
+               }
+            }
+            if (trace) {
+               log.trace(String.format("Checking operation %d for thread %d on key %d (%s)",
+                     record.getOperationId(), record.getThreadId(), record.getKeyId(), keyGenerator.generateKey(record.getKeyId())));
+            }
+            Object value = findValue(record);
+            if (containsOperation(value, record)) {
+               if (trace) {
+                  log.trace(String.format("Found operation %d for thread %d", record.getOperationId(), record.getThreadId()));
+               }
+               if (record.getOperationId() % logCounterUpdatePeriod == 0) {
+                  cacheWrapper.put(bucketId, checkerKey(slaveIndex, record.getThreadId()),
+                        new LastOperation(record.getOperationId(), Utils.getRandomSeed(record.rand)));
+               }
+               record.next();
+               record.setLastUnsuccessfulCheckTimestamp(Long.MIN_VALUE);
+               pool.reportStoredOperation();
+            } else {
+               if (record.getLastStressorOperation() >= record.getOperationId()) {
+                  log.error(String.format("Missing operation %d for thread %d on key %d (%s) %s",
+                        record.getOperationId(), record.getThreadId(), record.getKeyId(),
+                        keyGenerator.generateKey(record.getKeyId()),
+                        value == null ? " - entry was completely lost" : ""));
+                  if (trace) {
+                     log.trace("Not found in " + value);
+                  }
+                  pool.reportMissingOperation();
+                  record.next();
+               } else {
+                  record.setLastUnsuccessfulCheckTimestamp(System.currentTimeMillis());
+               }
+            }
+         } catch (Exception e) {
+            log.error("Cannot check value " + record.getKeyId(), e);
+         } finally {
+            if (record == null) {
+               try {
+                  Thread.sleep(100);
+               } catch (InterruptedException e) {
+                  Thread.interrupted();
+               }
+            } else {
+               pool.add(record);
+            }
+         }
+      }
+   }
+
+   protected abstract AbstractStressorRecord newRecord(AbstractStressorRecord record, long operationId, long seed);
+
+   protected abstract Object findValue(AbstractStressorRecord record) throws Exception;
+
+   protected abstract boolean containsOperation(Object value, AbstractStressorRecord record);
+
+   public static abstract class Pool {
+      protected final int totalThreads;
+      protected final ConcurrentLinkedQueue<AbstractStressorRecord> records = new ConcurrentLinkedQueue<AbstractStressorRecord>();
+      private AtomicLong missingOperations = new AtomicLong();
+      private volatile long lastStoredOperationTimestamp = Long.MIN_VALUE;
+
+      public Pool(int numThreads, int numSlaves) {
+         totalThreads = numThreads * numSlaves;
+      }
+
+      public long getMissingOperations() {
+         return missingOperations.get();
+      }
+
+      public void reportMissingOperation() {
+         missingOperations.incrementAndGet();
+      }
+
+      public int getTotalThreads() {
+         return totalThreads;
+      }
+
+      public void reportStoredOperation() {
+         lastStoredOperationTimestamp = System.currentTimeMillis();
+      }
+
+      public long getLastStoredOperationTimestamp() {
+         return lastStoredOperationTimestamp;
+      }
+
+      public AbstractStressorRecord take() {
+         return records.poll();
+      }
+
+      public void add(AbstractStressorRecord record) {
+         records.add(record);
+      }
+   }
+
+   public static class LastOperation implements Serializable {
+      private long operationId;
+      private long seed;
+
+      public LastOperation(long operationId, long seed) {
+         this.operationId = operationId;
+         this.seed = seed;
+      }
+
+      public long getOperationId() {
+         return operationId;
+      }
+
+      public long getSeed() {
+         return seed;
+      }
+
+      @Override
+      public String toString() {
+         return String.format("LastOperation{operationId=%d, seed=%016X}", operationId, seed);
+      }
+   }
+
+   protected abstract static class AbstractStressorRecord {
+      protected final Random rand;
+      protected final int threadId;
+      protected long currentKeyId;
+      protected long currentOp = -1;
+      private long lastStressorOperation = -1;
+      private long lastUnsuccessfulCheckTimestamp = Long.MIN_VALUE;
+
+      public AbstractStressorRecord(long seed, int threadId, long operationId) {
+         this.rand = Utils.setRandomSeed(new Random(0), seed);
+         this.threadId = threadId;
+         this.currentOp = operationId;
+      }
+
+      public AbstractStressorRecord(Random rand, int threadId) {
+         this.rand = rand;
+         this.threadId = threadId;
+      }
+
+      public abstract void next();
+
+      public int getThreadId() {
+         return threadId;
+      }
+
+      public long getLastStressorOperation() {
+         return lastStressorOperation;
+      }
+
+      public void setLastStressorOperation(long lastStressorOperation) {
+         this.lastStressorOperation = lastStressorOperation;
+      }
+
+      public long getLastUnsuccessfulCheckTimestamp() {
+         return lastUnsuccessfulCheckTimestamp;
+      }
+
+      public void setLastUnsuccessfulCheckTimestamp(long lastUnsuccessfulCheckTimestamp) {
+         this.lastUnsuccessfulCheckTimestamp = lastUnsuccessfulCheckTimestamp;
+      }
+
+      public long getKeyId() {
+         return currentKeyId;
+      }
+
+      public long getOperationId() {
+         return currentOp;
+      }
+   }
+}

--- a/framework/src/main/java/org/radargun/stressors/PrivateLogChecker.java
+++ b/framework/src/main/java/org/radargun/stressors/PrivateLogChecker.java
@@ -1,0 +1,109 @@
+package org.radargun.stressors;
+
+import java.util.Random;
+
+import org.radargun.stages.helpers.Range;
+
+/**
+ * @author Radim Vansa &lt;rvansa@redhat.com&gt;
+ */
+public class PrivateLogChecker extends LogChecker {
+
+   public PrivateLogChecker(int id, Pool logCheckerPool, BackgroundOpsManager manager) {
+      super("PrivateLogChecker-" + id, manager, logCheckerPool);
+   }
+
+   @Override
+   protected AbstractStressorRecord newRecord(AbstractStressorRecord record, long operationId, long seed) {
+      return new StressorRecord((StressorRecord) record, operationId, seed);
+   }
+
+   @Override
+   protected Object findValue(AbstractStressorRecord record) throws Exception {
+      // We cannot atomically get the two vars - the stressor could move backup to main or back between the two
+      // gets. But the chance for doing this 1000 times is small enough.
+      Object value = null;
+      long keyId = record.getKeyId();
+      for (int i = 0; i < 1000; ++i) {
+         value = cacheWrapper.get(bucketId, keyGenerator.generateKey(keyId));
+         if (value == null) {
+            keyId = ~keyId;
+            if (keyId > 0) {
+               // we yield because of the first entry to empty cache
+               Thread.yield();
+            }
+         } else {
+            break;
+         }
+      }
+      return value;
+   }
+
+   @Override
+   protected boolean containsOperation(Object value, AbstractStressorRecord record) {
+      if (value == null) {
+         return false;
+      }
+      if (!(value instanceof PrivateLogValue)) {
+         log.error("Key " + record.getKeyId() + " has unexpected value " + value);
+         return false;
+      }
+      PrivateLogValue logValue = (PrivateLogValue) value;
+      if (logValue.getThreadId() == record.getThreadId()) {
+         for (int i = logValue.size() - 1; i >= 0; --i) {
+            long operationId = logValue.getOperationId(i);
+            if (operationId > record.getLastStressorOperation()) {
+               record.setLastStressorOperation(operationId);
+            }
+            if (operationId == record.getOperationId()) {
+               return true;
+            }
+         }
+      } else {
+         log.error("Expected value from threadId " + record.getThreadId() + " but found from " + logValue.getThreadId());
+      }
+      return false;
+   }
+
+   public static class Pool extends LogChecker.Pool {
+
+      public Pool(int numSlaves, int numThreads, int numEntries) {
+         super(numThreads, numSlaves);
+         for (int slaveId = 0; slaveId < numSlaves; ++slaveId) {
+            Range slaveKeyRange = Range.divideRange(numEntries, numSlaves, slaveId);
+            for (int threadId = 0; threadId < numThreads; ++threadId) {
+               Range threadKeyRange = Range.divideRange(slaveKeyRange.getSize(), numThreads, threadId);
+               Range range = threadKeyRange.shift(slaveKeyRange.getStart());
+               log.trace("Expecting range " + range + " for thread " + (slaveId * numThreads + threadId));
+               records.add(new StressorRecord(slaveId * numThreads + threadId, range));
+            }
+         }
+      }
+   }
+
+   private static class StressorRecord extends AbstractStressorRecord {
+      private final long keyRangeStart;
+      private final int keyRangeSize;
+
+      public StressorRecord(int threadId, Range keyRange) {
+         super(new Random(threadId), threadId);
+         this.keyRangeStart = keyRange.getStart();
+         this.keyRangeSize = keyRange.getSize();
+         next();
+      }
+
+      public StressorRecord(StressorRecord record, long operationId, long seed) {
+         super(seed, record.threadId, operationId);
+         this.keyRangeStart = record.keyRangeStart;
+         this.keyRangeSize = record.keyRangeSize;
+         next();
+      }
+
+      @Override
+      public void next() {
+         currentKeyId = keyRangeStart + rand.nextInt(keyRangeSize);
+         currentOp++;
+      }
+   }
+
+}

--- a/framework/src/main/java/org/radargun/stressors/PrivateLogValue.java
+++ b/framework/src/main/java/org/radargun/stressors/PrivateLogValue.java
@@ -1,0 +1,55 @@
+package org.radargun.stressors;
+
+import java.io.Serializable;
+
+/**
+ * @author Radim Vansa &lt;rvansa@redhat.com&gt;
+ */
+public class PrivateLogValue implements Serializable {
+   private final int threadId;
+   private final long[] operationIds;
+   public PrivateLogValue(int threadId, long operationId) {
+      this.threadId = threadId;
+      operationIds = new long[] { operationId };
+   }
+
+   private PrivateLogValue(int threadId, long[] operationIds) {
+      this.threadId = threadId;
+      this.operationIds = operationIds;
+   }
+
+   public PrivateLogValue with(long operationId) {
+      long[] newOperationIds = new long[operationIds.length + 1];
+      System.arraycopy(operationIds, 0, newOperationIds, 0, operationIds.length);
+      newOperationIds[operationIds.length] = operationId;
+      return new PrivateLogValue(threadId, newOperationIds);
+   }
+
+   public PrivateLogValue shift(int checkedValues, long operationId) {
+      long[] newOperationIds = new long[operationIds.length - checkedValues + 1];
+      System.arraycopy(operationIds, checkedValues, newOperationIds, 0, operationIds.length - checkedValues);
+      newOperationIds[operationIds.length - checkedValues] = operationId;
+      return new PrivateLogValue(threadId, newOperationIds);
+   }
+
+   public int size() {
+      return operationIds.length;
+   }
+
+   public long getOperationId(int i) {
+      return operationIds[i];
+   }
+
+   @Override
+   public String toString() {
+      StringBuilder sb = new StringBuilder("[").append(threadId).append(" #").append(operationIds.length).append(": ");
+      for (long op : operationIds) {
+         sb.append(op).append(", ");
+      }
+      return sb.append("]").toString();
+   }
+
+   public int getThreadId() {
+      return threadId;
+   }
+}

--- a/framework/src/main/java/org/radargun/stressors/SharedLogValue.java
+++ b/framework/src/main/java/org/radargun/stressors/SharedLogValue.java
@@ -1,0 +1,162 @@
+package org.radargun.stressors;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.HashSet;
+
+/**
+ * Value that stores all operations that were executed on this entry.
+ *
+ * @author Radim Vansa &lt;rvansa@redhat.com&gt;
+ */
+public class SharedLogValue implements Serializable {
+   private final int[] threadIds;
+   private final long[] operationIds;
+
+   public SharedLogValue(int threadId, long operationId) {
+      threadIds = new int[] { threadId };
+      operationIds = new long[] { operationId };
+   }
+
+   protected SharedLogValue(int[] threadIds, long[] operationIds) {
+      this.threadIds = threadIds;
+      this.operationIds = operationIds;
+   }
+
+   public SharedLogValue with(int threadId, long operationId) {
+      int[] newThreadIds = new int[threadIds.length + 1];
+      System.arraycopy(threadIds, 0, newThreadIds, 0, threadIds.length);
+      newThreadIds[threadIds.length] = threadId;
+      long[] newOperationIds = new long[operationIds.length + 1];
+      System.arraycopy(operationIds, 0, newOperationIds, 0, operationIds.length);
+      newOperationIds[operationIds.length] = operationId;
+      return new SharedLogValue(newThreadIds, newOperationIds);
+   }
+
+   public SharedLogValue with(int threadId, long operationId, long checkedOperationId) {
+      int toRemoveCount = 0;
+      for (int i = 0; i < threadIds.length; ++i) {
+         if (threadIds[i] == threadId && operationIds[i] <= checkedOperationId) {
+            ++toRemoveCount;
+         }
+      }
+      int[] newThreadIds = new int[threadIds.length - toRemoveCount + 1];
+      long[] newOperationIds = new long[operationIds.length - toRemoveCount + 1];
+      for (int i = 0, j = 0; i < threadIds.length; ++i) {
+         if (threadIds[i] != threadId || operationIds[i] > checkedOperationId) {
+            newThreadIds[j] = threadIds[i];
+            newOperationIds[j] = operationIds[i];
+            ++j;
+         }
+      }
+      newThreadIds[newThreadIds.length - 1] = threadId;
+      newOperationIds[newOperationIds.length - 1] = operationId;
+      return new SharedLogValue(newThreadIds, newOperationIds);
+   }
+
+   public SharedLogValue join(SharedLogValue other) {
+      // reserve enough space
+      // the values will likely have the same beginning
+      int commonIndex;
+      int minLength = Math.min(threadIds.length, other.threadIds.length);
+      for (commonIndex = 0; commonIndex < minLength; ++commonIndex) {
+         if (threadIds[commonIndex] != other.threadIds[commonIndex] || operationIds[commonIndex] != other.operationIds[commonIndex]) {
+            break;
+         }
+      }
+      if (commonIndex == threadIds.length) {
+         return other;
+      } else if (commonIndex == other.threadIds.length) {
+         return this;
+      } else {
+         HashSet<ThreadOperation> operations = new HashSet<ThreadOperation>();
+         for (int i = commonIndex; i < threadIds.length; ++i) {
+            operations.add(new ThreadOperation(threadIds[i], operationIds[i]));
+         }
+         for (int i = commonIndex; i < other.threadIds.length; ++i) {
+            operations.add(new ThreadOperation(other.threadIds[i], other.operationIds[i]));
+         }
+         int[] newThreadIds = new int[commonIndex + operations.size()];
+         long[] newOperationIds = new long[commonIndex + operations.size()];
+         System.arraycopy(threadIds, 0, newThreadIds, 0, commonIndex);
+         System.arraycopy(operationIds, 0, newOperationIds, 0, commonIndex);
+         for (ThreadOperation operation : operations) {
+            newThreadIds[commonIndex] = operation.threadId;
+            newOperationIds[commonIndex] = operation.operationId;
+            ++commonIndex;
+         }
+         return new SharedLogValue(newThreadIds, newOperationIds);
+      }
+   }
+
+   private static class ThreadOperation {
+      public final int threadId;
+      public final long operationId;
+
+      private ThreadOperation(int threadId, long operationId) {
+         this.threadId = threadId;
+         this.operationId = operationId;
+      }
+
+      @Override
+      public boolean equals(Object o) {
+         if (this == o) return true;
+         if (o == null || getClass() != o.getClass()) return false;
+
+         ThreadOperation that = (ThreadOperation) o;
+
+         if (operationId != that.operationId) return false;
+         if (threadId != that.threadId) return false;
+
+         return true;
+      }
+
+      @Override
+      public int hashCode() {
+         int result = threadId;
+         result = 31 * result + (int) (operationId ^ (operationId >>> 32));
+         return result;
+      }
+   }
+
+   public int size() {
+      return threadIds.length;
+   }
+
+   public int getThreadId(int index) {
+      return threadIds[index];
+   }
+
+   public long getOperationId(int index) {
+      return operationIds[index];
+   }
+
+   @Override
+   public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+
+      SharedLogValue that = (SharedLogValue) o;
+
+      if (!Arrays.equals(operationIds, that.operationIds)) return false;
+      if (!Arrays.equals(threadIds, that.threadIds)) return false;
+
+      return true;
+   }
+
+   @Override
+   public int hashCode() {
+      int result = Arrays.hashCode(threadIds);
+      result = 31 * result + Arrays.hashCode(operationIds);
+      return result;
+   }
+
+   @Override
+   public String toString() {
+      StringBuilder sb = new StringBuilder("[ #").append(threadIds.length).append(": ");
+      for (int i = 0; i < threadIds.length; ++i) {
+         sb.append(threadIds[i]).append('~').append(operationIds[i]).append(", ");
+      }
+      return sb.append(']').toString();
+   }
+}

--- a/framework/src/main/java/org/radargun/utils/Utils.java
+++ b/framework/src/main/java/org/radargun/utils/Utils.java
@@ -7,6 +7,7 @@ import java.io.FileWriter;
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.net.URL;
 import java.net.URLClassLoader;
@@ -18,7 +19,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
+import java.util.Random;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 import com.sun.management.HotSpotDiagnosticMXBean;
 import org.apache.commons.logging.Log;
@@ -386,5 +389,21 @@ public class Utils {
       Class clazz = Class.forName(HOTSPOT_BEAN_CLASS);
       Method m = clazz.getMethod(HOTSPOT_BEAN_DUMP_METHOD, String.class, boolean.class);
       m.invoke(hotspotMBean, file, true);
+   }
+
+   public static long getRandomSeed(Random random) {
+      try {
+         Field seedField = Random.class.getDeclaredField("seed");
+         seedField.setAccessible(true);
+         return ((AtomicLong) seedField.get(random)).get();
+      } catch (Exception e) {
+         log.error("Cannot access seed", e);
+         throw new RuntimeException(e);
+      }
+   }
+
+   public static Random setRandomSeed(Random random, long seed) {
+      random.setSeed(seed ^ 0x5DEECE66DL);
+      return random;
    }
 }

--- a/framework/src/main/resources/radargun-1.1.xsd
+++ b/framework/src/main/resources/radargun-1.1.xsd
@@ -18,6 +18,7 @@
                         <element name="AbstractMaster" type="rg:AbstractMaster"/>
                         <element name="AbstractStart" type="rg:AbstractStart"/>
                         <element name="Check" type="rg:Check"/>
+                        <element name="CheckBackgroundStressors" type="rg:CheckBackgroundStressors"/>
                         <element name="CheckData" type="rg:CheckData"/>
                         <element name="CheckTopology" type="rg:CheckTopology"/>
                         <element name="ClearCluster" type="rg:ClearCluster"/>
@@ -130,6 +131,7 @@
             <element name="AbstractMaster" type="rg:AbstractMaster"/>
             <element name="AbstractStart" type="rg:AbstractStart"/>
             <element name="Check" type="rg:Check"/>
+            <element name="CheckBackgroundStressors" type="rg:CheckBackgroundStressors"/>
             <element name="CheckData" type="rg:CheckData"/>
             <element name="CheckTopology" type="rg:CheckTopology"/>
             <element name="ClearCluster" type="rg:ClearCluster"/>
@@ -254,6 +256,14 @@
    <complexType abstract="true" name="Check">
       <annotation>
          <documentation/>
+      </annotation>
+      <complexContent>
+         <extension base="rg:AbstractDist"/>
+      </complexContent>
+   </complexType>
+   <complexType name="CheckBackgroundStressors">
+      <annotation>
+         <documentation>Stage that checks the progress in background stressors and fails if something went wrong.</documentation>
       </annotation>
       <complexContent>
          <extension base="rg:AbstractDist"/>
@@ -1468,6 +1478,31 @@ Remember to set up JVM args: "-agentpath:/path/to/libjprofilerti.so=offline,id=1
                   <documentation>Use conditional putIfAbsent instead of simple put for loading the keys. Default is false.</documentation>
                </annotation>
             </attribute>
+            <attribute name="logCheckersNoProgressTimeout" type="rg:long__org_radargun_config_TimeConverter">
+               <annotation>
+                  <documentation>Maximum time for which are the log value checkers allowed to show no new checked values (error is thrown in CheckBackgroundStressors stage). Default is one minute.</documentation>
+               </annotation>
+            </attribute>
+            <attribute name="logCheckingThreads" type="rg:int">
+               <annotation>
+                  <documentation>Number of threads on each node that are checking whether all operations from stressor threads have been logged. Default is 10.</documentation>
+               </annotation>
+            </attribute>
+            <attribute name="logCounterUpdatePeriod" type="rg:long">
+               <annotation>
+                  <documentation>Number of operations after which will the stressor or checker update in-cache operation counter. Default is 50.</documentation>
+               </annotation>
+            </attribute>
+            <attribute name="logValueMaxSize" type="rg:int">
+               <annotation>
+                  <documentation>Maximum number of records in one entry before the older ones have to be truncated. Default is 100.</documentation>
+               </annotation>
+            </attribute>
+            <attribute name="noLoading" type="rg:boolean">
+               <annotation>
+                  <documentation>Do not execute the loading, start usual request right away.</documentation>
+               </annotation>
+            </attribute>
             <attribute name="numEntries" type="rg:int">
                <annotation>
                   <documentation>Amount of entries (key-value pairs) inserted into the cache. Default is 1024.</documentation>
@@ -1488,9 +1523,19 @@ Remember to set up JVM args: "-agentpath:/path/to/libjprofilerti.so=offline,id=1
                   <documentation>Ratio of REMOVE requests. Default is 0.</documentation>
                </annotation>
             </attribute>
+            <attribute name="sharedKeys" type="rg:boolean">
+               <annotation>
+                  <documentation>By default each thread accesses only its private set of keys. This allows all threads all values. Atomic operations are required for this functionality. Default is false.</documentation>
+               </annotation>
+            </attribute>
             <attribute name="transactionSize" type="rg:int">
                <annotation>
                   <documentation>Amount of request wrapped into single transaction. By default transactions are not used (explicitely).</documentation>
+               </annotation>
+            </attribute>
+            <attribute name="useLogValues" type="rg:boolean">
+               <annotation>
+                  <documentation>Use values which trace all operation on these keys. Therefore, they're always growing. Default is false.</documentation>
                </annotation>
             </attribute>
             <attribute name="waitUntilLoaded" type="rg:boolean">


### PR DESCRIPTION
- checks if each operation's result can be seen from all nodes
- tests GET, PUT, REMOVE (both conditional and non-conditional), PUT_IF_ABSENT, REPLACE (conditional)
- theoretically we may miss some error but there should be no false positives (would be a bug in stressors)
- minor: apache.log4j -> apache.commons (as used in all the rest of framework)
