### PR TITLE
Fix an issue in populateGraph() that could cause an

### DIFF
--- a/framework/src/main/java/org/radargun/reporting/LocalSystemMonitorChart.java
+++ b/framework/src/main/java/org/radargun/reporting/LocalSystemMonitorChart.java
@@ -141,8 +141,14 @@ public class LocalSystemMonitorChart {
          }
       } else {
          for (Object item : monitorData.getItems()) {
-            TimeSeriesDataItem tsdi = (TimeSeriesDataItem) item;
-            reportStrings.set(counter, reportStrings.get(counter) + "," + tsdi.getValue());
+            /*
+             * It's possible that one node gathered more data items than another node in the
+             * cluster. If this happens, ignore those items.
+             */
+            if (counter < reportStrings.size()) {
+               TimeSeriesDataItem tsdi = (TimeSeriesDataItem) item;
+               reportStrings.set(counter, reportStrings.get(counter) + "," + tsdi.getValue());
+            }
             counter++;
          }
       }


### PR DESCRIPTION
IndexOutOfBoundsException

It's possible that one node in the cluster collected more JVMMonitor
items than another node. In this case, the extra items are ignored.
