### PR TITLE
Improvements for starting/killing nodes

### DIFF
--- a/framework/src/main/java/org/radargun/stages/StartClusterStage.java
+++ b/framework/src/main/java/org/radargun/stages/StartClusterStage.java
@@ -1,13 +1,13 @@
 package org.radargun.stages;
 
+import java.util.Set;
+
 import org.radargun.DistStageAck;
 import org.radargun.config.Property;
 import org.radargun.config.Stage;
 import org.radargun.config.TimeConverter;
 import org.radargun.stages.helpers.StartHelper;
 import org.radargun.state.MasterState;
-
-import java.util.Set;
 
 /**
  * Stage that starts a CacheWrapper on each slave.
@@ -28,6 +28,9 @@ public class StartClusterStage extends AbstractStartStage {
 
    @Property(converter = TimeConverter.class, doc = "Delay between initiating start of i-th and (i+1)-th slave. Default is 500 ms")
    private long delayBetweenStartingSlaves = 500;
+
+   @Property(converter = TimeConverter.class, doc = "Time allowed the cluster to reach `expectNumSlaves` members. Default is 3 minutes.")
+   private long clusterFormationTimeout = 180000;
 
    @Property(doc = "The number of slaves that should be up after all slaves are started. Applicable only with " +
          "validateCluster=true. Default is all slaves in the cluster (in the same site in case of multi-site configuration).")
@@ -66,7 +69,7 @@ public class StartClusterStage extends AbstractStartStage {
       
       StartHelper.start(productName, config, confAttributes, slaveState, getSlaveIndex(),
             validateCluster ? new StartHelper.ClusterValidation(expectNumSlaves, getActiveSlaveCount()) : null,
-            reachable, classLoadHelper, ack);
+            clusterFormationTimeout, reachable, classLoadHelper, ack);
       if (!ack.isError()) {
          log.info("Successfully started cache wrapper on slave " + getSlaveIndex() + ": " + slaveState.getCacheWrapper());
       }

--- a/framework/src/main/resources/radargun-1.1.xsd
+++ b/framework/src/main/resources/radargun-1.1.xsd
@@ -987,6 +987,11 @@ Remember to set up JVM args: "-agentpath:/path/to/libjprofilerti.so=offline,id=1
                   <documentation>If set to true, the nodes should be shutdown. Default is false = simulate node crash.</documentation>
                </annotation>
             </attribute>
+            <attribute name="waitForDelayed" type="rg:boolean">
+               <annotation>
+                  <documentation>If set, the stage will not kill any node but will wait until the delayed execution is finished. Default is false</documentation>
+               </annotation>
+            </attribute>
          </extension>
       </complexContent>
    </complexType>
@@ -1161,9 +1166,14 @@ Remember to set up JVM args: "-agentpath:/path/to/libjprofilerti.so=offline,id=1
                   <documentation>Set of slaves which should be killed in this stage. Default is empty.</documentation>
                </annotation>
             </attribute>
+            <attribute name="killDelay" type="rg:long__org_radargun_config_TimeConverter">
+               <annotation>
+                  <documentation>Delay before the slaves are killed. Default is 0.</documentation>
+               </annotation>
+            </attribute>
             <attribute name="reachable" type="string">
                <annotation>
-                  <documentation>Applicable only for cache wrappers with Partitionable feature. Set of slaves that should bereachable from the new node. Default is empty.</documentation>
+                  <documentation>Applicable only for cache wrappers with Partitionable feature. Set of slaves that should bereachable from the new node. Default is all slaves.</documentation>
                </annotation>
             </attribute>
             <attribute name="role" type="rg:org_radargun_stages_helpers_RoleHelper_Role">
@@ -1174,6 +1184,16 @@ Remember to set up JVM args: "-agentpath:/path/to/libjprofilerti.so=offline,id=1
             <attribute name="start" type="string">
                <annotation>
                   <documentation>Set of slaves which should be started in this stage. Default is empty.</documentation>
+               </annotation>
+            </attribute>
+            <attribute name="startDelay" type="rg:long__org_radargun_config_TimeConverter">
+               <annotation>
+                  <documentation>Delay before the slaves are started. Default is 0.</documentation>
+               </annotation>
+            </attribute>
+            <attribute name="tearDown" type="rg:boolean">
+               <annotation>
+                  <documentation>If set to true, the nodes should be shutdown. Default is false = simulate node crash.</documentation>
                </annotation>
             </attribute>
          </extension>
@@ -1620,6 +1640,11 @@ Remember to set up JVM args: "-agentpath:/path/to/libjprofilerti.so=offline,id=1
       </annotation>
       <complexContent>
          <extension base="rg:AbstractStart">
+            <attribute name="clusterFormationTimeout" type="rg:long__org_radargun_config_TimeConverter">
+               <annotation>
+                  <documentation>Time allowed the cluster to reach `expectNumSlaves` members. Default is 3 minutes.</documentation>
+               </annotation>
+            </attribute>
             <attribute name="delayAfterFirstSlaveStarts" type="rg:long__org_radargun_config_TimeConverter">
                <annotation>
                   <documentation>Delay (staggering) after first slave's start is initiated. Default is 5s</documentation>

--- a/plugins/infinispan51/src/main/java/org/radargun/protocols/SLAVE_PARTITION.java
+++ b/plugins/infinispan51/src/main/java/org/radargun/protocols/SLAVE_PARTITION.java
@@ -18,6 +18,10 @@
  */
 package org.radargun.protocols;
 
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.util.Set;
+
 import org.jgroups.Event;
 import org.jgroups.Global;
 import org.jgroups.Header;
