### PR TITLE
CacheWrapper (BasicOperations) API supports local/global clear

### DIFF
--- a/framework/src/main/java/org/radargun/BasicOperations.java
+++ b/framework/src/main/java/org/radargun/BasicOperations.java
@@ -36,8 +36,8 @@ public interface BasicOperations {
    Object remove(String bucket, Object key) throws Exception;
 
    /**
-    * This is called after each test type (if emptyCacheBetweenTests is set to true in benchmark.xml) and is
-    * used to flush the cache.
+    * Remove all entries from the cache. If local is set to true, remove entries only on this node.
+    * @param local
     */
-   void empty() throws Exception;
+   void clear(boolean local) throws Exception;
 }

--- a/framework/src/main/java/org/radargun/local/LocalBenchmark.java
+++ b/framework/src/main/java/org/radargun/local/LocalBenchmark.java
@@ -78,6 +78,7 @@ public class LocalBenchmark {
                      monitor.stopMonitoringLocal();
                   }
                   stressor.destroy();
+                  wrapper.clear(true);
                }
                generateReport(results, product.getKey(), config);
                wrapper.tearDown();

--- a/framework/src/main/java/org/radargun/stressors/StressTestStressor.java
+++ b/framework/src/main/java/org/radargun/stressors/StressTestStressor.java
@@ -175,7 +175,6 @@ public class StressTestStressor extends AbstractCacheWrapperStressor {
    }
 
    public void destroy() throws Exception {
-      cacheWrapper.empty();
       cacheWrapper = null;
       bulkCacheWrapper = null;
    }

--- a/framework/src/main/java/org/radargun/stressors/TpccStressor.java
+++ b/framework/src/main/java/org/radargun/stressors/TpccStressor.java
@@ -105,7 +105,6 @@ public class TpccStressor extends AbstractCacheWrapperStressor {
    }
 
    public void destroy() throws Exception {
-      cacheWrapper.empty();
       cacheWrapper = null;
    }
 

--- a/framework/src/main/java/org/radargun/stressors/WarmupStressor.java
+++ b/framework/src/main/java/org/radargun/stressors/WarmupStressor.java
@@ -136,7 +136,6 @@ public class WarmupStressor extends AbstractCacheWrapperStressor {
 
 
    public void destroy() throws Exception {
-      wrapper.empty();
       wrapper = null;
    }
 }

--- a/framework/src/main/resources/radargun-1.1.xsd
+++ b/framework/src/main/resources/radargun-1.1.xsd
@@ -428,7 +428,13 @@
          <documentation>Removes all data from the cache</documentation>
       </annotation>
       <complexContent>
-         <extension base="rg:AbstractDist"/>
+         <extension base="rg:AbstractDist">
+            <attribute name="local" type="rg:boolean">
+               <annotation>
+                  <documentation>Execute local variant of clear on each slave. Default value is true.</documentation>
+               </annotation>
+            </attribute>
+         </extension>
       </complexContent>
    </complexType>
    <complexType name="StressTest">

--- a/plugins/chm/src/main/java/org/radargun/cachewrappers/ChmWrapper.java
+++ b/plugins/chm/src/main/java/org/radargun/cachewrappers/ChmWrapper.java
@@ -80,7 +80,8 @@ public class ChmWrapper implements CacheWrapper, BulkOperationsCapable, AtomicOp
       return values;
    }
 
