### PR TITLE
Background ops fixes, improve trace logging

### DIFF
--- a/core/src/main/java/org/radargun/stages/cache/background/BackgroundOpsManager.java
+++ b/core/src/main/java/org/radargun/stages/cache/background/BackgroundOpsManager.java
@@ -112,6 +112,10 @@ public class BackgroundOpsManager extends ServiceListenerAdapter {
    }
 
    private void loadCaches() {
+      if (lifecycle != null && !lifecycle.isRunning()) {
+         log.warn("Can't load caches, service is not running");
+         return;
+      }
       basicCache = slaveState.getTrait(BasicOperations.class).getCache(generalConfiguration.cacheName);
       ConditionalOperations conditionalOperations = slaveState.getTrait(ConditionalOperations.class);
       conditionalCache = conditionalOperations == null ? null : conditionalOperations.getCache(generalConfiguration.cacheName);

--- a/core/src/main/java/org/radargun/stages/cache/background/StressorRecord.java
+++ b/core/src/main/java/org/radargun/stages/cache/background/StressorRecord.java
@@ -56,9 +56,10 @@ public class StressorRecord {
    }
 
    public String getStatus() {
-      return String.format("thread=%d, lastStressorOperation=%d, currentOp=%d, currentKeyId=%08X, notifiedOps=%s, requireNotify=%d",
-            threadId, getLastConfirmedOperationId(),
-            currentOp, currentKeyId, notifiedOps, requireNotify);
+      return String.format("thread=%d, lastStressorOperation=%d, currentOp=%d, currentKeyId=%08X, notifiedOps=%s, requireNotify=%d, " +
+                                 "lastSuccessfulCheckTimestamp=%d, lastUnsuccessfulCheckTimestamp=%d.",
+            threadId, getLastConfirmedOperationId(), currentOp, currentKeyId, notifiedOps, requireNotify,
+            lastSuccessfulCheckTimestamp, lastUnsuccessfulCheckTimestamp);
    }
 
    public Object getLastConfirmedOperationId() {


### PR DESCRIPTION
* Avoid loading caches if the service is not running
* Allow to scan for ignored keys also for non-zero operation ids (when StressorRecordPool survives service restart)
* Improve trace logging