@@ -28,17 +32,13 @@ import org.jgroups.logging.LogFactory;
 import org.jgroups.stack.Protocol;
 import org.jgroups.util.Streamable;
 
-import java.io.DataInput;
-import java.io.DataOutput;
-import java.util.Set;
-
 public class SLAVE_PARTITION extends Protocol {
 
-   private static final short PROTOCOL_ID = (short)0x51A7;
-   private static Log log = LogFactory.getLog(SLAVE_PARTITION.class);
+   protected static final short PROTOCOL_ID = (short)0x51A7;
+   protected static Log log = LogFactory.getLog(SLAVE_PARTITION.class);
    
-   private int slaveIndex = -1;
-   private Set<Integer> allowedSlaves;
+   protected int slaveIndex = -1;
+   protected Set<Integer> allowedSlaves;
    
    static {
       log.info("Registering SLAVE_PARTITION with id " + PROTOCOL_ID);
@@ -88,7 +88,7 @@ public class SLAVE_PARTITION extends Protocol {
       public SlaveHeader() {
       }
 
-      private SlaveHeader(int index) {
+      public SlaveHeader(int index) {
           this.index=index;
       }
       

--- a/plugins/infinispan52/src/main/java/org/radargun/cachewrappers/Infinispan52Lifecycle.java
+++ b/plugins/infinispan52/src/main/java/org/radargun/cachewrappers/Infinispan52Lifecycle.java
@@ -26,6 +26,7 @@ import java.util.List;
 import org.jgroups.JChannel;
 import org.jgroups.protocols.relay.RELAY2;
 import org.jgroups.protocols.relay.Relayer;
+import org.radargun.protocols.SLAVE_PARTITION;
 
 public class Infinispan52Lifecycle extends InfinispanPartitionableLifecycle {
    public Infinispan52Lifecycle(Infinispan52Wrapper wrapper) {
@@ -79,5 +80,10 @@ public class Infinispan52Lifecycle extends InfinispanPartitionableLifecycle {
          log.info("No RELAY2 protocol in XS wrapper");
       }
       return list;
+   }
+
+   @Override
+   protected Class<? extends SLAVE_PARTITION> getPartitionProtocolClass() {
+      return SLAVE_PARTITION_33.class;
    }
 }

--- a/plugins/infinispan52/src/main/java/org/radargun/cachewrappers/SLAVE_PARTITION_33.java
+++ b/plugins/infinispan52/src/main/java/org/radargun/cachewrappers/SLAVE_PARTITION_33.java
@@ -1,0 +1,23 @@
+package org.radargun.cachewrappers;
+
+import org.jgroups.Event;
+import org.jgroups.Message;
+import org.radargun.protocols.SLAVE_PARTITION;
+
+/**
+ * SLAVE_PARTITION adapted for JGroups 3.3.x
+ *
+ * @author Radim Vansa &lt;rvansa@redhat.com&gt;
+ */
+public class SLAVE_PARTITION_33 extends SLAVE_PARTITION {
+   @Override
+   public Object down(Event evt) {
+      switch (evt.getType()) {
+         case Event.MSG:
+            Message msg = (Message) evt.getArg();
+            // putHeader signature has changed
+            msg.putHeader(PROTOCOL_ID, new SlaveHeader(this.slaveIndex));
+      }
+      return down_prot.down(evt);
+   }
+}


### PR DESCRIPTION
- KillStage with delayExecuting can be followed with KillStage with waitForDelayed which will wait until the execution is finished
- ParallelStartKillStage can delay the start/kill, also tearDown is supported
- StartClusterStage has configurable cluster formation timeout (waiting until the number of members gets to the expected value)
- fixed SLAVE_PARTITION for JGroups >= 3.3.x
