### PR TITLE
Initial background package refactoring

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -15,6 +15,7 @@
    <properties>
       <version.log4j>1.2.16</version.log4j>
       <version.log4j2>2.0-beta9</version.log4j2>
+      <maven.test.skip>false</maven.test.skip>
    </properties>
 
    <dependencies>
@@ -23,21 +24,6 @@
          <artifactId>jboss-transaction-api</artifactId>
          <version>1.0.1.GA</version>
       </dependency>
-
-      <!--<dependency>-->
-         <!--<groupId>javax.activation</groupId>-->
-         <!--<artifactId>activation</artifactId>-->
-         <!--<version>1.1</version>-->
-      <!--</dependency>-->
-
-      <!--<dependency>-->
-         <!--<groupId>javax.mail</groupId>-->
-         <!--<artifactId>mail</artifactId>-->
-         <!--<version>1.4.2</version>-->
-         <!--<service>jar</service>-->
-         <!--<scope>compile</scope>-->
-      <!--</dependency>-->
-
       <dependency>
          <groupId>log4j</groupId>
          <artifactId>log4j</artifactId>

--- a/core/src/main/java/org/radargun/stages/cache/background/AbstractLogLogic.java
+++ b/core/src/main/java/org/radargun/stages/cache/background/AbstractLogLogic.java
@@ -50,7 +50,7 @@ abstract class AbstractLogLogic<ValueType> extends AbstractLogic {
    private int remainingTxOps;
    private volatile long lastConfirmedOperation = -1;
 
-   public AbstractLogLogic(BackgroundOpsManager manager, long stressorId) {
+   public AbstractLogLogic(BackgroundOpsManager manager) {
       super(manager);
       this.nonTxBasicCache = manager.getBasicCache();
       if (transactionSize <= 0) {

--- a/core/src/main/java/org/radargun/stages/cache/background/AbstractLogLogic.java
+++ b/core/src/main/java/org/radargun/stages/cache/background/AbstractLogLogic.java
@@ -188,7 +188,7 @@ abstract class AbstractLogLogic<ValueType> extends AbstractLogic {
          }
          return true;
       } catch (Exception e) {
-         InterruptedException ie = findInterruptionCause(null, e);
+         InterruptedException ie = Utils.findThrowableCauseByClass(e, InterruptedException.class);
          if (ie != null) {
             throw ie;
          } else if (e.getClass().getName().contains("SuspectException")) {

--- a/core/src/main/java/org/radargun/stages/cache/background/AbstractLogic.java
+++ b/core/src/main/java/org/radargun/stages/cache/background/AbstractLogic.java
@@ -45,13 +45,4 @@ public abstract class AbstractLogic implements Logic {
       this.stressor = stressor;
    }
 
-   protected static InterruptedException findInterruptionCause(Throwable eParent, Throwable e) {
-      if (e == null || eParent == e) {
-         return null;
-      } else if (e instanceof InterruptedException) {
-         return (InterruptedException) e;
-      } else {
-         return findInterruptionCause(e, e.getCause());
-      }
-   }
 }

--- a/core/src/main/java/org/radargun/stages/cache/background/AbstractLogic.java
+++ b/core/src/main/java/org/radargun/stages/cache/background/AbstractLogic.java
@@ -10,7 +10,7 @@ import org.radargun.traits.Transactional;
 import java.util.Random;
 
 /**
- * Common operations for all logics.
+ * Common operations for all logic types.
  *
  * @author Radim Vansa &lt;rvansa@redhat.com&gt;
  */

--- a/core/src/main/java/org/radargun/stages/cache/background/AbstractLogic.java
+++ b/core/src/main/java/org/radargun/stages/cache/background/AbstractLogic.java
@@ -7,6 +7,8 @@ import org.radargun.stages.cache.generators.KeyGenerator;
 import org.radargun.traits.BasicOperations;
 import org.radargun.traits.Transactional;
 
+import java.util.Random;
+
 /**
  * Common operations for all logics.
  *
@@ -20,6 +22,7 @@ public abstract class AbstractLogic implements Logic {
 
    protected BackgroundOpsManager manager;
    protected KeyGenerator keyGenerator;
+   protected final int operations;
    protected final int transactionSize;
    protected Stressor stressor;
    protected Transactional.Transaction ongoingTx;
@@ -28,6 +31,7 @@ public abstract class AbstractLogic implements Logic {
       this.manager = manager;
       this.keyGenerator = manager.getKeyGenerator();
       this.transactionSize = manager.getGeneralConfiguration().getTransactionSize();
+      this.operations = manager.getGeneralConfiguration().puts + manager.getGeneralConfiguration().gets + manager.getGeneralConfiguration().removes;
    }
 
    @Override
@@ -41,8 +45,18 @@ public abstract class AbstractLogic implements Logic {
       }
    }
 
+   @Override
    public void setStressor(Stressor stressor) {
       this.stressor = stressor;
+   }
+
+   public Operation getOperation(Random rand) {
+      int r = rand.nextInt(operations);
+      if (r < manager.getGeneralConfiguration().gets) {
+         return BasicOperations.GET;
+      } else if (r < manager.getGeneralConfiguration().gets + manager.getGeneralConfiguration().puts) {
+         return BasicOperations.PUT;
+      } else return BasicOperations.REMOVE;
    }
 
 }

--- a/core/src/main/java/org/radargun/stages/cache/background/BackgroundOpsManager.java
+++ b/core/src/main/java/org/radargun/stages/cache/background/BackgroundOpsManager.java
@@ -212,7 +212,7 @@ public class BackgroundOpsManager extends ServiceListenerAdapter {
       int numThreads = generalConfiguration.numThreads;
       if (generalConfiguration.sharedKeys) {
          if (logLogicConfiguration.enabled) {
-            return new SharedLogLogic(this, generalConfiguration.numEntries, generalConfiguration.keyIdOffset);
+            return new SharedLogLogic(this, new Range(generalConfiguration.keyIdOffset, generalConfiguration.keyIdOffset + generalConfiguration.numEntries));
          } else {
             throw new IllegalArgumentException("Legacy logic cannot use shared keys.");
          }

--- a/core/src/main/java/org/radargun/stages/cache/background/BackgroundOpsManager.java
+++ b/core/src/main/java/org/radargun/stages/cache/background/BackgroundOpsManager.java
@@ -212,7 +212,7 @@ public class BackgroundOpsManager extends ServiceListenerAdapter {
       int numThreads = generalConfiguration.numThreads;
       if (generalConfiguration.sharedKeys) {
          if (logLogicConfiguration.enabled) {
-            return new SharedLogLogic(this, numThreads * slaveState.getIndexInGroup() + index, generalConfiguration.numEntries, generalConfiguration.keyIdOffset);
+            return new SharedLogLogic(this, generalConfiguration.numEntries, generalConfiguration.keyIdOffset);
          } else {
             throw new IllegalArgumentException("Legacy logic cannot use shared keys.");
          }
@@ -222,7 +222,9 @@ public class BackgroundOpsManager extends ServiceListenerAdapter {
          Range range = Range.divideRange(generalConfiguration.numEntries, totalThreads, numThreads * slaveState.getIndexInGroup() + index).shift(generalConfiguration.keyIdOffset);
 
          if (logLogicConfiguration.enabled) {
-            return new PrivateLogLogic(this, numThreads * slaveState.getIndexInGroup() + index, range);
+            int threadId = numThreads * slaveState.getIndexInGroup() + index;
+            log.tracef("Stressor %d has range %s", threadId, range);
+            return new PrivateLogLogic(this, range);
          } else {
             // TODO: remove preloading from background stressors at all, use load-data instead
             List<Integer> deadSlaves = legacyLogicConfiguration.loadDataForDeadSlaves;

--- a/core/src/main/java/org/radargun/stages/cache/background/BackgroundOpsManager.java
+++ b/core/src/main/java/org/radargun/stages/cache/background/BackgroundOpsManager.java
@@ -457,9 +457,10 @@ public class BackgroundOpsManager extends ServiceListenerAdapter {
 
    public synchronized String getError() {
       if (logLogicConfiguration.enabled) {
-         if (stressorRecordPool != null && (stressorRecordPool.getMissingOperations() > 0 || stressorRecordPool.getMissingNotifications() > 0)) {
-            return String.format("Background stressors report %d missing operations and %d missing notifications!",
-                  stressorRecordPool.getMissingOperations(), stressorRecordPool.getMissingNotifications());
+         if (stressorRecordPool != null
+               && (stressorRecordPool.getMissingOperations() > 0 || stressorRecordPool.getMissingNotifications() > 0 || stressorRecordPool.getStaleReads() > 0)) {
+            return String.format("Background stressors report %d missing operations, %d missing notifications and %d stale reads!",
+                  stressorRecordPool.getMissingOperations(), stressorRecordPool.getMissingNotifications(), stressorRecordPool.getStaleReads());
          }
          if (stressorThreads != null) {
             for (Stressor stressor : stressorThreads) {
@@ -571,6 +572,10 @@ public class BackgroundOpsManager extends ServiceListenerAdapter {
 
    public Stressor[] getStressorThreads() {
       return stressorThreads;
+   }
+
+   public StressorRecordPool getStressorRecordPool() {
+      return stressorRecordPool;
    }
 
    // TODO:

--- a/core/src/main/java/org/radargun/stages/cache/background/BackgroundOpsManager.java
+++ b/core/src/main/java/org/radargun/stages/cache/background/BackgroundOpsManager.java
@@ -55,7 +55,6 @@ public class BackgroundOpsManager extends ServiceListenerAdapter {
    private GeneralConfiguration generalConfiguration;
    private LegacyLogicConfiguration legacyLogicConfiguration;
    private LogLogicConfiguration logLogicConfiguration;
-   private int operations;
 
    private String name;
    private SlaveState slaveState;
@@ -108,7 +107,6 @@ public class BackgroundOpsManager extends ServiceListenerAdapter {
       instance.generalConfiguration = generalConfiguration;
       instance.legacyLogicConfiguration = legacyLogicConfiguration;
       instance.logLogicConfiguration = logLogicConfiguration;
-      instance.operations = generalConfiguration.puts + generalConfiguration.gets + generalConfiguration.removes;
 
       instance.lifecycle = slaveState.getTrait(Lifecycle.class);
       instance.listeners = slaveState.getTrait(CacheListeners.class);
@@ -144,15 +142,6 @@ public class BackgroundOpsManager extends ServiceListenerAdapter {
       conditionalCache = null;
       debugableCache = null;
       cacheInfo = null;
-   }
-
-   public Operation getOperation(Random rand) {
-      int r = rand.nextInt(operations);
-      if (r < generalConfiguration.gets) {
-         return BasicOperations.GET;
-      } else if (r < generalConfiguration.gets + generalConfiguration.puts) {
-         return BasicOperations.PUT;
-      } else return BasicOperations.REMOVE;
    }
 
    public synchronized void startBackgroundThreads() {

--- a/core/src/main/java/org/radargun/stages/cache/background/BackgroundStatisticsManager.java
+++ b/core/src/main/java/org/radargun/stages/cache/background/BackgroundStatisticsManager.java
@@ -1,0 +1,204 @@
+package org.radargun.stages.cache.background;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.*;
+
+import org.radargun.logging.Log;
+import org.radargun.logging.LogFactory;
+import org.radargun.reporting.Timeline;
+import org.radargun.state.ServiceListenerAdapter;
+import org.radargun.state.SlaveState;
+import org.radargun.stats.OperationStats;
+import org.radargun.stats.Statistics;
+import org.radargun.stats.representation.OperationThroughput;
+
+/**
+ * Coordinator for collecting statistics from background stressor threads started by {@link org.radargun.stages.cache.background.BackgroundOpsManager}.
+ *
+ * @author Matej Cimbora &lt;mcimbora@redhat.com&gt;
+ * @author Radim Vansa &lt;rvansa@redhat.com&gt;
+ */
+public final class BackgroundStatisticsManager extends ServiceListenerAdapter {
+
+   public static final String CACHE_SIZE = "Cache size";
+   private static final String PREFIX = "BackgroundStatistics.";
+   private static final Log log = LogFactory.getLog(BackgroundStatisticsManager.class);
+
+   private BackgroundOpsManager backgroundOpsManager;
+   private long statsIterationDuration;
+   private List<IterationStats> stats;
+
+   private ScheduledFuture statsTask;
+   private SizeThread sizeThread;
+   private ScheduledExecutorService executor = Executors.newScheduledThreadPool(1);
+
+   private BackgroundStatisticsManager() {}
+
+   private BackgroundStatisticsManager(BackgroundOpsManager backgroundOpsManager, long statsIterationDuration) {
+      this.backgroundOpsManager = backgroundOpsManager;
+      this.statsIterationDuration = statsIterationDuration;
+   }
+
+   /**
+    * Returns {@link org.radargun.stages.cache.background.BackgroundStatisticsManager} instance. Creates {@link org.radargun.stages.cache.background.BackgroundOpsManager}
+    * internally, if not found in slave state.
+    */
+   public static BackgroundStatisticsManager getOrCreateInstance(SlaveState slaveState, String name, long statsIterationDuration) {
+      BackgroundStatisticsManager statisticsManager = getInstance(slaveState, name);
+      if (statisticsManager == null) {
+         statisticsManager = new BackgroundStatisticsManager(BackgroundOpsManager.getOrCreateInstance(slaveState, name), statsIterationDuration);
+         slaveState.put(PREFIX + name, statisticsManager);
+      }
+      return statisticsManager;
+   }
+
+   public static BackgroundStatisticsManager getInstance(SlaveState slaveState, String name) {
+      return (BackgroundStatisticsManager) slaveState.get(PREFIX + name);
+   }
+
+   public synchronized List<IterationStats> getStats() {
+      List<IterationStats> statsToReturn = stats;
+      stats = null;
+      return statsToReturn;
+   }
+
+   public synchronized void startStats() {
+      if (stats == null) {
+         stats = new ArrayList<>();
+      }
+      if (sizeThread == null) {
+         sizeThread = new SizeThread();
+         sizeThread.start();
+      }
+      if (statsTask == null) {
+         statsTask = executor.scheduleAtFixedRate(new StatsTask(), 0, statsIterationDuration, TimeUnit.MILLISECONDS);
+      }
+   }
+
+   public synchronized void stopStats() {
+      if (statsTask != null) {
+         statsTask.cancel(true);
+         statsTask = null;
+      }
+      if (sizeThread != null) {
+         log.debug("Interrupting size thread");
+         sizeThread.interrupt();
+         try {
+            sizeThread.join();
+         } catch (InterruptedException e) {
+            log.error("Interrupted while waiting for stat thread to end.");
+         }
+         sizeThread = null;
+      }
+   }
+
+   @Override
+   public void serviceDestroyed() {
+      stopStats();
+   }
+
+   private class StatsTask implements Runnable {
+      public StatsTask() {
+         gatherStats(); // throw away first stats
+      }
+
+      public void run() {
+         stats.add(gatherStats());
+      }
+
+      private IterationStats gatherStats() {
+         Stressor[] threads = backgroundOpsManager.getStressorThreads();
+         List<Statistics> stats;
+         if (threads == null) {
+            stats = Collections.EMPTY_LIST;
+         } else {
+            stats = new ArrayList<Statistics>(threads.length);
+            for (int i = 0; i < threads.length; i++) {
+               if (threads[i] != null) {
+                  stats.add(threads[i].getStatsSnapshot(true));
+               }
+            }
+         }
+         Timeline timeline = backgroundOpsManager.getSlaveState().getTimeline();
+         long now = System.currentTimeMillis();
+         long cacheSize = sizeThread.getAndResetSize();
+         timeline.addValue(CACHE_SIZE, new Timeline.Value(now, cacheSize));
+         if (stats.isEmpty()) {
+            // add zero for all operations we've already reported
+            for (String valueCategory : timeline.getValueCategories()) {
+               if (valueCategory.endsWith(" Throughput")) {
+                  timeline.addValue(valueCategory, new Timeline.Value(now, 0));
+               }
+            }
+         } else {
+            Statistics aggregated = stats.get(0).copy();
+            for (int i = 1; i < stats.size(); ++i) {
+               aggregated.merge(stats.get(i));
+            }
+            for (Map.Entry<String, OperationStats> entry : aggregated.getOperationsStats().entrySet()) {
+               OperationThroughput throughput = entry.getValue().getRepresentation(OperationThroughput.class, stats.size(), TimeUnit.MILLISECONDS.toNanos(aggregated.getEnd() - aggregated.getBegin()));
+               if (throughput != null && (throughput.actual != 0 || timeline.getValues(entry.getKey() + " Throughput") != null)) {
+                  timeline.addValue(entry.getKey() + " Throughput", new Timeline.Value(now, throughput.actual));
+               }
+            }
+         }
+         log.trace(String.format("Adding iteration %d: %s.", BackgroundStatisticsManager.this.stats.size(), stats));
+         return new IterationStats(stats, cacheSize);
+      }
+   }
+
+   /**
+    *
+    * Used for fetching cache size. If the size can't be fetched during one stat iteration, value 0
+    * will be used.
+    *
+    */
+   private class SizeThread extends Thread {
+      private boolean getSize = true;
+      private long size = -1;
+
+      @Override
+      public void run() {
+         try {
+            while (!isInterrupted()) {
+               synchronized (this) {
+                  while (!getSize) {
+                     wait(100);
+                  }
+                  getSize = false;
+               }
+               if (backgroundOpsManager.getCacheInfo() != null && backgroundOpsManager.getLifecycle().isRunning()) {
+                  size = backgroundOpsManager.getCacheInfo().getOwnedSize();
+               } else {
+                  size = 0;
+               }
+            }
+         } catch (InterruptedException e) {
+            log.trace("SizeThread interrupted.");
+         }
+      }
+
+      public synchronized long getAndResetSize() {
+         long rSize = size;
+         size = -1;
+         getSize = true;
+         notify();
+         return rSize;
+      }
+   }
+
+   public static class IterationStats implements Serializable {
+      public final List<Statistics> statistics;
+      public final long cacheSize;
+
+      private IterationStats(List<Statistics> statistics, long cacheSize) {
+         this.statistics = statistics;
+         this.cacheSize = cacheSize;
+      }
+   }
+
+}

--- a/core/src/main/java/org/radargun/stages/cache/background/BackgroundStatisticsStartStage.java
+++ b/core/src/main/java/org/radargun/stages/cache/background/BackgroundStatisticsStartStage.java
@@ -20,7 +20,7 @@ public class BackgroundStatisticsStartStage extends AbstractDistStage {
    @Override
    public DistStageAck executeOnSlave() {
       try {
-         BackgroundOpsManager instance = BackgroundOpsManager.getOrCreateInstance(slaveState, name, statsIterationDuration);
+         BackgroundStatisticsManager instance = BackgroundStatisticsManager.getOrCreateInstance(slaveState, name, statsIterationDuration);
 
          log.info("Starting statistics threads");
          instance.startStats();

--- a/core/src/main/java/org/radargun/stages/cache/background/BackgroundStatisticsStopStage.java
+++ b/core/src/main/java/org/radargun/stages/cache/background/BackgroundStatisticsStopStage.java
@@ -28,7 +28,7 @@ public class BackgroundStatisticsStopStage extends AbstractDistStage {
    @Override
    public DistStageAck executeOnSlave() {
       try {
-         BackgroundOpsManager instance = BackgroundOpsManager.getInstance(slaveState, name);
+         BackgroundStatisticsManager instance = BackgroundStatisticsManager.getInstance(slaveState, name);
          if (instance != null) {
             instance.stopStats();
             return new StatisticsAck(slaveState, instance.getStats());
@@ -56,7 +56,7 @@ public class BackgroundStatisticsStopStage extends AbstractDistStage {
       Table<Integer, Integer, Long> cacheSizes = new Table<Integer, Integer, Long>();
       for (StatisticsAck ack : Projections.instancesOf(acks, StatisticsAck.class)) {
          int i = 0;
-         for (BackgroundOpsManager.IterationStats stats : ack.iterations) {
+         for (BackgroundStatisticsManager.IterationStats stats : ack.iterations) {
             test.addStatistics(i, ack.getSlaveIndex(), stats.statistics);
             cacheSizes.put(ack.getSlaveIndex(), i, stats.cacheSize);
             ++i;
@@ -70,16 +70,16 @@ public class BackgroundStatisticsStopStage extends AbstractDistStage {
             min = Math.min(min, iterationData.getValue());
             max = Math.max(max, iterationData.getValue());
          }
-         Report.TestResult result = new Report.TestResult(BackgroundOpsManager.CACHE_SIZE, slaveResults, min < max ? String.format("%d .. %d", min, max) : "-", false);
+         Report.TestResult result = new Report.TestResult(BackgroundStatisticsManager.CACHE_SIZE, slaveResults, min < max ? String.format("%d .. %d", min, max) : "-", false);
          test.addResult(iteration, result);
       }
       return StageResult.SUCCESS;
    }
 
    private static class StatisticsAck extends DistStageAck {
-      public final List<BackgroundOpsManager.IterationStats> iterations;
+      public final List<BackgroundStatisticsManager.IterationStats> iterations;
 
-      private StatisticsAck(SlaveState slaveState, List<BackgroundOpsManager.IterationStats> iterations) {
+      private StatisticsAck(SlaveState slaveState, List<BackgroundStatisticsManager.IterationStats> iterations) {
          super(slaveState);
          this.iterations = iterations;
       }

--- a/core/src/main/java/org/radargun/stages/cache/background/BackgroundStressorsStartStage.java
+++ b/core/src/main/java/org/radargun/stages/cache/background/BackgroundStressorsStartStage.java
@@ -31,6 +31,7 @@ public class BackgroundStressorsStartStage extends AbstractDistStage {
 
    @Override
    public DistStageAck executeOnSlave() {
+      validateConfiguration();
       slaveState.put(CacheSelector.CACHE_SELECTOR, new CacheSelector.UseCache(generalConfiguration.cacheName));
       try {
          BackgroundOpsManager instance = BackgroundOpsManager.getOrCreateInstance(slaveState, name,
@@ -44,6 +45,14 @@ public class BackgroundStressorsStartStage extends AbstractDistStage {
          return successfulResponse();
       } catch (Exception e) {
          return errorResponse("Error while starting background stats", e);
+      }
+   }
+
+   private void validateConfiguration() {
+      if (generalConfiguration.numEntries < generalConfiguration.numThreads * slaveState.getGroupSize()) {
+         throw new IllegalArgumentException(String.format("'numEntries' needs to be greater than or equal to the product" +
+                     " of 'numThreads' and group size'. Required minimum '%d', was: '%d'.", generalConfiguration.numEntries,
+               generalConfiguration.numThreads * slaveState.getGroupSize()));
       }
    }
 }

--- a/core/src/main/java/org/radargun/stages/cache/background/GeneralConfiguration.java
+++ b/core/src/main/java/org/radargun/stages/cache/background/GeneralConfiguration.java
@@ -18,7 +18,8 @@ public class GeneralConfiguration {
    @Property(doc = "Ratio of REMOVE requests. Default is 0.")
    protected int removes = 0;
 
-   @Property(doc = "Number of entries (key-value pairs) inserted into the cache. Default is 1024.")
+   @Property(doc = "Number of entries (key-value pairs) inserted into the cache. Default is 1024. Needs to be greater " +
+         "than or equal to the product of 'numThreads' and group size.")
    protected long numEntries = 1024;
 
    @Property(doc = "First key ID used for key generation. Default is 0.")

--- a/core/src/main/java/org/radargun/stages/cache/background/LegacyLogic.java
+++ b/core/src/main/java/org/radargun/stages/cache/background/LegacyLogic.java
@@ -8,6 +8,7 @@ import org.radargun.stages.helpers.Range;
 import org.radargun.traits.BasicOperations;
 import org.radargun.traits.ConditionalOperations;
 import org.radargun.traits.Transactional;
+import org.radargun.utils.Utils;
 
 /**
  * Original background stressors logic which loads all entries into cache and then overwrites them.
@@ -163,7 +164,7 @@ class LegacyLogic extends AbstractLogic {
             }
          }
       } catch (Exception e) {
-         InterruptedException ie = findInterruptionCause(null, e);
+         InterruptedException ie = Utils.findThrowableCauseByClass(e,InterruptedException.class);
          if (ie != null) {
             throw ie;
          } else if (e.getClass().getName().contains("SuspectException")) {

--- a/core/src/main/java/org/radargun/stages/cache/background/LegacyLogic.java
+++ b/core/src/main/java/org/radargun/stages/cache/background/LegacyLogic.java
@@ -106,10 +106,9 @@ class LegacyLogic extends AbstractLogic {
          return;
       }
       long startTime = 0;
-      Object key = null;
-      Operation operation = manager.getOperation(rand);
+      Operation operation = getOperation(rand);
       try {
-         key = keyGenerator.generateKey(currentKey++);
+         Object key = keyGenerator.generateKey(currentKey++);
          if (currentKey == keyRangeEnd) {
             currentKey = keyRangeStart;
          }

--- a/core/src/main/java/org/radargun/stages/cache/background/LogChecker.java
+++ b/core/src/main/java/org/radargun/stages/cache/background/LogChecker.java
@@ -89,6 +89,7 @@ public abstract class LogChecker extends Thread {
                Thread.sleep(UNSUCCESSFUL_CHECK_MIN_DELAY_MS);
             }
             record = stressorRecordPool.take();
+            log.trace("Checking record: " + record);
             if (System.currentTimeMillis() < record.getLastUnsuccessfulCheckTimestamp() + UNSUCCESSFUL_CHECK_MIN_DELAY_MS) {
                delayedKeys++;
                continue;

--- a/core/src/main/java/org/radargun/stages/cache/background/LogChecker.java
+++ b/core/src/main/java/org/radargun/stages/cache/background/LogChecker.java
@@ -144,7 +144,7 @@ public abstract class LogChecker extends Thread {
             } else {
                long confirmationTimestamp = record.getCurrentConfirmationTimestamp();
                if (confirmationTimestamp >= 0) {
-                  log.debug("Detected stale read");
+                  log.debug("Detected stale read, keyId: " + record.getKeyId());
                }
                if (confirmationTimestamp >= 0
                      && (writeApplyMaxDelay <= 0 || System.currentTimeMillis() > confirmationTimestamp + writeApplyMaxDelay)) {

--- a/core/src/main/java/org/radargun/stages/cache/background/LogCheckerPool.java
+++ b/core/src/main/java/org/radargun/stages/cache/background/LogCheckerPool.java
@@ -39,13 +39,6 @@ public class LogCheckerPool implements CacheListeners.UpdatedListener, CacheList
       registerListeners(true); // synchronous listeners
    }
 
-   public LogCheckerPool(int totalThreads, BackgroundOpsManager manager) {
-      this.totalThreads = totalThreads;
-      this.allRecords = new AtomicReferenceArray<>(totalThreads);
-      log.trace("Pool will contain " + allRecords.length() + records);
-      this.manager = manager;
-   }
-
    protected void registerListeners(boolean sync) {
       if (!manager.getLogLogicConfiguration().isCheckNotifications()) {
          return;

--- a/core/src/main/java/org/radargun/stages/cache/background/LogCheckerPool.java
+++ b/core/src/main/java/org/radargun/stages/cache/background/LogCheckerPool.java
@@ -1,0 +1,202 @@
+package org.radargun.stages.cache.background;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReferenceArray;
+
+import org.radargun.logging.Log;
+import org.radargun.logging.LogFactory;
+import org.radargun.traits.CacheListeners;
+
+/**
+ * TODO document
+ *
+ * @author Radim Vansa &lt;rvansa@redhat.com&gt;
+ */
+public class LogCheckerPool implements CacheListeners.UpdatedListener, CacheListeners.CreatedListener {
+
+   protected static final Log log = LogFactory.getLog(LogCheckerPool.class);
+
+   private final int totalThreads;
+   private final AtomicReferenceArray<StressorRecord> allRecords;
+   private final ConcurrentLinkedQueue<StressorRecord> records = new ConcurrentLinkedQueue<StressorRecord>();
+   private final BackgroundOpsManager manager;
+   private final AtomicLong missingOperations = new AtomicLong();
+   private final AtomicLong missingNotifications = new AtomicLong();
+
+   public LogCheckerPool(int totalThreads, List<StressorRecord> stressorRecords, BackgroundOpsManager manager) {
+      this.totalThreads = totalThreads;
+      this.allRecords = new AtomicReferenceArray<>(totalThreads);
+      this.manager = manager;
+      for (StressorRecord stressorRecord: stressorRecords) {
+         addNew(stressorRecord);
+      }
+      log.trace("Pool will contain " + allRecords.length() + records);
+      registerListeners(true); // synchronous listeners
+   }
+
+   public LogCheckerPool(int totalThreads, BackgroundOpsManager manager) {
+      this.totalThreads = totalThreads;
+      this.allRecords = new AtomicReferenceArray<>(totalThreads);
+      log.trace("Pool will contain " + allRecords.length() + records);
+      this.manager = manager;
+   }
+
+   protected void registerListeners(boolean sync) {
+      if (!manager.getLogLogicConfiguration().isCheckNotifications()) {
+         return;
+      }
+      CacheListeners listeners = manager.getListeners();
+      if (listeners == null) {
+         throw new IllegalArgumentException("Service does not support cache listeners");
+      }
+      Collection<CacheListeners.Type> supported = listeners.getSupportedListeners();
+      if (!supported.containsAll(Arrays.asList(CacheListeners.Type.CREATED, CacheListeners.Type.UPDATED))) {
+         throw new IllegalArgumentException("Service does not support required listener types; supported are: " + supported);
+      }
+      String cacheName = manager.getGeneralConfiguration().getCacheName();
+      manager.getListeners().addCreatedListener(cacheName, this, sync);
+      manager.getListeners().addUpdatedListener(cacheName, this, sync);
+   }
+
+   public long getMissingOperations() {
+      return missingOperations.get();
+   }
+
+   public long getMissingNotifications() {
+      return missingNotifications.get();
+   }
+
+   public void reportMissingOperation() {
+      missingOperations.incrementAndGet();
+   }
+
+   public void reportMissingNotification() {
+      missingNotifications.incrementAndGet();
+   }
+
+   public int getTotalThreads() {
+      return totalThreads;
+   }
+
+   public Collection<StressorRecord> getRecords() {
+      ArrayList<StressorRecord> records = new ArrayList<>();
+      for (int i = 0; i < allRecords.length(); ++i) {
+         records.add(allRecords.get(i));
+      }
+      return records;
+   }
+
+   public StressorRecord take() {
+      return records.poll();
+   }
+
+   public void add(StressorRecord record) {
+      records.add(record);
+   }
+
+   private void addNew(StressorRecord record) {
+      records.add(record);
+      allRecords.set(record.getThreadId(), record);
+   }
+
+   public String waitUntilChecked(long timeout) {
+      for (int i = 0; i < totalThreads; ++i) {
+         StressorRecord record = allRecords.get(i);
+         if (record == null) continue;
+         try {
+            // as the pool survives service restarts, we have to always grab actual cache
+            LogChecker.LastOperation lastOperation = (LogChecker.LastOperation) manager.getBasicCache().get(LogChecker.lastOperationKey(record.getThreadId()));
+            if (lastOperation == null) {
+               log.trace("Thread " + record.getThreadId() + " has no recorded operation.");
+            } else {
+               record.addConfirmation(lastOperation.getOperationId(), lastOperation.getTimestamp());
+            }
+         } catch (Exception e) {
+            log.error("Failed to read last operation key for thread " + record.getThreadId(), e);
+         }
+      }
+      for (;;) {
+         boolean allChecked = true;
+         long now = System.currentTimeMillis();
+         for (int i = 0; i < totalThreads; ++i) {
+            StressorRecord record = allRecords.get(i);
+            if (record == null) continue;
+            long confirmationTimestamp = record.getCurrentConfirmationTimestamp();
+            if (confirmationTimestamp > 0) {
+               if (log.isTraceEnabled()) {
+                  log.trace(record.getStatus());
+               }
+               allChecked = false;
+               break;
+            }
+            if (record.getLastSuccessfulCheckTimestamp() + timeout < now) {
+               String error = "Waiting for checker for record [" + record.getStatus() + "] timed out after "
+                     + (now - record.getLastSuccessfulCheckTimestamp()) + " ms";
+               log.error(error);
+               return error;
+            }
+         }
+         if (allChecked) {
+            StringBuilder sb = new StringBuilder("All checks OK: ");
+            for (int i = 0; i < totalThreads; ++i) {
+               StressorRecord record = allRecords.get(i);
+               if (record == null) continue;
+               sb.append(record.getThreadId()).append("# ")
+                     .append(record.getOperationId()).append(" (")
+                     .append(record.getLastConfirmedOperationId()).append("), ");
+            }
+            log.debug(sb.toString());
+            return null;
+         }
+         try {
+            Thread.sleep(1000);
+         } catch (InterruptedException e) {
+            log.error("Interrupted waiting for checkers.", e);
+            return e.toString();
+         }
+      }
+   }
+
+   protected void notify(int threadId, long operationId, Object key) {
+      StressorRecord record = allRecords.get(threadId);
+      record.notify(operationId, key);
+   }
+
+   protected void requireNotify(int threadId, long operationId) {
+      StressorRecord record = allRecords.get(threadId);
+      record.requireNotify(operationId);
+   }
+
+   @Override
+   public void created(Object key, Object value) {
+      log.trace("Created " + key + " -> " + value);
+      modified(key, value);
+   }
+
+   @Override
+   public void updated(Object key, Object value) {
+      log.trace("Updated " + key + " -> " + value);
+      modified(key, value);
+   }
+
+   public void modified(Object key, Object value) {
+      if (value instanceof PrivateLogValue) {
+         PrivateLogValue logValue = (PrivateLogValue) value;
+         notify(logValue.getThreadId(), logValue.getOperationId(logValue.size() - 1), key);
+      } else if (value instanceof SharedLogValue) {
+         SharedLogValue logValue = (SharedLogValue) value;
+         int last = logValue.size() - 1;
+         notify(logValue.getThreadId(last), logValue.getOperationId(last), key);
+      } else if (key instanceof String && ((String) key).startsWith(LogChecker.LAST_OPERATION_PREFIX)) {
+         int threadId = Integer.parseInt(((String) key).substring(LogChecker.LAST_OPERATION_PREFIX.length()));
+         LogChecker.LastOperation last = (LogChecker.LastOperation) value;
+         requireNotify(threadId, last.getOperationId() + 1);
+      }
+   }
+
+}

--- a/core/src/main/java/org/radargun/stages/cache/background/PrivateLogChecker.java
+++ b/core/src/main/java/org/radargun/stages/cache/background/PrivateLogChecker.java
@@ -7,7 +7,7 @@ package org.radargun.stages.cache.background;
  */
 public class PrivateLogChecker extends LogChecker {
 
-   public PrivateLogChecker(int id, LogCheckerPool pool, BackgroundOpsManager manager) {
+   public PrivateLogChecker(int id, StressorRecordPool pool, BackgroundOpsManager manager) {
       super(manager.getName() + "-Checker-" + id, manager, pool);
    }
 

--- a/core/src/main/java/org/radargun/stages/cache/background/PrivateLogLogic.java
+++ b/core/src/main/java/org/radargun/stages/cache/background/PrivateLogLogic.java
@@ -38,7 +38,7 @@ class PrivateLogLogic extends AbstractLogLogic<PrivateLogValue> {
 
    @Override
    protected boolean invokeLogic(long keyId) throws Exception {
-      Operation operation = manager.getOperation(operationTypeRandom);
+      Operation operation = getOperation(operationTypeRandom);
 
       OperationTimestampPair prevOperation = timestamps.get(keyId);
       // first we have to get the value

--- a/core/src/main/java/org/radargun/stages/cache/background/PrivateLogLogic.java
+++ b/core/src/main/java/org/radargun/stages/cache/background/PrivateLogLogic.java
@@ -17,8 +17,6 @@ import org.radargun.traits.BasicOperations;
  */
 class PrivateLogLogic extends AbstractLogLogic<PrivateLogValue> {
 
-   private final long keyRangeStart;
-   private final long keyRangeEnd;
    // Timestamps of the last writes into given values. As we can get stale read for some period,
    // we cannot overwrite the value again until we can be sure that we can safely read current
    // value of that entry. We have to keep the timestamps here, as we cannot reliably determine
@@ -35,14 +33,7 @@ class PrivateLogLogic extends AbstractLogLogic<PrivateLogValue> {
    private final Collection<KeyOperationPair> txModifications = new ArrayList<>(Math.max(0, transactionSize));
 
    PrivateLogLogic(BackgroundOpsManager manager, Range range) {
-      super(manager);
-      this.keyRangeStart = range.getStart();
-      this.keyRangeEnd = range.getEnd();
-   }
-
-   @Override
-   protected long nextKeyId() {
-      return (keySelectorRandom.nextLong() & Long.MAX_VALUE) % (keyRangeEnd - keyRangeStart) + keyRangeStart;
+      super(manager, range);
    }
 
    @Override

--- a/core/src/main/java/org/radargun/stages/cache/background/PrivateLogLogic.java
+++ b/core/src/main/java/org/radargun/stages/cache/background/PrivateLogLogic.java
@@ -50,6 +50,7 @@ class PrivateLogLogic extends AbstractLogLogic<PrivateLogValue> {
             backupValue = checkedGetValue(~keyId);
             if (backupValue == null || !backupValue.contains(prevOperation.operationId)) {
                // definitely stale read
+               log.trace("Detected stale read, keyId: " + keyId);
                waitForStaleRead(prevOperation.timestamp);
                return false;
             } else {

--- a/core/src/main/java/org/radargun/stages/cache/background/PrivateLogLogic.java
+++ b/core/src/main/java/org/radargun/stages/cache/background/PrivateLogLogic.java
@@ -34,9 +34,8 @@ class PrivateLogLogic extends AbstractLogLogic<PrivateLogValue> {
    // the transaction is committed
    private final Collection<KeyOperationPair> txModifications = new ArrayList<>(Math.max(0, transactionSize));
 
-   PrivateLogLogic(BackgroundOpsManager manager, long threadId, Range range) {
-      super(manager, threadId);
-      log.tracef("Stressor %d has range %s", threadId, range);
+   PrivateLogLogic(BackgroundOpsManager manager, Range range) {
+      super(manager);
       this.keyRangeStart = range.getStart();
       this.keyRangeEnd = range.getEnd();
    }

--- a/core/src/main/java/org/radargun/stages/cache/background/PrivateLogLogic.java
+++ b/core/src/main/java/org/radargun/stages/cache/background/PrivateLogLogic.java
@@ -113,7 +113,8 @@ class PrivateLogLogic extends AbstractLogLogic<PrivateLogValue> {
             Thread.sleep(5000);
          }
       } else {
-         throw new RuntimeException("Stale reads are not allowed in this configuration");
+         manager.getStressorRecordPool().reportStaleRead();
+         stressor.requestTerminate();
       }
    }
 

--- a/core/src/main/java/org/radargun/stages/cache/background/SharedLogChecker.java
+++ b/core/src/main/java/org/radargun/stages/cache/background/SharedLogChecker.java
@@ -7,7 +7,7 @@ package org.radargun.stages.cache.background;
  */
 public class SharedLogChecker extends LogChecker {
 
-   public SharedLogChecker(int id, LogCheckerPool pool, BackgroundOpsManager manager) {
+   public SharedLogChecker(int id, StressorRecordPool pool, BackgroundOpsManager manager) {
       super(manager.getName() + "-Checker-" + id, manager, pool);
    }
 

--- a/core/src/main/java/org/radargun/stages/cache/background/SharedLogChecker.java
+++ b/core/src/main/java/org/radargun/stages/cache/background/SharedLogChecker.java
@@ -1,25 +1,23 @@
 package org.radargun.stages.cache.background;
 
-import java.util.Random;
-
 /**
- * Checker used for {@link PrivateLogValue shared log values}
+ * Checker used for {@link org.radargun.stages.cache.background.PrivateLogValue shared log values}
  *
  * @author Radim Vansa &lt;rvansa@redhat.com&gt;
  */
-class SharedLogChecker extends LogChecker {
+public class SharedLogChecker extends LogChecker {
 
-   public SharedLogChecker(int id, Pool pool, BackgroundOpsManager manager) {
+   public SharedLogChecker(int id, LogCheckerPool pool, BackgroundOpsManager manager) {
       super(manager.getName() + "-Checker-" + id, manager, pool);
    }
 
    @Override
-   protected AbstractStressorRecord newRecord(AbstractStressorRecord record, long operationId, long seed) {
-      return new StressorRecord((StressorRecord) record, operationId, seed);
+   protected StressorRecord newRecord(StressorRecord record, long operationId, long seed) {
+      return new StressorRecord(record, operationId, seed);
    }
 
    @Override
-   protected Object findValue(AbstractStressorRecord record) throws Exception {
+   protected Object findValue(StressorRecord record) throws Exception {
       // The value can always be moved so that we can't read it directly. However, if the value has not changed
       // since previous read, the complement could not have been removed - the operation definitely is not
       // in any entry.
@@ -42,7 +40,7 @@ class SharedLogChecker extends LogChecker {
    }
 
    @Override
-   protected boolean containsOperation(Object value, AbstractStressorRecord record) {
+   protected boolean containsOperation(Object value, StressorRecord record) {
       if (value == null) {
          return false;
       }
@@ -57,63 +55,4 @@ class SharedLogChecker extends LogChecker {
       return false;
    }
 
-   public static class Pool extends LogChecker.Pool {
-
-      public Pool(int numSlaves, int numThreads, long numEntries, long keyIdOffset, BackgroundOpsManager manager) {
-         super(numThreads, numSlaves, manager);
-         int totalThreads = numThreads * numSlaves;
-         for (int threadId = 0; threadId < totalThreads; ++threadId) {
-            log.tracef("Record %d has range 0 - %d", threadId, numEntries);
-            addNew(new StressorRecord(threadId, numEntries, keyIdOffset));
-         }
-         registerListeners(true); // synchronous listeners
-      }
-
-      @Override
-      public void created(Object key, Object value) {
-         log.trace("Created " + key + " -> " + value);
-         modified(key, value);
-      }
-
-      @Override
-      public void updated(Object key, Object value) {
-         log.trace("Updated " + key + " -> " + value);
-         modified(key, value);
-      }
-
-      @Override
-      protected void modified(Object key, Object value) {
-         if (value instanceof SharedLogValue) {
-            SharedLogValue logValue = (SharedLogValue) value;
-            int last = logValue.size() - 1;
-            notify(logValue.getThreadId(last), logValue.getOperationId(last), key);
-         } else super.modified(key, value);
-      }
-   }
-
-
-   private static class StressorRecord extends AbstractStressorRecord {
-      private final long numEntries;
-      private final long keyIdOffset;
-
-      public StressorRecord(int threadId, long numEntries, long keyIdOffset) {
-         super(new Random(threadId), threadId);
-         this.numEntries = numEntries;
-         this.keyIdOffset = keyIdOffset;
-         next();
-      }
-
-      public StressorRecord(SharedLogChecker.StressorRecord record, long operationId, long seed) {
-         super(seed, record.getThreadId(), operationId);
-         this.numEntries = record.numEntries;
-         this.keyIdOffset = record.keyIdOffset;
-         next();
-      }
-
-      @Override
-      public void next() {
-         currentKeyId = (rand.nextLong() & Long.MAX_VALUE) % numEntries + keyIdOffset;
-         checkFinished(currentOp++);
-      }
-   }
 }

--- a/core/src/main/java/org/radargun/stages/cache/background/SharedLogLogic.java
+++ b/core/src/main/java/org/radargun/stages/cache/background/SharedLogLogic.java
@@ -1,5 +1,6 @@
 package org.radargun.stages.cache.background;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import org.radargun.Operation;
@@ -29,7 +30,7 @@ class SharedLogLogic extends AbstractLogLogic<SharedLogValue> {
 
    @Override
    protected boolean invokeLogic(long keyId) throws Exception {
-      Operation operation = manager.getOperation(operationTypeRandom);
+      Operation operation = getOperation(operationTypeRandom);
 
       // In shared mode, we can't ever atomically modify the two keys (main and backup) to have only
       // one of them with the actual value (this is not true even for private mode but there the moment
@@ -99,6 +100,14 @@ class SharedLogLogic extends AbstractLogLogic<SharedLogValue> {
       } else {
          return filtered;
       }
+   }
+
+   protected Map<Integer, Long> getCheckedOperations(long minOperationId) throws StressorException, BreakTxRequest {
+      Map<Integer, Long> minIds = new HashMap<Integer, Long>();
+      for (int thread = 0; thread < manager.getGeneralConfiguration().getNumThreads() * manager.getSlaveState().getClusterSize(); ++thread) {
+         minIds.put(thread, getCheckedOperation(thread, minOperationId));
+      }
+      return minIds;
    }
 
    @Override

--- a/core/src/main/java/org/radargun/stages/cache/background/SharedLogLogic.java
+++ b/core/src/main/java/org/radargun/stages/cache/background/SharedLogLogic.java
@@ -3,6 +3,7 @@ package org.radargun.stages.cache.background;
 import java.util.Map;
 
 import org.radargun.Operation;
+import org.radargun.stages.helpers.Range;
 import org.radargun.traits.BasicOperations;
 import org.radargun.traits.ConditionalOperations;
 
@@ -16,23 +17,14 @@ import org.radargun.traits.ConditionalOperations;
 class SharedLogLogic extends AbstractLogLogic<SharedLogValue> {
 
    private final ConditionalOperations.Cache nonTxConditionalCache;
-   private final long numEntries;
-   private final long keyIdOffset;
    private ConditionalOperations.Cache conditionalCache;
 
-   SharedLogLogic(BackgroundOpsManager manager, long numEntries, long keyIdOffset) {
-      super(manager);
+   SharedLogLogic(BackgroundOpsManager manager, Range range) {
+      super(manager, range);
       nonTxConditionalCache = manager.getConditionalCache();
       if (transactionSize <= 0) {
          conditionalCache = nonTxConditionalCache;
       }
-      this.numEntries = numEntries;
-      this.keyIdOffset = keyIdOffset;
-   }
-
-   @Override
-   protected long nextKeyId() {
-      return (keySelectorRandom.nextLong() & Long.MAX_VALUE) % numEntries + keyIdOffset;
    }
 
    @Override

--- a/core/src/main/java/org/radargun/stages/cache/background/SharedLogLogic.java
+++ b/core/src/main/java/org/radargun/stages/cache/background/SharedLogLogic.java
@@ -20,8 +20,8 @@ class SharedLogLogic extends AbstractLogLogic<SharedLogValue> {
    private final long keyIdOffset;
    private ConditionalOperations.Cache conditionalCache;
 
-   SharedLogLogic(BackgroundOpsManager manager, long threadId, long numEntries, long keyIdOffset) {
-      super(manager, threadId);
+   SharedLogLogic(BackgroundOpsManager manager, long numEntries, long keyIdOffset) {
+      super(manager);
       nonTxConditionalCache = manager.getConditionalCache();
       if (transactionSize <= 0) {
          conditionalCache = nonTxConditionalCache;

--- a/core/src/main/java/org/radargun/stages/cache/background/Stressor.java
+++ b/core/src/main/java/org/radargun/stages/cache/background/Stressor.java
@@ -6,14 +6,18 @@ import org.radargun.stats.DefaultOperationStats;
 import org.radargun.stats.SynchronizedStatistics;
 
 /**
-* Stressor thread running in parallel to many stages.
+* Stressor thread running in parallel to many stages. Its behavior is specified by plugging in specific
+* {@link org.radargun.stages.cache.background.Logic} implementation.
+*
+* @See org.radargun.stages.cache.background.LegacyLogic
+* @See org.radargun.stages.cache.background.PrivateLogLogic
+* @See org.radargun.stages.cache.background.SharedLogLogic
 *
 * @author Radim Vansa &lt;rvansa@redhat.com&gt;
 */
 class Stressor extends Thread {
 
    private static final Log log = LogFactory.getLog(Stressor.class);
-   private static final boolean trace = log.isTraceEnabled();
 
    protected final int id;
    private final Logic logic;

--- a/core/src/main/java/org/radargun/stages/cache/background/StressorRecord.java
+++ b/core/src/main/java/org/radargun/stages/cache/background/StressorRecord.java
@@ -17,6 +17,7 @@ public class StressorRecord {
    protected static final Log log = LogFactory.getLog(StressorRecord.class);
    protected static final boolean trace = log.isTraceEnabled();
    protected final Random rand;
+   protected Range keyRange;
    protected final int threadId;
    protected long currentKeyId;
    protected volatile long currentOp = -1;
@@ -26,15 +27,11 @@ public class StressorRecord {
    private Set<Long> notifiedOps = new HashSet<Long>();
    private long requireNotify = Long.MAX_VALUE;
 
-   private long numEntries;
-   private long keyIdOffset;
-
    public StressorRecord(int threadId, Range keyRange) {
       this.rand = new Random(threadId);
       log.trace("Initializing record random with " + Utils.getRandomSeed(rand));
       this.threadId = threadId;
-      this.numEntries = keyRange.getSize();
-      this.keyIdOffset = keyRange.getStart();
+      this.keyRange = keyRange;
       privateNext();
    }
 
@@ -43,8 +40,6 @@ public class StressorRecord {
       log.trace("Initializing record random with " + seed);
       this.threadId = record.threadId;
       this.currentOp = operationId;
-      this.numEntries = record.numEntries;
-      this.keyIdOffset = record.keyIdOffset;
       privateNext();
    }
 
@@ -54,7 +49,7 @@ public class StressorRecord {
 
    // avoid calling overridable method in constructor, as object can be found in an inconsistent state
    private void privateNext() {
-      currentKeyId = keyIdOffset + (rand.nextLong() & Long.MAX_VALUE) % numEntries;
+      currentKeyId = keyRange.getStart() + (rand.nextLong() & Long.MAX_VALUE) % keyRange.getSize();
       checkFinished(currentOp++);
    }
 

--- a/core/src/main/java/org/radargun/stages/cache/background/StressorRecord.java
+++ b/core/src/main/java/org/radargun/stages/cache/background/StressorRecord.java
@@ -1,0 +1,187 @@
+package org.radargun.stages.cache.background;
+
+import java.util.*;
+
+import org.radargun.logging.Log;
+import org.radargun.logging.LogFactory;
+import org.radargun.stages.helpers.Range;
+import org.radargun.utils.Utils;
+
+/**
+ * // TODO: Document this
+ *
+ * @author Radim Vansa &lt;rvansa@redhat.com&gt;
+ */
+public class StressorRecord {
+
+   protected static final Log log = LogFactory.getLog(StressorRecord.class);
+   protected static final boolean trace = log.isTraceEnabled();
+   protected final Random rand;
+   protected final int threadId;
+   protected long currentKeyId;
+   protected volatile long currentOp = -1;
+   protected final List<StressorConfirmation> confirmations = new LinkedList<>();
+   private long lastUnsuccessfulCheckTimestamp = Long.MIN_VALUE;
+   private long lastSuccessfulCheckTimestamp = System.currentTimeMillis();
+   private Set<Long> notifiedOps = new HashSet<Long>();
+   private long requireNotify = Long.MAX_VALUE;
+
+   private long numEntries;
+   private long keyIdOffset;
+
+   public StressorRecord(int threadId, Range keyRange) {
+      this.rand = new Random(threadId);
+      log.trace("Initializing record random with " + Utils.getRandomSeed(rand));
+      this.threadId = threadId;
+      this.numEntries = keyRange.getSize();
+      this.keyIdOffset = keyRange.getStart();
+      privateNext();
+   }
+
+   public StressorRecord(StressorRecord record, long operationId, long seed) {
+      this.rand = Utils.setRandomSeed(new Random(0), seed);
+      log.trace("Initializing record random with " + seed);
+      this.threadId = record.threadId;
+      this.currentOp = operationId;
+      this.numEntries = record.numEntries;
+      this.keyIdOffset = record.keyIdOffset;
+      privateNext();
+   }
+
+   public void next() {
+      privateNext();
+   }
+
+   // avoid calling overridable method in constructor, as object can be found in an inconsistent state
+   private void privateNext() {
+      currentKeyId = keyIdOffset + (rand.nextLong() & Long.MAX_VALUE) % numEntries;
+      checkFinished(currentOp++);
+   }
+
+   public String getStatus() {
+      return String.format("thread=%d, lastStressorOperation=%d, currentOp=%d, currentKeyId=%08X, notifiedOps=%s, requireNotify=%d",
+            threadId, getLastConfirmedOperationId(),
+            currentOp, currentKeyId, notifiedOps, requireNotify);
+   }
+
+   public Object getLastConfirmedOperationId() {
+      return confirmations.isEmpty() ? -1 : confirmations.get(confirmations.size() - 1);
+   }
+
+   public int getThreadId() {
+      return threadId;
+   }
+
+   public long getLastUnsuccessfulCheckTimestamp() {
+      return lastUnsuccessfulCheckTimestamp;
+   }
+
+   public void setLastUnsuccessfulCheckTimestamp(long lastUnsuccessfulCheckTimestamp) {
+      this.lastUnsuccessfulCheckTimestamp = lastUnsuccessfulCheckTimestamp;
+   }
+
+   public long getKeyId() {
+      return currentKeyId;
+   }
+
+   public long getOperationId() {
+      return currentOp;
+   }
+
+   public Set<Long> getNotifiedOps() {
+      return notifiedOps;
+   }
+
+   public long getRequireNotify() {
+      return requireNotify;
+   }
+
+   public Random getRand() {
+      return rand;
+   }
+
+   public synchronized void notify(long operationId, Object key) {
+      if (operationId < currentOp || !notifiedOps.add(operationId)) {
+         log.warn("Duplicit notification for operation " + operationId + " on key " + key);
+      }
+   }
+
+   public void checkFinished(long operationId) {
+      // remove old confirmations
+      Iterator<StressorConfirmation> iterator = confirmations.iterator();
+      while (iterator.hasNext()) {
+         StressorConfirmation confirmation = iterator.next();
+         if (confirmation.operationId > operationId) {
+            break;
+         }
+         iterator.remove();
+      }
+      // remove old notifications
+      synchronized (this) {
+         notifiedOps.remove(operationId);
+      }
+   }
+
+   public synchronized void requireNotify(long operationId) {
+      if (operationId < requireNotify) {
+         requireNotify = operationId;
+      }
+   }
+
+   public synchronized boolean hasNotification(long operationId) {
+      if (operationId < requireNotify) return true;
+      return notifiedOps.contains(operationId);
+   }
+
+   public void setLastSuccessfulCheckTimestamp(long timestamp) {
+      this.lastSuccessfulCheckTimestamp = timestamp;
+   }
+
+   public long getLastSuccessfulCheckTimestamp() {
+      return lastSuccessfulCheckTimestamp;
+   }
+
+   public void addConfirmation(long operationId, long timestamp) {
+      try {
+         ListIterator<StressorConfirmation> iterator = confirmations.listIterator(confirmations.size());
+         if (trace) {
+            log.tracef("Confirmations for thread %d were %s", threadId, confirmations);
+         }
+         while (iterator.hasPrevious()) {
+            StressorConfirmation confirmation = iterator.previous();
+            if (confirmation.operationId < operationId) {
+               confirmations.add(iterator.nextIndex(), new StressorConfirmation(operationId, timestamp));
+               return;
+            } else if (confirmation.operationId == operationId) {
+               return;
+            }
+         }
+      } finally {
+         if (trace) {
+            log.tracef("Confirmations for thread %d are %s", threadId, confirmations);
+         }
+      }
+   }
+
+   /**
+    * @return Epoch time (ms) timestamp or negative value if not confirmed yet.
+    */
+   public long getCurrentConfirmationTimestamp() {
+      for (StressorConfirmation confirmation : confirmations) {
+         if (confirmation.operationId > currentOp) {
+            return confirmation.timestamp;
+         }
+      }
+      return -1;
+   }
+
+   public class StressorConfirmation {
+      public final long operationId;
+      public final long timestamp;
+
+      public StressorConfirmation(long operationId, long timestamp) {
+         this.operationId = operationId;
+         this.timestamp = timestamp;
+      }
+   }
+}

--- a/core/src/main/java/org/radargun/stages/cache/background/StressorRecord.java
+++ b/core/src/main/java/org/radargun/stages/cache/background/StressorRecord.java
@@ -8,7 +8,9 @@ import org.radargun.stages.helpers.Range;
 import org.radargun.utils.Utils;
 
 /**
- * // TODO: Document this
+ * Divides key space used by {@link org.radargun.stages.cache.background.Stressor}s into multiple segments, corresponding
+ * to key range defined by {@link org.radargun.stages.cache.background.AbstractLogLogic} implementations.
+ * Furthermore, it keeps track of currently processed key and operation performed by {@link org.radargun.stages.cache.background.LogChecker}.
  *
  * @author Radim Vansa &lt;rvansa@redhat.com&gt;
  */

--- a/core/src/main/java/org/radargun/stages/cache/background/StressorRecordPool.java
+++ b/core/src/main/java/org/radargun/stages/cache/background/StressorRecordPool.java
@@ -28,8 +28,10 @@ public class StressorRecordPool implements CacheListeners.UpdatedListener, Cache
    // Represents current state of pool
    private final ConcurrentLinkedQueue<StressorRecord> availableRecords = new ConcurrentLinkedQueue<StressorRecord>();
    private final BackgroundOpsManager manager;
+   // TODO move the following attributes to a separate class (or elsewhere)
    private final AtomicLong missingOperations = new AtomicLong();
    private final AtomicLong missingNotifications = new AtomicLong();
+   private final AtomicLong staleReads = new AtomicLong();
 
    public StressorRecordPool(int totalThreads, List<StressorRecord> stressorRecords, BackgroundOpsManager manager) {
       this.totalThreads = totalThreads;
@@ -67,12 +69,20 @@ public class StressorRecordPool implements CacheListeners.UpdatedListener, Cache
       return missingNotifications.get();
    }
 
+   public long getStaleReads() {
+      return staleReads.get();
+   }
+
    public void reportMissingOperation() {
       missingOperations.incrementAndGet();
    }
 
    public void reportMissingNotification() {
       missingNotifications.incrementAndGet();
+   }
+
+   public void reportStaleRead() {
+      staleReads.incrementAndGet();
    }
 
    public int getTotalThreads() {

--- a/core/src/main/java/org/radargun/stages/helpers/Range.java
+++ b/core/src/main/java/org/radargun/stages/helpers/Range.java
@@ -4,10 +4,12 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
-public class Range {
+public final class Range {
    
    private long start;
    private long end;
+
+   private Range() {}
 
    public Range(long start, long end) {
       this.start = start;

--- a/core/src/main/java/org/radargun/utils/Utils.java
+++ b/core/src/main/java/org/radargun/utils/Utils.java
@@ -602,4 +602,17 @@ public class Utils {
       if (args == null || args.length <= arg || !clazz.isInstance(args[arg])) throw new IllegalArgumentException(Arrays.toString(args));
       return (T) args[arg];
    }
+
+   public static <T> T findThrowableCauseByClass(Throwable t, Class<T> clazz) {
+      if (clazz == null) {
+         throw new IllegalArgumentException("'clazz' parameter cannot be null.");
+      }
+      if (t == null) {
+         return null;
+      } else if (clazz.isAssignableFrom(t.getClass())) {
+         return (T) t;
+      } else {
+         return findThrowableCauseByClass(t.getCause(), clazz);
+      }
+   }
 }

--- a/core/src/test/java/org/radargun/config/UtilsTest.java
+++ b/core/src/test/java/org/radargun/config/UtilsTest.java
@@ -1,0 +1,41 @@
+package org.radargun.config;
+
+import org.radargun.utils.Utils;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+/**
+ * @author Matej Cimbora &lt;mcimbora@redhat.com&gt;
+ */
+@Test
+public class UtilsTest {
+
+   public void testFindThrowableCauseByClass() {
+      Exception root = new TestRootException();
+      Exception child = new TestChildException(root);
+      Exception result = Utils.findThrowableCauseByClass(child, TestRootException.class);
+      assertTrue(result instanceof TestRootException);
+
+      child = new TestChildException();
+      result = Utils.findThrowableCauseByClass(child, TestRootException.class);
+      assertEquals(null, result);
+   }
+
+   @Test(expectedExceptions = IllegalArgumentException.class)
+   public void testFindThrowableCauseByClassNullArg() {
+      Utils.findThrowableCauseByClass(new TestChildException(), null);
+   }
+
+   private static class TestRootException extends Exception {}
+
+   private static class TestChildException extends Exception {
+
+      private TestChildException() {
+      }
+
+      private TestChildException(Throwable cause) {
+         super(cause);
+      }
+   }
+}


### PR DESCRIPTION
This is an initial proposal of bg package refactoring in order to improve code readibility. What has been done so far:
* Unified LogCheckerPool object hierarchy into a single class - IMO with current implementation, splitting it into separate classes had no benefits. Refactored into a separate class rather than keeping it in LogChecker.
* The same story for StressorRecord - Introduced a separate class merging the whole hierarchy.

Another ideas I'll be working on (TODO):
* Simplify BackgroundOpsManager - at least splitting statistics into separate mngr
* Tracking missing operations & notifications should be performed in a separate object - currently a pool holds the references that breaks class cohesion. Its purpose should be solely to provide a value on demand.
* ?

Should you have any other ideas or comments, feel free to add those.