### PR TITLE
Fix: in TX context the entries written in one transactions can be committed in different order

### DIFF
--- a/framework/src/main/java/org/radargun/stressors/PrivateLogChecker.java
+++ b/framework/src/main/java/org/radargun/stressors/PrivateLogChecker.java
@@ -51,11 +51,7 @@ public class PrivateLogChecker extends LogChecker {
       PrivateLogValue logValue = (PrivateLogValue) value;
       if (logValue.getThreadId() == record.getThreadId()) {
          for (int i = logValue.size() - 1; i >= 0; --i) {
-            long operationId = logValue.getOperationId(i);
-            if (operationId > record.getLastStressorOperation()) {
-               record.setLastStressorOperation(operationId);
-            }
-            if (operationId == record.getOperationId()) {
+            if (logValue.getOperationId(i) == record.getOperationId()) {
                return true;
             }
          }


### PR DESCRIPTION
We can't assume that this operation should be completed from seeing "later" operation, when in transactional context.