-   public void empty() throws Exception {
+   @Override
+   public void clear(boolean local) throws Exception {
       chm.clear();
    }
 

--- a/plugins/coherence3/src/main/java/org/radargun/cachewrappers/Coherence3Wrapper.java
+++ b/plugins/coherence3/src/main/java/org/radargun/cachewrappers/Coherence3Wrapper.java
@@ -83,7 +83,11 @@ public class Coherence3Wrapper implements CacheWrapper {
       return nc.remove(key);
    }
 
-   public void empty() throws Exception {
+   @Override
+   public void clear(boolean local) throws Exception {
+      if (local) {
+         log.warn("This cache cannot remove only local entries");
+      }
       nc.clear();
    }
 

--- a/plugins/ehcache25/src/main/java/org/radargun/cachewrappers/EHCacheWrapper.java
+++ b/plugins/ehcache25/src/main/java/org/radargun/cachewrappers/EHCacheWrapper.java
@@ -78,8 +78,9 @@ public class EHCacheWrapper implements CacheWrapper, AtomicOperationsCapable, Bu
       return cache.get(key);
    }
 
-   public void empty() throws Exception {
-      cache.removeAll();
+   @Override
+   public void clear(boolean local) throws Exception {
+      cache.removeAll(local);
    }
 
    public void put(String path, Object key, Object value) throws Exception {

--- a/plugins/ehcache26/src/main/java/org/radargun/cachewrappers/EHCacheWrapper.java
+++ b/plugins/ehcache26/src/main/java/org/radargun/cachewrappers/EHCacheWrapper.java
@@ -78,8 +78,9 @@ public class EHCacheWrapper implements CacheWrapper, AtomicOperationsCapable, Bu
       return cache.get(key);
    }
 
-   public void empty() throws Exception {
-      cache.removeAll();
+   @Override
+   public void clear(boolean local) throws Exception {
+      cache.removeAll(local);
    }
 
    public void put(String path, Object key, Object value) throws Exception {

--- a/plugins/hazelcast2/src/main/java/org/radargun/cachewrappers/HazelcastWrapper.java
+++ b/plugins/hazelcast2/src/main/java/org/radargun/cachewrappers/HazelcastWrapper.java
@@ -87,7 +87,10 @@ public class HazelcastWrapper implements CacheWrapper, AtomicOperationsCapable {
    }
 
    @Override
-   public void empty() throws Exception {
+   public void clear(boolean local) throws Exception {
+      if (local) {
+         log.warn("This cache cannot remove only local entries");
+      }
       hazelcastMap.clear();
    }
 

--- a/plugins/infinispan4/src/main/java/org/radargun/cachewrappers/InfinispanWrapper.java
+++ b/plugins/infinispan4/src/main/java/org/radargun/cachewrappers/InfinispanWrapper.java
@@ -199,8 +199,8 @@ public class InfinispanWrapper implements CacheWrapper, Debugable, AtomicOperati
    }
 
    @Override
-   public void empty() throws Exception {
-      basicOperations.empty();
+   public void clear(boolean local) throws Exception {
+      basicOperations.clear(local);
    }
 
    @Override

--- a/plugins/jbosscache2/src/main/java/org/radargun/cachewrappers/JBossCache2Wrapper.java
+++ b/plugins/jbosscache2/src/main/java/org/radargun/cachewrappers/JBossCache2Wrapper.java
@@ -55,8 +55,11 @@ public class JBossCache2Wrapper implements CacheWrapper
       return cache.remove(Fqn.fromString(bucket), key);
    }
 
-   public void empty() throws Exception
+   public void clear(boolean local) throws Exception
    {
+      if (local) {
+         log.warn("This cache cannot remove only local entries");
+      }
       //not removing root because there it fails with buddy replication: http://jira.jboss.com/jira/browse/JBCACHE-1241
       cache.removeNode(Fqn.fromElements("test"));
    }

--- a/plugins/jbosscache3/src/main/java/org/radargun/cachewrappers/JBossCache3Wrapper.java
+++ b/plugins/jbosscache3/src/main/java/org/radargun/cachewrappers/JBossCache3Wrapper.java
@@ -79,8 +79,12 @@ public class JBossCache3Wrapper implements CacheWrapper
          return cache.remove(Fqn.fromString(bucket), key);
    }
 
-   public void empty() throws Exception
+   @Override
+   public void clear(boolean local) throws Exception
    {
+      if (local) {
+         log.warn("This cache cannot remove only local entries");
+      }
       if (FLAT)
       {
          flatCache.clear();

--- a/plugins/jgroups30/src/main/java/org/radargun/cachewrappers/JGroupsWrapper.java
+++ b/plugins/jgroups30/src/main/java/org/radargun/cachewrappers/JGroupsWrapper.java
@@ -173,8 +173,8 @@ public class JGroupsWrapper extends ReceiverAdapter implements CacheWrapper {
       throw new UnsupportedOperationException();
    }        
 
-   public void empty() throws Exception {
-      ; // no-op
+   public void clear(boolean local) throws Exception {
+      lastValue = null;
    }
 
    public void viewAccepted(View newView) {

--- a/plugins/terracotta3/src/main/java/org/radargun/cachewrappers/TerracottaWrapper.java
+++ b/plugins/terracotta3/src/main/java/org/radargun/cachewrappers/TerracottaWrapper.java
@@ -23,7 +23,7 @@ public class TerracottaWrapper implements CacheWrapper {
    }
 
    public void tearDown() throws Exception {
-      empty();
+      clear(true);
    }
 
    @Override
@@ -71,7 +71,8 @@ public class TerracottaWrapper implements CacheWrapper {
       return false;
    }
 
-   public void empty() throws Exception {
+   @Override
+   public void clear(boolean local) throws Exception {
       synchronized (sessionCaches) {
          for (Map cache : sessionCaches.values()) {
             synchronized (cache) {


### PR DESCRIPTION
- ClearClusterStage uses local clear on each node by default
