### PR TITLE
Separated getLocalSize() into getOwnedSize()

### DIFF
--- a/core/src/main/java/org/radargun/stages/cache/ClearCacheStage.java
+++ b/core/src/main/java/org/radargun/stages/cache/ClearCacheStage.java
@@ -65,12 +65,12 @@ public class ClearCacheStage extends AbstractDistStage {
                if (cacheInformation == null) return successfulResponse();
             } else {
                if (Boolean.FALSE.equals(local) || localBasicOperations == null) {
-                  int size;
-                  for (int count = new Random().nextInt(20) + 10; count > 0 && (size = cacheInformation.getCache(cacheName).getLocalSize()) > 0; --count) {
+                  long size;
+                  for (int count = new Random().nextInt(20) + 10; count > 0 && (size = cacheInformation.getCache(cacheName).getLocallyStoredSize()) > 0; --count) {
                      log.debug("Waiting until the cache gets empty (contains " + size + " entries)");
                      Thread.sleep(1000);
                   }
-                  if ((size = cacheInformation.getCache(cacheName).getLocalSize()) > 0) {
+                  if ((size = cacheInformation.getCache(cacheName).getLocallyStoredSize()) > 0) {
                      log.error("The cache was not cleared from another node (contains " + size + " entries), clearing locally");
                      DistStageAck response = executeClear();
                      if (response != null) return response;

--- a/core/src/main/java/org/radargun/stages/cache/background/BackgroundOpsManager.java
+++ b/core/src/main/java/org/radargun/stages/cache/background/BackgroundOpsManager.java
@@ -600,7 +600,7 @@ public class BackgroundOpsManager implements ServiceListener {
     */
    private class SizeThread extends Thread {
       private boolean getSize = true;
-      private int size = -1;
+      private long size = -1;
 
       @Override
       public void run() {
@@ -613,7 +613,7 @@ public class BackgroundOpsManager implements ServiceListener {
                   getSize = false;
                }
                if (cacheInfo != null && lifecycle.isRunning()) {
-                  size = cacheInfo.getLocalSize();
+                  size = cacheInfo.getOwnedSize();
                } else {
                   size = 0;
                }
@@ -623,8 +623,8 @@ public class BackgroundOpsManager implements ServiceListener {
          }
       }
 
-      public synchronized int getAndResetSize() {
-         int rSize = size;
+      public synchronized long getAndResetSize() {
+         long rSize = size;
          size = -1;
          getSize = true;
          notify();

--- a/core/src/main/java/org/radargun/stages/distributedtask/DistributedTaskStage.java
+++ b/core/src/main/java/org/radargun/stages/distributedtask/DistributedTaskStage.java
@@ -109,7 +109,7 @@ public class DistributedTaskStage<K, V, T> extends AbstractDistStage {
    }
 
    private String getPayload(long durationNanos) {
-      return slaveState.getSlaveIndex() + ", " + clustered.getClusteredNodes() + ", " + cacheInformation.getCache(null).getLocalSize() + ", " + durationNanos;
+      return slaveState.getSlaveIndex() + ", " + clustered.getClusteredNodes() + ", " + cacheInformation.getCache(null).getLocallyStoredSize() + ", " + durationNanos;
    }
 
    private DistStageAck executeTask() {
@@ -138,7 +138,8 @@ public class DistributedTaskStage<K, V, T> extends AbstractDistStage {
       ack.setText(getPayload(durationNanos));
 
       log.info("Distributed Execution task completed in " + Utils.prettyPrintTime(durationNanos, TimeUnit.NANOSECONDS));
-      log.info(clustered.getClusteredNodes() + " nodes were used. " + cacheInformation.getCache(null).getLocalSize() + " entries on this node");
+      log.infof("%d nodes were used. %d entries on this node",
+            clustered.getClusteredNodes(), cacheInformation.getCache(null).getLocallyStoredSize());
       log.info("Distributed execution results:");
       log.info("--------------------");
       for (T t : resultList) {

--- a/core/src/main/java/org/radargun/stages/mapreduce/MapReduceStage.java
+++ b/core/src/main/java/org/radargun/stages/mapreduce/MapReduceStage.java
@@ -157,7 +157,7 @@ public class MapReduceStage<KOut, VOut, R> extends AbstractDistStage {
 
    private String getPayload(String duration, String resultSize) {
       return slaveState.getSlaveIndex() + ", " + clustered.getClusteredNodes() + ", "
-            + cacheInformation.getCache(cacheInformation.getDefaultCacheName()).getLocalSize() + ", " + duration + ", "
+            + cacheInformation.getCache(cacheInformation.getDefaultCacheName()).getLocallyStoredSize() + ", " + duration + ", "
             + resultSize + ", " + slaveState.getConfigName();
    }
 
@@ -251,9 +251,8 @@ public class MapReduceStage<KOut, VOut, R> extends AbstractDistStage {
          ack.error("executeMapReduceTask() threw an exception", e);
          log.error("executeMapReduceTask() returned an exception", e);
       }
-      log.info(clustered.getClusteredNodes() + " nodes were used. "
-            + cacheInformation.getCache(cacheInformation.getDefaultCacheName()).getLocalSize()
-            + " entries on this node");
+      log.infof("%d nodes were used. %d entries on this node", clustered.getClusteredNodes(),
+            cacheInformation.getCache(null).getLocallyStoredSize());
       log.info("--------------------");
 
       return ack;

--- a/core/src/main/java/org/radargun/stages/tpcc/TpccBenchmarkStage.java
+++ b/core/src/main/java/org/radargun/stages/tpcc/TpccBenchmarkStage.java
@@ -94,7 +94,7 @@ public class TpccBenchmarkStage extends AbstractDistStage {
 
       try {
          Map<String, Object> results = stress();
-         String sizeInfo = "clusterSize:" + slaveState.getClusterSize() + ", nodeIndex:" + slaveState.getSlaveIndex() + ", cacheSize: " + cacheInformation.getCache(null).getLocalSize();
+         String sizeInfo = "clusterSize:" + slaveState.getClusterSize() + ", nodeIndex:" + slaveState.getSlaveIndex() + ", cacheSize: " + cacheInformation.getCache(null).getLocallyStoredSize();
          log.info(sizeInfo);
          results.put(SIZE_INFO, sizeInfo);
          return new MapAck(slaveState, results);

--- a/core/src/main/java/org/radargun/traits/CacheInformation.java
+++ b/core/src/main/java/org/radargun/traits/CacheInformation.java
@@ -22,20 +22,35 @@ public interface CacheInformation {
 
    interface Cache {
       /**
-       * @return Number of entries on this cache node.
+       * @return Number of entries that are 'owned' by this node. Sum of all nodes' {@link #getOwnedSize()}
+       * should be equal to {@link #getTotalSize()}. If this value is negative, this information is not available.
        */
-      int getLocalSize();
+      long getOwnedSize();
+
+      /**
+       * @return Number of entries physically stored on this cache node. Sum of all nodes' {@link #getLocallyStoredSize()}
+       * should be equal to {@link #getTotalSize()} * {@link #getNumReplicas()}. If the entry is stored multiple times
+       * (such as in-memory, on SSD disk and on conventional disk) it should be reported only once.
+       * If this value is negative, this information is not available.
+       */
+      long getLocallyStoredSize();
+
+      /**
+       * @return Number of entries physically stored on this cache node in heap memory. Entries persisted into
+       * disk or off-heap entries are not included.
+       */
+      long getMemoryStoredSize();
 
       /**
        * @return Number of entries in the whole cache, or negative number if the information is not available.
        */
-      int getTotalSize();
+      long getTotalSize();
 
       /**
        * The cache may be structured into different subparts.
        * @return Map of subpart-identification - subpart-size.
        */
-      Map<?, Integer> getStructuredSize();
+      Map<?, Long> getStructuredSize();
 
       /**
        * @return How many times is each entry replicated in the local cluster (group), or -1 if this cannot be determined.

--- a/plugins/chm/src/main/java/org/radargun/service/ChmCache.java
+++ b/plugins/chm/src/main/java/org/radargun/service/ChmCache.java
@@ -88,18 +88,28 @@ public class ChmCache implements BasicOperations.Cache, ConditionalOperations.Ca
    }
 
    @Override
-   public int getLocalSize() {
+   public long getOwnedSize() {
       return chm.size();
    }
 
    @Override
-   public int getTotalSize() {
-      return -1;
+   public long getLocallyStoredSize() {
+      return chm.size();
    }
 
    @Override
-   public Map<?, Integer> getStructuredSize() {
-      return Collections.singletonMap(name, chm.size());
+   public long getMemoryStoredSize() {
+      return chm.size();
+   }
+
+   @Override
+   public long getTotalSize() {
+      return chm.size();
+   }
+
+   @Override
+   public Map<?, Long> getStructuredSize() {
+      return Collections.singletonMap(name, (long) chm.size());
    }
 
    @Override

--- a/plugins/ehcache25/src/main/java/org/radargun/service/EHCacheInfo.java
+++ b/plugins/ehcache25/src/main/java/org/radargun/service/EHCacheInfo.java
@@ -41,18 +41,28 @@ public class EHCacheInfo implements CacheInformation {
       }
 
       @Override
-      public int getLocalSize() {
+      public long getOwnedSize() {
          return cache.getSize();
       }
 
       @Override
-      public int getTotalSize() {
+      public long getLocallyStoredSize() {
+         return cache.getSize();
+      }
+
+      @Override
+      public long getMemoryStoredSize() {
+         return cache.getSize();
+      }
+
+      @Override
+      public long getTotalSize() {
          return -1;
       }
 
       @Override
-      public Map<?, Integer> getStructuredSize() {
-         return Collections.singletonMap(cache.getName(), getLocalSize());
+      public Map<?, Long> getStructuredSize() {
+         return Collections.singletonMap(cache.getName(), getLocallyStoredSize());
       }
 
       @Override

--- a/plugins/hazelcast2/src/main/java/org/radargun/service/HazelcastCacheInfo.java
+++ b/plugins/hazelcast2/src/main/java/org/radargun/service/HazelcastCacheInfo.java
@@ -48,18 +48,28 @@ public class HazelcastCacheInfo implements CacheInformation {
       }
 
       @Override
-      public int getLocalSize() {
-         return (int) Math.min(map.getLocalMapStats().getOwnedEntryCount() + map.getLocalMapStats().getBackupEntryCount(), (long) Integer.MAX_VALUE);
+      public long getOwnedSize() {
+         return map.getLocalMapStats().getOwnedEntryCount();
       }
 
       @Override
-      public int getTotalSize() {
+      public long getLocallyStoredSize() {
+         return getMemoryStoredSize();
+      }
+
+      @Override
+      public long getMemoryStoredSize() {
+         return map.getLocalMapStats().getOwnedEntryCount() + map.getLocalMapStats().getBackupEntryCount();
+      }
+
+      @Override
+      public long getTotalSize() {
          return map.size();
       }
 
       @Override
-      public Map<?, Integer> getStructuredSize() {
-         return Collections.singletonMap(map.getName(), getLocalSize());
+      public Map<?, Long> getStructuredSize() {
+         return Collections.singletonMap(map.getName(), getOwnedSize());
       }
 
       @Override

--- a/plugins/infinispan4/src/main/java/org/radargun/service/InfinispanCacheInfo.java
+++ b/plugins/infinispan4/src/main/java/org/radargun/service/InfinispanCacheInfo.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.infinispan.AdvancedCache;
+import org.infinispan.context.Flag;
 import org.radargun.traits.CacheInformation;
 
 /**
@@ -40,18 +41,28 @@ public class InfinispanCacheInfo implements CacheInformation {
       }
 
       @Override
-      public int getLocalSize() {
-         return cache.size();
-      }
-
-      @Override
-      public int getTotalSize() {
+      public long getOwnedSize() {
          return -1;
       }
 
       @Override
-      public Map<?, Integer> getStructuredSize() {
-         return Collections.singletonMap(cache.getName(), getLocalSize());
+      public long getLocallyStoredSize() {
+         return cache.size();
+      }
+
+      @Override
+      public long getMemoryStoredSize() {
+         return cache.withFlags(Flag.SKIP_CACHE_LOAD).size();
+      }
+
+      @Override
+      public long getTotalSize() {
+         return -1;
+      }
+
+      @Override
+      public Map<?, Long> getStructuredSize() {
+         return Collections.singletonMap(cache.getName(), getOwnedSize());
       }
 
       @Override

--- a/plugins/infinispan52/src/main/java/org/radargun/service/Infinispan52CacheInfo.java
+++ b/plugins/infinispan52/src/main/java/org/radargun/service/Infinispan52CacheInfo.java
@@ -38,15 +38,15 @@ public class Infinispan52CacheInfo extends InfinispanCacheInfo {
       }
 
       @Override
-      public Map<?, Integer> getStructuredSize() {
+      public Map<?, Long> getStructuredSize() {
          ConsistentHash ch = ((DistributionManager) cache.getDistributionManager()).getReadConsistentHash();
          int segmentSizes[] = new int[ch.getNumSegments()];
          for (InternalCacheEntry entry : cache.getDataContainer()) {
             segmentSizes[ch.getSegment(entry.getKey())]++;
          }
-         Map<Integer, Integer> structured = new HashMap<Integer, Integer>();
+         Map<Integer, Long> structured = new HashMap<>();
          for (int i = 0; i < segmentSizes.length; ++i) {
-            structured.put(i, segmentSizes[i]);
+            structured.put(i, (long) segmentSizes[i]);
          }
          return structured;
       }
@@ -57,8 +57,8 @@ public class Infinispan52CacheInfo extends InfinispanCacheInfo {
       }
 
       @Override
-      public int getTotalSize() {
-         int totalSize = 0;
+      public long getTotalSize() {
+         long totalSize = 0;
          DistributedExecutorService des = new DefaultExecutorService(cache);
          CacheSizer<?, ?, Integer> cacheSizer = new CacheSizer<Object, Object, Integer>();
          DistributedTaskBuilder<Integer> taskBuilder = des.createDistributedTaskBuilder(cacheSizer);

--- a/plugins/infinispan70/src/main/java/org/radargun/service/Infinispan70CacheInfo.java
+++ b/plugins/infinispan70/src/main/java/org/radargun/service/Infinispan70CacheInfo.java
@@ -33,8 +33,8 @@ public class Infinispan70CacheInfo extends Infinispan53CacheInfo {
       }
 
       @Override
-      public int getTotalSize() {
-         int totalSize = 0;
+      public long getTotalSize() {
+         long totalSize = 0;
          EntryIterable entryIterator = null;
          try {
             entryIterator = cache.filterEntries(AllFilter.INSTANCE);


### PR DESCRIPTION
 (number of primary-owned entries, not supported by Infinispan) and getLocallyStoredSize() (including backups, not supported by Coherence), and adapted the stages working with this.
