### PR TITLE
3 small enhancements!

### DIFF
--- a/core/src/main/java/org/radargun/stages/cache/background/BackgroundOpsManager.java
+++ b/core/src/main/java/org/radargun/stages/cache/background/BackgroundOpsManager.java
@@ -397,14 +397,10 @@ public class BackgroundOpsManager extends ServiceListenerAdapter {
       // interrupt all threads
       log.debug("Stopping stressors");
       if (stressors && stressorThreads != null) {
-         for (int i = 0; i < stressorThreads.length; i++) {
-            stressorThreads[i].requestTerminate();
-         }
+         Stressor.requestTerminate();
       }
       if (checkers && logCheckers != null) {
-         for (int i = 0; i < logCheckers.length; ++i) {
-            logCheckers[i].requestTerminate();
-         }
+         LogChecker.requestTerminate();
       }
       if (keepAlive && keepAliveTask != null) {
          keepAliveTask.cancel(true);

--- a/core/src/main/java/org/radargun/stages/cache/background/Stressor.java
+++ b/core/src/main/java/org/radargun/stages/cache/background/Stressor.java
@@ -24,7 +24,7 @@ class Stressor extends Thread {
    private final long delayBetweenRequests;
    protected final SynchronizedStatistics stats = new SynchronizedStatistics(new DefaultOperationStats());
 
-   private volatile boolean terminate = false;
+   private static volatile boolean terminate = false;
 
    public Stressor(BackgroundOpsManager manager, Logic logic, int id) {
       super(manager.getName() + "Stressor-" + id);
@@ -52,7 +52,7 @@ class Stressor extends Thread {
       }
    }
 
-   public void requestTerminate() {
+   public static void requestTerminate() {
       terminate = true;
    }
 

--- a/core/src/main/java/org/radargun/stages/lifecycle/ServiceStartStage.java
+++ b/core/src/main/java/org/radargun/stages/lifecycle/ServiceStartStage.java
@@ -41,9 +41,10 @@ public class ServiceStartStage extends AbstractServiceStartStage {
    @Property(doc = "Collect configuration files and properties for the service, and pass those to reporters. Default is true.")
    private boolean dumpConfig = true;
 
-   @Property(doc = "The number of slaves that should be up after all slaves are started. Applicable only with " +
-         "validateCluster=true. Default is all slaves in the cluster (in the same site in case of multi-site configuration).")
-   private Integer expectNumSlaves;
+   @Property(doc = "The number of slaves that should be up after all slaves are started. Applicable only with "
+         + "validateCluster=true. Default is all slaves in the cluster where this stage will be executed (in the "
+         + "same site in case of multi-site configuration).")
+   private Integer expectNumSlaves = -1;
 
    @Property(doc = "Set of slaves that should be reachable to the newly spawned slaves (see Partitionable feature for details). Default is all slaves.")
    private Set<Integer> reachable = null;
@@ -72,6 +73,12 @@ public class ServiceStartStage extends AbstractServiceStartStage {
 
       log.info("Ack master's StartCluster stage. Local address is: " + slaveState.getLocalAddress()
             + ". This slave's index is: " + slaveState.getSlaveIndex());
+      
+      // If no value of expectNumSlaves is supplied, then use the slaves where the stage is executing as a default
+      if (expectNumSlaves == -1) {
+         expectNumSlaves = getExecutingSlaves().size();
+      }
+      
       try {
          LifecycleHelper.start(slaveState, validateCluster, expectNumSlaves, clusterFormationTimeout, reachable);
       } catch (RuntimeException e) {

--- a/plugins/infinispan60/src/main/java/org/radargun/service/Infinispan60ServerTopologyHistory.java
+++ b/plugins/infinispan60/src/main/java/org/radargun/service/Infinispan60ServerTopologyHistory.java
@@ -90,13 +90,9 @@ public class Infinispan60ServerTopologyHistory extends AbstractTopologyHistory {
          } else {
             if (entry.getValue().rehashInProgress) {
                addEvent(hashChanges, entry.getKey(), true, 0, 0);
-            } else {
-               addEvent(hashChanges, entry.getKey(), false, 0, 0);
             }
             if (entry.getValue().topologyChangeInProgress) {
                addEvent(topologyChanges, entry.getKey(), true, 0, 0);
-            } else {
-               addEvent(topologyChanges, entry.getKey(), false, 0, 0);
             }
          }
          cacheChangesOngoing.put(entry.getKey(), entry.getValue());
@@ -149,11 +145,12 @@ public class Infinispan60ServerTopologyHistory extends AbstractTopologyHistory {
             Boolean stateTransferInProgress = (Boolean) connection.getAttribute(stateTransferManagerName,
                   JMX_STATE_TRANSFER_IN_PROGRESS_ATTR);
             if (stateTransferInProgress) {
-               log.debug("Rehash in progress for cache: " + rehashCacheNameMap.get(stateTransferManagerName.toString()));
+               log.debug("Rehash in progress on cache: " + rehashCacheNameMap.get(stateTransferManagerName.toString()));
                status.rehashInProgress = true;
                rehashesInProgress++;
             } else {
-               log.debug("No rehash in progress");
+               log.trace("No rehash in progress on cache: "
+                     + rehashCacheNameMap.get(stateTransferManagerName.toString()));
                status.rehashInProgress = false;
             }
             statusMap.put(rehashCacheNameMap.get(stateTransferManagerName.toString()), status);
@@ -188,10 +185,12 @@ public class Infinispan60ServerTopologyHistory extends AbstractTopologyHistory {
             status = statusMap.get(topologyChangeCacheNameMap.get(rpcManagerName.toString()));
             String pendingView = (String) connection.getAttribute(rpcManagerName, JMX_PENDING_VIEW_ATTR);
             if (pendingView.equals("null")) {
-               log.debug("No topology change in progress");
+               log.trace("No topology change in progress on cache: "
+                     + topologyChangeCacheNameMap.get(rpcManagerName.toString()));
                status.topologyChangeInProgress = false;
             } else {
-               log.info("Topology change in progress. Pending view = " + pendingView);
+               log.debug("Topology change in progress on cache: "
+                     + topologyChangeCacheNameMap.get(rpcManagerName.toString()) + ". Pending view = " + pendingView);
                status.topologyChangeInProgress = true;
                topologyChangesInProgress++;
             }


### PR DESCRIPTION
Make requestTerminate() static and the terminate variable static and
volatile in LogChecker and Stressor classes, and change the call site in
BackgroundOpsManager

If multiple groups are used with ServiceStart, calculate the
expectNumSlaves based on getExecutingSlaves().size().

Don't add end events for events that the code didn't start in
Infinispan60ServerTopologyHistory