### PR TITLE
Two minor fixes

### DIFF
--- a/core/src/main/resources/slave.sh
+++ b/core/src/main/resources/slave.sh
@@ -16,13 +16,13 @@ default_master() {
   MASTER_HOST=`sed -n -e '/bindAddress/{
                            s/.*bindAddress="${//
                            s/}".*//
-                           s/:.*//
+                           s/.*://
                            p
                            }' ${RADARGUN_HOME}/conf/benchmark-dist.xml`
   MASTER_PORT=`sed -n -e '/port="/{
                            s/.*port="${//
                            s/}".*//
-                           s/:.*//
+                           s/.*://
                            p
                            }' ${RADARGUN_HOME}/conf/benchmark-dist.xml`
 }

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -6,6 +6,7 @@
       <artifactId>radargun-parent</artifactId>
       <groupId>org.radargun</groupId>
       <version>2.0.0-SNAPSHOT</version>
+      <relativePath>../parent/pom.xml</relativePath>
    </parent>
    <artifactId>radargun-extensions</artifactId>
    <name>RadarGun extensions</name>


### PR DESCRIPTION
Add relativePath value, so the extension example compiles
Fix sed command in slave.sh to get default master host and port
