### PR TITLE
Background stressors tests:

### DIFF
--- a/framework/src/main/java/org/radargun/stages/CheckBackgroundStressorsStage.java
+++ b/framework/src/main/java/org/radargun/stages/CheckBackgroundStressorsStage.java
@@ -1,6 +1,7 @@
 package org.radargun.stages;
 
 import org.radargun.DistStageAck;
+import org.radargun.config.Property;
 import org.radargun.config.Stage;
 import org.radargun.stressors.BackgroundOpsManager;
 
@@ -9,6 +10,13 @@ import org.radargun.stressors.BackgroundOpsManager;
  */
 @Stage(doc = "Stage that checks the progress in background stressors and fails if something went wrong.")
 public class CheckBackgroundStressorsStage extends AbstractDistStage {
+
+   @Property(doc = "Do not write additional operations until all operations are confirmed. Default is false.")
+   private boolean waitUntilChecked = false;
+
+   @Property(doc = "Resume writers after we have stopped them in order to let checkers check everything. Default is false.")
+   private boolean resumeAfterChecked = false;
+
    @Override
    public DistStageAck executeOnSlave() {
       DefaultDistStageAck ack = newDefaultStageAck();
@@ -19,11 +27,28 @@ public class CheckBackgroundStressorsStage extends AbstractDistStage {
       if (manager != null) {
          String error = manager.getError();
          if (error != null) {
-            log.error(error);
-            ack.setError(true);
-            ack.setErrorMessage(error);
+            return fail(error);
+         }
+         if (waitUntilChecked && resumeAfterChecked) {
+            return fail("Cannot both wait and resume in the same stage; other node may have not finished checking.");
+         }
+         if (waitUntilChecked) {
+            error = manager.waitUntilChecked();
+            if (error != null) {
+               return fail(error);
+            }
+         } else if (resumeAfterChecked) {
+            manager.resumeAfterChecked();
          }
       }
+      return ack;
+   }
+
+   private DistStageAck fail(String error) {
+      DefaultDistStageAck ack = newDefaultStageAck();
+      log.error(error);
+      ack.setError(true);
+      ack.setErrorMessage(error);
       return ack;
    }
 }

--- a/framework/src/main/java/org/radargun/stages/StartBackgroundStressorsStage.java
+++ b/framework/src/main/java/org/radargun/stages/StartBackgroundStressorsStage.java
@@ -74,7 +74,15 @@ public class StartBackgroundStressorsStage extends AbstractDistStage {
 
    @Property(doc = "Maximum time for which are the log value checkers allowed to show no new checked values " +
          "(error is thrown in CheckBackgroundStressors stage). Default is one minute.", converter = TimeConverter.class)
-   private long logCheckersNoProgressTimeout = 60000;
+   private long logCheckersNoProgressTimeout = 120000;
+
+   @Property(doc = "When the log value is full, the stressor needs to wait until all checkers confirm that " +
+         "the records have been checked before discarding oldest records. With ignoreDeadCheckers=true " +
+         "the stressor does not wait for checkers on dead nodes. Default is false.")
+   private boolean ignoreDeadCheckers = false;
+
+   @Property(doc = "Period after which a slave is considered to be dead. Default is 90 s.", converter = TimeConverter.class)
+   private long deadSlaveTimeout = 90000;
 
    @Property(doc = "By default each thread accesses only its private set of keys. This allows all threads all values. " +
          "Atomic operations are required for this functionality. Default is false.")
@@ -91,14 +99,15 @@ public class StartBackgroundStressorsStage extends AbstractDistStage {
                BackgroundOpsManager.getOrCreateInstance(slaveState, puts, gets, removes, numEntries,
                      entrySize, bucketId, numThreads, delayBetweenRequests, getActiveSlaveCount(), getSlaveIndex(),
                      transactionSize, loadDataOnSlaves, loadDataForDeadSlaves, loadOnly, loadWithPutIfAbsent,
-                     useLogValues, logCheckingThreads, logValueMaxSize, logCounterUpdatePeriod, logCheckersNoProgressTimeout, sharedKeys);
+                     useLogValues, logCheckingThreads, logValueMaxSize, logCounterUpdatePeriod, logCheckersNoProgressTimeout,
+                     ignoreDeadCheckers, deadSlaveTimeout, sharedKeys);
 
          log.info("Starting stressor threads");
          if (slaveState.getCacheWrapper() != null) {
             if (noLoading) {
                instance.setLoaded(true);
             }
-            instance.startStressors();
+            instance.startBackgroundThreads();
             if (waitUntilLoaded) {
                log.info("Waiting until all stressor threads load data");
                instance.waitUntilLoaded();

--- a/framework/src/main/java/org/radargun/stages/StopBackgroundStressorsStage.java
+++ b/framework/src/main/java/org/radargun/stages/StopBackgroundStressorsStage.java
@@ -24,7 +24,7 @@ public class StopBackgroundStressorsStage extends AbstractDistStage {
          BackgroundOpsManager instance = BackgroundOpsManager.getInstance(slaveState);
          if (instance != null) {
             instance.waitUntilLoaded();
-            instance.stopStressors();
+            instance.stopBackgroundThreads();
          } else {
             log.error("No " + BackgroundOpsManager.NAME);
             ack.setError(true);

--- a/framework/src/main/java/org/radargun/stressors/SharedLogChecker.java
+++ b/framework/src/main/java/org/radargun/stressors/SharedLogChecker.java
@@ -23,7 +23,7 @@ class SharedLogChecker extends LogChecker {
       // in any entry.
       Object value = null, prevValue = null, prev2Value;
       long keyId = record.getKeyId();
-      for (int i = 0; i < 1000; ++i) {
+      for (int i = 0; i < 100; ++i) {
          prev2Value = prevValue;
          prevValue = value;
          value = cacheWrapper.get(bucketId, keyGenerator.generateKey(keyId));
@@ -31,7 +31,7 @@ class SharedLogChecker extends LogChecker {
             break;
          }
          if (keyId < 0 && record.getLastStressorOperation() < record.getOperationId()) {
-            // do not poll it 1000x when we're not sure that the operation is written, try just twice
+            // do not poll it 100x when we're not sure that the operation is written, try just twice
             break;
          }
          keyId = ~keyId;
@@ -64,8 +64,8 @@ class SharedLogChecker extends LogChecker {
 
    public static class Pool extends LogChecker.Pool {
 
-      public Pool(int numSlaves, int numThreads, int numEntries) {
-         super(numThreads, numSlaves);
+      public Pool(int numSlaves, int numThreads, int numEntries, BackgroundOpsManager manager) {
+         super(numThreads, numSlaves, manager);
          for (int slaveId = 0; slaveId < numSlaves; ++slaveId) {
             for (int threadId = 0; threadId < numThreads; ++threadId) {
                add(new StressorRecord(slaveId * numThreads + threadId, numEntries));

--- a/framework/src/main/java/org/radargun/stressors/SharedLogValue.java
+++ b/framework/src/main/java/org/radargun/stressors/SharedLogValue.java
@@ -92,6 +92,15 @@ public class SharedLogValue implements Serializable {
       }
    }
 
+   public long minFrom(int threadId) {
+      long operationId = Long.MAX_VALUE;
+      for (int i = 0; i < threadIds.length; ++i) {
+         if (threadIds[i] == threadId)
+            operationId = Math.min(operationIds[i], operationId);
+      }
+      return operationId;
+   }
+
    private static class ThreadOperation {
       public final int threadId;
       public final long operationId;

--- a/framework/src/main/resources/radargun-1.1.xsd
+++ b/framework/src/main/resources/radargun-1.1.xsd
@@ -271,7 +271,18 @@
          <documentation>Stage that checks the progress in background stressors and fails if something went wrong.</documentation>
       </annotation>
       <complexContent>
-         <extension base="rg:AbstractDist"/>
+         <extension base="rg:AbstractDist">
+            <attribute name="resumeAfterChecked" type="rg:boolean">
+               <annotation>
+                  <documentation>Resume writers after we have stopped them in order to let checkers check everything. Default is false.</documentation>
+               </annotation>
+            </attribute>
+            <attribute name="waitUntilChecked" type="rg:boolean">
+               <annotation>
+                  <documentation>Do not write additional operations until all operations are confirmed. Default is false.</documentation>
+               </annotation>
+            </attribute>
+         </extension>
       </complexContent>
    </complexType>
    <complexType name="CheckData">
@@ -1537,6 +1548,11 @@ Remember to set up JVM args: "-agentpath:/path/to/libjprofilerti.so=offline,id=1
                   <documentation>Bucket where the entries should be inserted. Default is </documentation>
                </annotation>
             </attribute>
+            <attribute name="deadSlaveTimeout" type="rg:long__org_radargun_config_TimeConverter">
+               <annotation>
+                  <documentation>Period after which a slave is considered to be dead. Default is 90 s.</documentation>
+               </annotation>
+            </attribute>
             <attribute name="delayBetweenRequests" type="rg:long__org_radargun_config_TimeConverter">
                <annotation>
                   <documentation>Time between consecutive requests of one stressor thread. Default is 0.</documentation>
@@ -1550,6 +1566,11 @@ Remember to set up JVM args: "-agentpath:/path/to/libjprofilerti.so=offline,id=1
             <attribute name="gets" type="rg:int">
                <annotation>
                   <documentation>Ratio of GET requests. Default is 2.</documentation>
+               </annotation>
+            </attribute>
+            <attribute name="ignoreDeadCheckers" type="rg:boolean">
+               <annotation>
+                  <documentation>When the log value is full, the stressor needs to wait until all checkers confirm that the records have been checked before discarding oldest records. With ignoreDeadCheckers=true the stressor does not wait for checkers on dead nodes. Default is false.</documentation>
                </annotation>
             </attribute>
             <attribute name="loadDataForDeadSlaves" type="string">


### PR DESCRIPTION
- waiting until all operations are checked (and resuming afterwards)
- stressors may ignore that checkers on dead nodes have not checked everything
  (this is important for elasticity tests where we may end up with single node)
