### PR TITLE
Failover testing - fix wrong slave indices and addition of confirmations

### DIFF
--- a/core/src/main/java/org/radargun/stages/cache/background/AbstractLogLogic.java
+++ b/core/src/main/java/org/radargun/stages/cache/background/AbstractLogLogic.java
@@ -291,7 +291,7 @@ abstract class AbstractLogLogic<ValueType> extends AbstractLogic {
     */
    protected long getCheckedOperation(int thread, long minOperationId) throws StressorException, BreakTxRequest {
       long minimumOperationId = Long.MAX_VALUE;
-      for (int i = 0; i < manager.getSlaveState().getClusterSize(); ++i) {
+      for (int i = 0; i < manager.getSlaveState().getGroupSize(); ++i) {
          Object lastCheckedOperationId;
          try {
             lastCheckedOperationId = basicCache.get(LogChecker.checkerKey(i, thread));

--- a/core/src/main/java/org/radargun/stages/cache/background/SharedLogLogic.java
+++ b/core/src/main/java/org/radargun/stages/cache/background/SharedLogLogic.java
@@ -104,7 +104,7 @@ class SharedLogLogic extends AbstractLogLogic<SharedLogValue> {
 
    protected Map<Integer, Long> getCheckedOperations(long minOperationId) throws StressorException, BreakTxRequest {
       Map<Integer, Long> minIds = new HashMap<Integer, Long>();
-      for (int thread = 0; thread < manager.getGeneralConfiguration().getNumThreads() * manager.getSlaveState().getClusterSize(); ++thread) {
+      for (int thread = 0; thread < manager.getGeneralConfiguration().getNumThreads() * manager.getSlaveState().getGroupSize(); ++thread) {
          minIds.put(thread, getCheckedOperation(thread, minOperationId));
       }
       return minIds;

--- a/core/src/main/java/org/radargun/stages/cache/background/StressorRecord.java
+++ b/core/src/main/java/org/radargun/stages/cache/background/StressorRecord.java
@@ -63,7 +63,7 @@ public class StressorRecord {
    }
 
    public Object getLastConfirmedOperationId() {
-      return confirmations.isEmpty() ? -1 : confirmations.get(confirmations.size() - 1);
+      return confirmations.isEmpty() ? -1 : confirmations.get(confirmations.size() - 1).operationId;
    }
 
    public int getThreadId() {
@@ -153,6 +153,9 @@ public class StressorRecord {
             } else if (confirmation.operationId == operationId) {
                return;
             }
+         }
+         if (confirmations.isEmpty()) {
+            confirmations.add(new StressorConfirmation(operationId, timestamp));
          }
       } finally {
          if (trace) {


### PR DESCRIPTION
Fix
* faulty slave indices when using multiple groups
* adding confirmations to StressorRecord