### PR TITLE
Updated versions

### DIFF
--- a/plugins/infinispan70/pom.xml
+++ b/plugins/infinispan70/pom.xml
@@ -112,7 +112,7 @@
             </property>
          </activation>
          <properties>
-            <version.infinispan>7.0.0.Final</version.infinispan>
+            <version.infinispan>7.0.2.Final</version.infinispan>
          </properties>
       </profile>
       <profile>

--- a/plugins/jdg63/pom.xml
+++ b/plugins/jdg63/pom.xml
@@ -30,7 +30,7 @@
             </property>
          </activation>
          <properties>
-            <version.infinispan>6.1.0.Final-redhat-4</version.infinispan>
+            <version.infinispan>6.1.2.Final-redhat-1</version.infinispan>
          </properties>
       </profile>
       <profile>

--- a/plugins/jdg64/pom.xml
+++ b/plugins/jdg64/pom.xml
@@ -30,7 +30,7 @@
             </property>
          </activation>
          <properties>
-            <version.infinispan>6.2.0.GA-redhat-1</version.infinispan>
+            <version.infinispan>6.2.0.ER5-redhat-1</version.infinispan>
          </properties>
       </profile>
       <profile>


### PR DESCRIPTION
Replaces @alanfx 's PR. I have used ER5 for JDG 6.4 since this is the version used in Beta release.
