### PR TITLE
Add getTotalSize() for Infinispan 5.2 and greater

### DIFF
--- a/plugins/infinispan52/src/main/java/org/radargun/service/CacheSizer.java
+++ b/plugins/infinispan52/src/main/java/org/radargun/service/CacheSizer.java
@@ -1,0 +1,33 @@
+package org.radargun.service;
+
+import java.io.Serializable;
+import java.util.Set;
+
+import org.infinispan.Cache;
+import org.infinispan.distexec.DistributedCallable;
+
+/**
+ * 
+ * A distributed callable class used to get the total size of the cache based on the cache size on
+ * each node in the cluster.
+ * 
+ * @author Alan Field &lt;afield@redhat.com&gt;
+ */
+@SuppressWarnings("serial")
+public class CacheSizer<K, V, T> implements DistributedCallable<K, V, Integer>, Serializable {
+
+   Cache<K, V> cache;
+   Set<K> keys;
+
+   @Override
+   public void setEnvironment(Cache<K, V> cache, Set<K> keys) {
+      this.cache = cache;
+      this.keys = keys;
+   }
+
+   @Override
+   public Integer call() throws Exception {
+      return cache.size();
+   }
+
+}

--- a/plugins/infinispan52/src/main/java/org/radargun/service/Infinispan52CacheInfo.java
+++ b/plugins/infinispan52/src/main/java/org/radargun/service/Infinispan52CacheInfo.java
@@ -1,18 +1,28 @@
 package org.radargun.service;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 
 import org.infinispan.AdvancedCache;
 import org.infinispan.container.entries.InternalCacheEntry;
+import org.infinispan.distexec.DefaultExecutorService;
+import org.infinispan.distexec.DistributedExecutorService;
+import org.infinispan.distexec.DistributedTaskBuilder;
 import org.infinispan.distribution.DistributionManager;
 import org.infinispan.distribution.ch.ConsistentHash;
+import org.radargun.logging.Log;
+import org.radargun.logging.LogFactory;
 import org.radargun.traits.CacheInformation;
 
 /**
  * @author Radim Vansa &lt;rvansa@redhat.com&gt;
  */
 public class Infinispan52CacheInfo extends InfinispanCacheInfo {
+   private final Log log = LogFactory.getLog(this.getClass());
+
    public Infinispan52CacheInfo(InfinispanEmbeddedService service) {
       super(service);
    }
@@ -44,6 +54,44 @@ public class Infinispan52CacheInfo extends InfinispanCacheInfo {
       @Override
       public int getEntryOverhead() {
          return 152;
+      }
+
+      @Override
+      public int getTotalSize() {
+         int totalSize = 0;
+         DistributedExecutorService des = new DefaultExecutorService(cache);
+         CacheSizer<?, ?, Integer> cacheSizer = new CacheSizer<Object, Object, Integer>();
+         DistributedTaskBuilder<Integer> taskBuilder = des.createDistributedTaskBuilder(cacheSizer);
+         List<Future<Integer>> futureList = des.submitEverywhere(taskBuilder.build());
+         
+         for (Future<Integer> future : futureList) {
+            try {
+               totalSize += future.get().intValue();
+            } catch (InterruptedException e) {
+               log.error("The distributed task was interrupted.", e);
+               return -1;
+            } catch (ExecutionException e) {
+               log.error("An error occurred executing the distributed task.", e);
+               return -1;
+            }
+         }
+         
+         if (cache.getAdvancedCache().getDistributionManager() != null) {
+            int numMembers = cache.getCacheManager().getMembers().size();
+            int numOwners = cache.getAdvancedCache().getCacheConfiguration().clustering().hash().numOwners();
+            // In replicated mode, numOwners is always 2
+            if (cache.getAdvancedCache().getCacheConfiguration().clustering().cacheMode().isReplicated()) {
+               numOwners = numMembers;
+            }
+            // Adjust for current cluster size
+            if (numMembers >= numOwners) {
+               totalSize /= numOwners;
+            } else {
+               totalSize /= numMembers;
+            }
+         }
+
+         return totalSize;
       }
    }
 }


### PR DESCRIPTION
Use a distributed executor to get the local cache size of each node,
then determine the total size based on the clustering mode and cluster
size.

Note: The accuracy of results with passivation enabled on Infinispan
versions less than 6 is not guaranteed.
