### PR TITLE
2 small enhancements!

### DIFF
--- a/core/src/main/java/org/radargun/stages/lifecycle/ServiceStartStage.java
+++ b/core/src/main/java/org/radargun/stages/lifecycle/ServiceStartStage.java
@@ -41,9 +41,10 @@ public class ServiceStartStage extends AbstractServiceStartStage {
    @Property(doc = "Collect configuration files and properties for the service, and pass those to reporters. Default is true.")
    private boolean dumpConfig = true;
 
-   @Property(doc = "The number of slaves that should be up after all slaves are started. Applicable only with " +
-         "validateCluster=true. Default is all slaves in the cluster (in the same site in case of multi-site configuration).")
-   private Integer expectNumSlaves;
+   @Property(doc = "The number of slaves that should be up after all slaves are started. Applicable only with "
+         + "validateCluster=true. Default is all slaves in the cluster where this stage will be executed (in the "
+         + "same site in case of multi-site configuration).")
+   private Integer expectNumSlaves = -1;
 
    @Property(doc = "Set of slaves that should be reachable to the newly spawned slaves (see Partitionable feature for details). Default is all slaves.")
    private Set<Integer> reachable = null;
@@ -72,6 +73,12 @@ public class ServiceStartStage extends AbstractServiceStartStage {
 
       log.info("Ack master's StartCluster stage. Local address is: " + slaveState.getLocalAddress()
             + ". This slave's index is: " + slaveState.getSlaveIndex());
+      
+      // If no value of expectNumSlaves is supplied, then use the slaves where the stage is executing as a default
+      if (expectNumSlaves == -1) {
+         expectNumSlaves = getExecutingSlaves().size();
+      }
+      
       try {
          LifecycleHelper.start(slaveState, validateCluster, expectNumSlaves, clusterFormationTimeout, reachable);
       } catch (RuntimeException e) {


### PR DESCRIPTION
If multiple groups are used with ServiceStart, calculate the
expectNumSlaves based on getExecutingSlaves().size().

Don't add end events for events that the code didn't start in
Infinispan60ServerTopologyHistory