### PR TITLE
Fixes for Random data, Map/Reduce, and Distributed Task reporting

### DIFF
--- a/core/src/main/java/org/radargun/stages/distributedtask/DistributedTaskStage.java
+++ b/core/src/main/java/org/radargun/stages/distributedtask/DistributedTaskStage.java
@@ -1,8 +1,10 @@
 package org.radargun.stages.distributedtask;
 
-import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -12,8 +14,13 @@ import org.radargun.DistStageAck;
 import org.radargun.StageResult;
 import org.radargun.config.Property;
 import org.radargun.config.Stage;
+import org.radargun.reporting.Report;
 import org.radargun.stages.AbstractDistStage;
+import org.radargun.stages.cache.RandomDataStage;
 import org.radargun.state.SlaveState;
+import org.radargun.stats.DataOperationStats;
+import org.radargun.stats.DefaultStatistics;
+import org.radargun.stats.Statistics;
 import org.radargun.traits.CacheInformation;
 import org.radargun.traits.Clustered;
 import org.radargun.traits.DistributedTaskExecutor;
@@ -32,8 +39,6 @@ import org.radargun.utils.Utils;
  */
 @Stage(doc = "Stage which executes a MapReduce Task against all keys in the cache.")
 public class DistributedTaskStage<K, V, T> extends AbstractDistStage {
-
-   private final String FIRST_SCALE_STAGE_KEY = "firstScalingStage";
 
    // TODO: use approach similar to generators
    @Property(optional = false, doc = "Fully qualified class name of the "
@@ -57,8 +62,15 @@ public class DistributedTaskStage<K, V, T> extends AbstractDistStage {
          + "executed. The default is null, and tasks will be executed against all nodes in the cluster.")
    private String nodeAddress;
 
+   @Property(doc = "The number of times to execute the Callable. The default is 1.")
+   private int numExecutions = 1;
+
+   @Property(doc = "The name of the key in the MasterState object that returns the total number of "
+         + "bytes processed by the Callable. The default is RandomDataStage.RANDOMDATA_TOTALBYTES_KEY.")
+   private String totalBytesKey = RandomDataStage.RANDOMDATA_TOTALBYTES_KEY;
+
    @InjectTrait(dependency = InjectTrait.Dependency.MANDATORY)
-   private DistributedTaskExecutor executor;
+   private DistributedTaskExecutor<T> executor;
 
    @InjectTrait(dependency = InjectTrait.Dependency.MANDATORY)
    private CacheInformation cacheInformation;
@@ -69,23 +81,21 @@ public class DistributedTaskStage<K, V, T> extends AbstractDistStage {
    @Override
    public StageResult processAckOnMaster(List<DistStageAck> acks) {
       StageResult result = super.processAckOnMaster(acks);
-      StringBuilder reportCsvContent = new StringBuilder();
 
-      // TODO: move this into test report
-      if (masterState.get(FIRST_SCALE_STAGE_KEY) == null) {
-         masterState.put(FIRST_SCALE_STAGE_KEY, masterState.getConfigName());
-         reportCsvContent.append("NODE_INDEX, NUMBER_OF_NODES, KEY_COUNT_ON_NODE, DURATION_NANOSECONDS\n");
-      }
+      Report report = masterState.getReport();
+      Report.Test test = report.createTest("Distributed_Task_Stage", null, true);
+      int testIteration = test.getIterations().size();
 
-      for (TextAck ack : Projections.instancesOf(acks, TextAck.class)) {
-         reportCsvContent.append(ack.getText()).append("\n");
-      }
-      reportCsvContent.append("\n");
+      Map<Integer, Report.SlaveResult> durationsResult = new HashMap<Integer, Report.SlaveResult>();
 
-      try {
-         Utils.createOutputFile("distributedexecution.csv", reportCsvContent.toString(), false);
-      } catch (IOException e) {
-         log.error("Failed to create report.", e);
+      for (DistributedTaskAck ack : Projections.instancesOf(acks, DistributedTaskAck.class)) {
+         if (ack.stats != null) {
+            DataOperationStats opStats = (DataOperationStats) ack.stats.getOperationsStats().get(DistributedTaskExecutor.EXECUTE.name);
+            opStats.setTotalBytes((Long) masterState.get(totalBytesKey));
+            durationsResult.put(ack.getSlaveIndex(), new Report.SlaveResult(opStats.getResponseTimes(), false));
+            test.addResult(testIteration, new Report.TestResult("Callable durations", durationsResult, "", false));
+            test.addStatistics(testIteration, ack.getSlaveIndex(), Collections.singletonList(ack.stats));
+         }
       }
 
       return result;
@@ -104,72 +114,75 @@ public class DistributedTaskStage<K, V, T> extends AbstractDistStage {
       if (slaveState.getSlaveIndex() == 0) {
          return executeTask();
       } else {
-         return new TextAck(slaveState);
+         return new DistributedTaskAck(slaveState);
       }
-   }
-
-   private String getPayload(long durationNanos) {
-      return slaveState.getSlaveIndex() + ", " + clustered.getClusteredNodes() + ", " + cacheInformation.getCache(null).getLocallyStoredSize() + ", " + durationNanos;
    }
 
    private DistStageAck executeTask() {
-      Callable<T> callable = Utils.instantiate(slaveState.getClassLoader(), this.callable);
-      callable = (Callable<T>) Utils.invokeMethodWithString(callable, Utils.parseParams(callableParams));
+      DistributedTaskAck ack = new DistributedTaskAck(slaveState);
+      Statistics stats = new DefaultStatistics(new DataOperationStats());
 
-      DistributedTaskExecutor.Builder<T> builder = executor.builder(null).callable(callable);
-      if (executionPolicy != null) builder.executionPolicy(executionPolicy);
-      if (failoverPolicy != null) builder.failoverPolicy(failoverPolicy);
-      if (nodeAddress != null) builder.nodeAddress(nodeAddress);
-      DistributedTaskExecutor.Task<T> task = builder.build();
+      stats.begin();
+      for (int i = 0; i < numExecutions; i++) {
+         Callable<T> callable = Utils.instantiate(slaveState.getClassLoader(), this.callable);
+         callable = Utils.invokeMethodWithString(callable, Utils.parseParams(callableParams));
 
-      log.info("--------------------");
-      TextAck ack = new TextAck(slaveState);
-      List<T> resultList = new ArrayList<T>();
+         DistributedTaskExecutor.Builder<T> builder = executor.builder(null).callable(callable);
+         if (executionPolicy != null)
+            builder.executionPolicy(executionPolicy);
+         if (failoverPolicy != null)
+            builder.failoverPolicy(failoverPolicy);
+         if (nodeAddress != null)
+            builder.nodeAddress(nodeAddress);
+         DistributedTaskExecutor.Task<T> task = builder.build();
 
-      long start = System.nanoTime();
-      List<Future<T>> futureList = task.execute();
-      if (futureList == null) {
-         ack.error("No future objects returned from executing the distributed task.");
-      } else {
-         for (Future<T> future : futureList) {
-            try {
-               resultList.add(future.get());
-            } catch (InterruptedException e) {
-               ack.error("The distributed task was interrupted.", e);
-            } catch (ExecutionException e) {
-               ack.error("An error occurred executing the distributed task.", e);
+         log.info("--------------------");
+         List<T> resultList = new ArrayList<T>();
+
+         long start = System.nanoTime();
+         List<Future<T>> futureList = task.execute();
+         if (futureList == null) {
+            ack.error("No future objects returned from executing the distributed task.");
+         } else {
+            for (Future<T> future : futureList) {
+               try {
+                  resultList.add(future.get());
+               } catch (InterruptedException e) {
+                  ack.error("The distributed task was interrupted.", e);
+               } catch (ExecutionException e) {
+                  ack.error("An error occurred executing the distributed task.", e);
+               }
             }
          }
-      }
-      long durationNanos = System.nanoTime() - start;
-      ack.setText(getPayload(durationNanos));
+         long durationNanos = System.nanoTime() - start;
+         stats.registerRequest(durationNanos, DistributedTaskExecutor.EXECUTE);
 
-      log.info("Distributed Execution task completed in " + Utils.prettyPrintTime(durationNanos, TimeUnit.NANOSECONDS));
-      log.infof("%d nodes were used. %d entries on this node",
-            clustered.getClusteredNodes(), cacheInformation.getCache(null).getLocallyStoredSize());
-      log.info("Distributed execution results:");
-      log.info("--------------------");
-      for (T t : resultList) {
-         log.info(t.toString());
+         log.info("Distributed Execution task completed in "
+               + Utils.prettyPrintTime(durationNanos, TimeUnit.NANOSECONDS));
+         log.infof("%d nodes were used. %d entries on this node", clustered.getClusteredNodes(), cacheInformation
+               .getCache(null).getLocallyStoredSize());
+         log.info("Distributed execution results:");
+         log.info("--------------------");
+         for (T t : resultList) {
+            log.info(t.toString());
+         }
+         log.info("--------------------");
       }
-      log.info("--------------------");
+      stats.end();
+      ack.setStats(stats);
       return ack;
    }
 
-   private static class TextAck extends DistStageAck {
-      private String text;
+   private static class DistributedTaskAck extends DistStageAck {
+      private Statistics stats;
 
-      private TextAck(SlaveState slaveState) {
+      public DistributedTaskAck(SlaveState slaveState) {
          super(slaveState);
-         this.text = text;
       }
 
-      public void setText(String text) {
-         this.text = text;
+      public void setStats(Statistics stats) {
+         this.stats = stats;
       }
 
-      public String getText() {
-         return text;
-      }
    }
 }

--- a/core/src/main/java/org/radargun/stages/mapreduce/MapReduceStage.java
+++ b/core/src/main/java/org/radargun/stages/mapreduce/MapReduceStage.java
@@ -111,6 +111,10 @@ public class MapReduceStage<KOut, VOut, R> extends AbstractDistStage {
    @Property(doc = "The number of times to execute the Map/Reduce task. The default is 10.")
    private int numExecutions = 10;
 
+   @Property(doc = "The name of the key in the MasterState object that returns the total number of "
+         + "bytes processed by the Map/Reduce task. The default is RandomDataStage.RANDOMDATA_TOTALBYTES_KEY.")
+   private String totalBytesKey = RandomDataStage.RANDOMDATA_TOTALBYTES_KEY;
+
    private Map<KOut, VOut> payloadMap = null;
    private R payloadObject = null;
 
@@ -152,16 +156,15 @@ public class MapReduceStage<KOut, VOut, R> extends AbstractDistStage {
             } else {
                opStats = (DataOperationStats) ack.stats.getOperationsStats().get(MapReducer.MAPREDUCE_COLLATOR.name);
             }
-            opStats.setTotalBytes((Long) masterState.get(RandomDataStage.RANDOMDATA_TOTALBYTES_KEY));
+            opStats.setTotalBytes((Long) masterState.get(totalBytesKey));
             test.addStatistics(testIteration, ack.getSlaveIndex(), Collections.singletonList(ack.stats));
             durationsResult.put(ack.getSlaveIndex(), new Report.SlaveResult(opStats.getResponseTimes(), false));
-            test.addResult(testIteration, new Report.TestResult("Map/Reduce durations result map", durationsResult,
-                  "-", false));
+            test.addResult(testIteration, new Report.TestResult("Map/Reduce durations", durationsResult, "", false));
          }
          if (ack.numberOfResultKeys != null) {
             numberOfResultKeysResult.put(ack.getSlaveIndex(), new Report.SlaveResult(ack.numberOfResultKeys, false));
             test.addResult(testIteration, new Report.TestResult("Key count in Map/Reduce result map",
-                  numberOfResultKeysResult, "-", false));
+                  numberOfResultKeysResult, "", false));
          }
       }
 

--- a/core/src/main/java/org/radargun/traits/DistributedTaskExecutor.java
+++ b/core/src/main/java/org/radargun/traits/DistributedTaskExecutor.java
@@ -4,8 +4,12 @@ import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 
+import org.radargun.Operation;
+
 @Trait(doc = "Provides the interface for executing distributed tasks.")
 public interface DistributedTaskExecutor<T> {
+   String TRAIT = DistributedTaskExecutor.class.getSimpleName();
+   Operation EXECUTE = Operation.register(TRAIT + ".Execute");
 
    interface Builder<T> {
       /**

--- a/core/src/main/java/org/radargun/utils/Utils.java
+++ b/core/src/main/java/org/radargun/utils/Utils.java
@@ -442,7 +442,7 @@ public class Utils {
     *           a Map where the public method name is the key, and the String parameter is the value
     * @return the modified Object, or <code>null</code> if the field can't be changed
     */
-   public static Object invokeMethodWithString(Object object, Map<String, String> properties) {
+   public static <T> T invokeMethodWithString(T object, Map<String, String> properties) {
       Class<? extends Object> clazz = object.getClass();
       for (Entry<String, String> entry : properties.entrySet()) {
          try {

--- a/plugins/infinispan70/src/main/java/org/radargun/service/Infinispan70EmbeddedService.java
+++ b/plugins/infinispan70/src/main/java/org/radargun/service/Infinispan70EmbeddedService.java
@@ -1,13 +1,6 @@
 package org.radargun.service;
 
-import java.io.FileNotFoundException;
-import java.io.InputStream;
-
-import org.infinispan.commons.util.FileLookup;
-import org.infinispan.configuration.parsing.ConfigurationBuilderHolder;
-import org.infinispan.configuration.parsing.ParserRegistry;
 import org.radargun.Service;
-import org.radargun.config.Property;
 import org.radargun.traits.ProvidesTrait;
 
 /**
@@ -15,6 +8,7 @@ import org.radargun.traits.ProvidesTrait;
  */
 @Service(doc = InfinispanEmbeddedService.SERVICE_DESCRIPTION)
 public class Infinispan70EmbeddedService extends Infinispan60EmbeddedService {
+   @SuppressWarnings("rawtypes")
    @Override
    @ProvidesTrait
    public Infinispan70MapReduce createMapReduce() {

--- a/reporters/reporter-default/src/main/java/org/radargun/reporting/csv/CsvReporter.java
+++ b/reporters/reporter-default/src/main/java/org/radargun/reporting/csv/CsvReporter.java
@@ -15,6 +15,7 @@ import org.radargun.reporting.Reporter;
 import org.radargun.reporting.Timeline;
 import org.radargun.stats.OperationStats;
 import org.radargun.stats.Statistics;
+import org.radargun.stats.representation.DataThroughput;
 import org.radargun.stats.representation.DefaultOutcome;
 import org.radargun.stats.representation.MeanAndDev;
 import org.radargun.stats.representation.OperationThroughput;
@@ -173,6 +174,15 @@ public class CsvReporter implements Reporter {
       if (meanAndDev != null) {
          rowData.put(operationName + ".ResponseTimeMean", String.valueOf(meanAndDev.mean));
          rowData.put(operationName + ".ResponseTimeDeviation", String.valueOf(meanAndDev.dev));
+      }
+      DataThroughput dataThroughput = os.getRepresentation(DataThroughput.class);
+      if (dataThroughput != null) {
+         rowData.put(operationName + ".DataThrouputMin", String.valueOf(dataThroughput.minThroughput));
+         rowData.put(operationName + ".DataThrouputMax", String.valueOf(dataThroughput.maxThroughput));
+         rowData.put(operationName + ".DataThrouputMean", String.valueOf(dataThroughput.meanThroughput));
+         rowData.put(operationName + ".DataThrouputStdDeviation", String.valueOf(dataThroughput.deviation));
+         rowData.put(operationName + ".TotalBytes", String.valueOf(dataThroughput.totalBytes));
+         rowData.put(operationName + ".ResponseTimes", Arrays.toString(dataThroughput.responseTimes).replace(",", ""));
       }
    }
 


### PR DESCRIPTION
DataThroughput
- Fix calculation when small values are used (No more Infinite
Throughput!)
- Store totalBytes to output to reports
- Generate array with only non-zero response times

CsvReporter
- Output DataThroughput values in CSV reports

RandomDataStage
- Report bytes written per node
- Report count of words and target memory per node
- Provide aggregated values

DistributedTaskStage
- Add property to retrieve the total bytes written to the cluster in
case RandomDataStage isn't used
- Report distributed task durations

MapReduceStage
- Add property to retrieve the total bytes written to the cluster in
case RandomDataStage isn't used
- Change aggregated values and result title

DistributedTaskExecutor
- Add operation for statistics gathering

Utils
- Make invokeMethodWithString use generic type instead of Object

Infinispan70EmbeddedService
- Remove unused imports