### PR TITLE
Add support for MapReduceTask combiners

### DIFF
--- a/framework/src/main/java/org/radargun/features/MapReduceCapable.java
+++ b/framework/src/main/java/org/radargun/features/MapReduceCapable.java
@@ -21,7 +21,6 @@ package org.radargun.features;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import org.radargun.CacheWrapper;
 import org.radargun.utils.ClassLoadHelper;
 
 public interface MapReduceCapable<KOut, VOut, R> {
@@ -116,19 +115,32 @@ public interface MapReduceCapable<KOut, VOut, R> {
 
    /**
     * 
-    * This method allows the caller to provide parameters to the Mapper, Reducer, and Collator
-    * objects used in a MapReduce job. Each Map contains keys for each public method name, and
-    * values for each single String parameter for the method. If no parameters are needed, these can
-    * be set to an empty Map.
+    * This method allows the caller to provide parameters to the Mapper, Reducer, Combiner, and
+    * Collator objects used in a MapReduce job. Each Map contains keys for each public method name,
+    * and values for each single String parameter for the method. If no parameters are needed, these
+    * can be set to an empty Map.
     * 
     * @param mapperParameters
     *           parameters for the Mapper object
     * @param reducerParameters
     *           parameters for the Reducer object
+    * @param combinerParameters
+    *           parameters for the Reducer object used as a combiner
     * @param collatorParameters
     *           parameters for the Collator object
     */
    public void setParameters(Map<String, String> mapperParameters, Map<String, String> reducerParameters,
-         Map<String, String> collatorParameters);
+         Map<String, String> combinerParameters, Map<String, String> collatorParameters);
+
+   /**
+    * 
+    * Specifies a Reducer class to be used with the MapReduceTask during the combine phase
+    * 
+    * @param combinerFqn
+    *           the fully qualified class name for the org.infinispan.distexec.mapreduce.Reducer
+    *           implementation. The implementation must have a no argument constructor.
+    * @return <code>true</code> if the CacheWrapper supports this flag, else <code>false</code>
+    */
+   public boolean setCombiner(String combinerFqn);
 
 }

--- a/framework/src/main/resources/radargun-1.1.xsd
+++ b/framework/src/main/resources/radargun-1.1.xsd
@@ -1016,6 +1016,16 @@ Remember to set up JVM args: "-agentpath:/path/to/libjprofilerti.so=offline,id=1
                   <documentation>A String in the form of 'methodName:methodParameter;methodName1:methodParameter1' that allows invoking a method on the Collator Object. The method must be public and take a String parameter. The default is null.</documentation>
                </annotation>
             </attribute>
+            <attribute name="combinerFqn" type="string">
+               <annotation>
+                  <documentation>Fully qualified class name of the org.infinispan.distexec.mapreduce.Reducer implementation to use as a combiner.</documentation>
+               </annotation>
+            </attribute>
+            <attribute name="combinerParams" type="string">
+               <annotation>
+                  <documentation>A String in the form of 'methodName:methodParameter;methodName1:methodParameter1' that allows invoking a method on the Reducer Object used as a combiner. The method must be public and take a String parameter. The default is null.</documentation>
+               </annotation>
+            </attribute>
             <attribute name="distributeReducePhase" type="rg:boolean">
                <annotation>
                   <documentation>Boolean value that determines if the Reduce phase of the MapReduceTask is distributed. The default is true.</documentation>

--- a/plugins/infinispan51/src/main/java/org/radargun/cachewrappers/Infinispan51Wrapper.java
+++ b/plugins/infinispan51/src/main/java/org/radargun/cachewrappers/Infinispan51Wrapper.java
@@ -201,8 +201,13 @@ public class Infinispan51Wrapper extends InfinispanWrapper
    }
 
    @Override
-   public void setParameters(Map mapperParameters, Map reducerParameters, Map collatorParameters) {
-      mapReduce.setParameters(mapperParameters, reducerParameters, collatorParameters);
+   public boolean setCombiner(String combinerFqn) {
+      return mapReduce.setCombiner(combinerFqn);
+   }
+
+   @Override
+   public void setParameters(Map mapperParameters, Map reducerParameters, Map combinerParameters, Map collatorParameters) {
+      mapReduce.setParameters(mapperParameters, reducerParameters, combinerParameters, collatorParameters);
    }
 
    @Override

--- a/plugins/infinispan52/src/main/java/org/radargun/cachewrappers/Infinispan52MapReduce.java
+++ b/plugins/infinispan52/src/main/java/org/radargun/cachewrappers/Infinispan52MapReduce.java
@@ -20,9 +20,11 @@ package org.radargun.cachewrappers;
 
 import org.infinispan.Cache;
 import org.infinispan.distexec.mapreduce.MapReduceTask;
+import org.infinispan.distexec.mapreduce.Reducer;
+import org.radargun.utils.ClassLoadHelper;
+import org.radargun.utils.Utils;
 
-public class Infinispan52MapReduce<KIn, VIn, KOut, VOut, R> extends
-      InfinispanMapReduce<KIn, VIn, KOut, VOut, R> {
+public class Infinispan52MapReduce<KIn, VIn, KOut, VOut, R> extends InfinispanMapReduce<KIn, VIn, KOut, VOut, R> {
 
    public Infinispan52MapReduce(Infinispan52Wrapper wrapper) {
       super(wrapper);
@@ -45,4 +47,27 @@ public class Infinispan52MapReduce<KIn, VIn, KOut, VOut, R> extends
       Cache<KIn, VIn> cache = (Cache<KIn, VIn>) wrapper.getCache(null);
       return new MapReduceTask<KIn, VIn, KOut, VOut>(cache, this.distributeReducePhase, this.useIntermediateSharedCache);
    }
+
+   @Override
+   public boolean setCombiner(String combinerFqn) {
+      this.combinerFqn = combinerFqn;
+      return true;
+   }
+
+   @Override
+   protected MapReduceTask<KIn, VIn, KOut, VOut> setCombiner(MapReduceTask<KIn, VIn, KOut, VOut> task,
+         ClassLoadHelper classLoadHelper, String combinerFqn) {
+      if (combinerFqn != null) {
+         try {
+            @SuppressWarnings("unchecked")
+            Reducer<KOut, VOut> combiner = (Reducer<KOut, VOut>) classLoadHelper.createInstance(combinerFqn);
+            Utils.invokeMethodWithString(combiner, this.combinerParameters);
+            task = task.combinedWith(combiner);
+         } catch (Exception e) {
+            throw (new IllegalArgumentException("Could not instantiate Combiner class: " + combinerFqn, e));
+         }
+      }
+      return task;
+   }
+
 }


### PR DESCRIPTION
Infinispan 5.2 added the ability to specify a Reducer that would be used
to reduce the values on the local node before the global reduce phase is
executed. This commit adds support for specifying this option in the
MapReduceStage parameters and implements support for them in the
MapReduceCapable interface and InfinispanMapReduce class.
