### PR TITLE
Add version.infinispan.public property to parent POM

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -250,5 +250,7 @@
    <properties>
       <!-- By default don't run unit tests for the fwk! -->
       <maven.test.skip>true</maven.test.skip>
+      <!-- Use this version of infinispan-distexec-demo in the JDG plugins -->
+      <version.infinispan.public>7.1.1.Final</version.infinispan.public>
    </properties>
 </project>

--- a/plugins/infinispan71/pom.xml
+++ b/plugins/infinispan71/pom.xml
@@ -119,6 +119,28 @@
             <version.infinispan>7.1.1.Final</version.infinispan>
          </properties>
       </profile>
+      <profile>
+         <id>demos</id>
+         <activation>
+            <property>
+               <name>!no-demos</name>
+            </property>
+         </activation>
+         <dependencies>
+            <dependency>
+               <groupId>org.infinispan</groupId>
+               <artifactId>infinispan-distexec-demo</artifactId>
+               <version>${version.infinispan}</version>
+               <optional>true</optional>
+               <exclusions>
+                   <exclusion>
+                       <groupId>org.infinispan</groupId>
+                       <artifactId>infinispan-embedded</artifactId>
+                   </exclusion>
+               </exclusions>
+            </dependency>
+         </dependencies>
+      </profile>
    </profiles>
 
 </project>

--- a/plugins/jdg62/pom.xml
+++ b/plugins/jdg62/pom.xml
@@ -15,8 +15,6 @@
 
    <properties>
       <version.infinispan>${jdg62.infinispan.version}</version.infinispan>
-      <!-- There is no productized version of infinispan-distexec-demo -->
-      <version.infinispan.public>6.0.2.Final</version.infinispan.public>
       <version.jbossts>4.17.7.Final-redhat-4</version.jbossts>
       <version.jta-spec>1.0.1.Final-redhat-2</version.jta-spec>
    </properties>

--- a/plugins/jdg63/pom.xml
+++ b/plugins/jdg63/pom.xml
@@ -15,8 +15,6 @@
 
    <properties>
       <version.infinispan>${jdg63.infinispan.version}</version.infinispan>
-      <!-- There is no productized version of infinispan-distexec-demo -->
-      <version.infinispan.public>7.0.3.Final</version.infinispan.public>
       <version.jbossts>4.17.15.Final-redhat-5</version.jbossts>
       <version.jta-spec>1.0.1.Final-redhat-2</version.jta-spec>
    </properties>

--- a/plugins/jdg64/pom.xml
+++ b/plugins/jdg64/pom.xml
@@ -15,8 +15,6 @@
 
    <properties>
       <version.infinispan>${jdg64.infinispan.version}</version.infinispan>
-      <!-- There is no productized version of infinispan-distexec-demo -->
-      <version.infinispan.public>7.0.3.Final</version.infinispan.public>
       <version.jbossts>4.17.15.Final-redhat-5</version.jbossts>
       <version.jta-spec>1.0.1.Final-redhat-2</version.jta-spec>
    </properties>

--- a/plugins/jdg65/pom.xml
+++ b/plugins/jdg65/pom.xml
@@ -15,7 +15,6 @@
 
    <properties>
       <version.infinispan>${jdg65.infinispan.version}</version.infinispan>
-      <version.infinispan.public>7.1.1.Final</version.infinispan.public>
       <version.jbossts>4.17.15.Final-redhat-5</version.jbossts>
       <version.jta-spec>1.0.1.Final-redhat-2</version.jta-spec>
    </properties>


### PR DESCRIPTION
    
This version of the infinispan-distexec-demo JAR is used as a dependency
in the JDG plugins
Also added the infinispan-distexec-demo profile to the infinispan71
plugin