### PR TITLE
JGroups probe wrapper

### DIFF
--- a/core/src/main/java/org/radargun/stages/JGroupsProbeStage.java
+++ b/core/src/main/java/org/radargun/stages/JGroupsProbeStage.java
@@ -1,0 +1,117 @@
+package org.radargun.stages;
+
+import org.radargun.DistStageAck;
+import org.radargun.config.DefinitionElement;
+import org.radargun.config.Property;
+import org.radargun.config.Stage;
+import org.radargun.utils.ReflexiveConverters;
+import org.radargun.utils.TimeConverter;
+
+import java.io.IOException;
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.net.MulticastSocket;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Inspired by org.jgroups.tests.Probe.
+ *
+ * @author Matej Cimbora
+ */
+@Stage(doc = "Allows to invoke JGroups probe queries. For details on probe usage see org.jgroups.tests.Probe.")
+public class JGroupsProbeStage extends AbstractDistStage {
+
+   @Property(doc = "List of queries to be performed.", optional = false, complexConverter = ListConverter.class)
+   private List<Query> queries = new ArrayList<>();
+
+   @Property(doc = "Diagnostic address to send queries to. Default is 224.0.75.75.")
+   private String address = "224.0.75.75";
+
+   @Property(doc = "Diagnostic port. Default is 7500.")
+   private int port = 7500;
+
+   @Property(doc = "Maximum time to wait for query responses. Default is 60 seconds. Valid only when used in conjunction " +
+         "with expectedResponseCount parameter.", converter = TimeConverter.class)
+   private long timeout = 60_000;
+
+   @Property(doc = "Minimum number of responses to wait for. Default is -1 don't wait for responses.", optional = false)
+   private int expectedResponseCount = -1;
+
+   @Property(doc = "Print results of operation to log (INFO level). By default trace logging needs to be enabled.")
+   private boolean printResultsAsInfo;
+
+   @Override
+   public DistStageAck executeOnSlave() {
+      if (queries.isEmpty()) {
+         log.info("No queries have been specified");
+         return successfulResponse();
+      }
+      MulticastSocket socket = null;
+      try {
+         socket = new MulticastSocket();
+         socket.setSoTimeout((int) timeout);
+         InetAddress targetAddress = InetAddress.getByName(address);
+         byte[] payload = getQuery().getBytes();
+         DatagramPacket packet = new DatagramPacket(payload, 0, payload.length, targetAddress, port);
+         socket.send(packet);
+
+         // receive responses
+         if (expectedResponseCount == -1) {
+            return successfulResponse();
+         }
+         long start = System.currentTimeMillis();
+         int received = 0;
+         while (received < expectedResponseCount) {
+            if (start + timeout < System.currentTimeMillis()) {
+               String errorMessage = "Timed out waiting for query responses";
+               log.error(errorMessage);
+               return errorResponse(errorMessage);
+            }
+            byte[] buffer = new byte[1024 * 64];
+            DatagramPacket result = new DatagramPacket(buffer, buffer.length);
+            socket.receive(result);
+            received++;
+            if (printResultsAsInfo) {
+               log.infof("Received response %s from %s:%d", new String(result.getData(), 0, result.getLength()), result.getAddress(), result.getPort());
+            } else {
+               log.tracef("Received response %s from %s:%d", new String(result.getData(), 0, result.getLength()), result.getAddress(), result.getPort());
+            }
+         }
+      } catch (IOException e) {
+         String errorMessage = "Exception while performing multicast socket operation. Make sure 'enable_diagnostics' property of TP is enabled " +
+               "and correct diagnostics port is specified";
+         log.error(errorMessage, e);
+         return errorResponse(errorMessage, e);
+      } finally {
+         if (socket != null) {
+            socket.close();
+         }
+      }
+      return successfulResponse();
+   }
+
+   private String getQuery() {
+      if (queries.size() == 1) {
+         return queries.get(0).query;
+      }
+      StringBuilder queryBuilder = new StringBuilder();
+      for (Query query : queries) {
+         queryBuilder.append(query.query).append(" ");
+      }
+      return queryBuilder.toString();
+   }
+
+   @DefinitionElement(name = "query", doc = "Single query element.")
+   private static class Query {
+      @Property(doc = "Query to be performed.", name = "value", optional = false)
+      private String query;
+   }
+
+   protected static class ListConverter extends ReflexiveConverters.ListConverter {
+      public ListConverter() {
+         super(new Class<?>[] { Query.class});
+      }
+   }
+}

--- a/core/src/main/resources/benchmark-jgroups.xml
+++ b/core/src/main/resources/benchmark-jgroups.xml
@@ -1,0 +1,47 @@
+<!-- RadarGun 2.0 benchmark aggregating miscellaneous features -->
+<benchmark xmlns="urn:radargun:benchmark:3.0">
+
+   <!-- Specifies where should the master open socket  -->
+   <master bindAddress="${master.address:127.0.0.1}" port="${master.port:2103}"/>
+
+   <!-- List of cluster configurations where the benchmark should run-->
+   <clusters>
+      <cluster size="2"/>
+   </clusters>
+
+   <!-- List of configurations of the services -->
+   <configurations>
+      <config name="Infinispan 7.0 - distributed">
+         <!-- All slaves use the same configuration -->
+         <setup plugin="infinispan70">
+            <embedded xmlns="urn:radargun:plugins:infinispan70:3.0" file="dist-sync.xml">
+               <enable-diagnostics>true</enable-diagnostics>
+            </embedded>
+         </setup>
+      </config>
+   </configurations>
+
+   <!-- Sequence of stages executed on the cluster -->
+   <scenario>
+      <!-- Start services on all nodes -->
+      <service-start/>
+      <!-- Run JGroups probe wrapper & execute multiple queries in one batch -->
+      <j-groups-probe expected-response-count="2" timeout="30s" print-results-as-info="true" slaves="0">
+         <queries>
+            <!-- change log level for selected protocols -->
+            <query value="op=FD_ALL.setLevel[DEBUG]"/>
+            <query value="op=FD_SOCK.setLevel[DEBUG]"/>
+            <!-- dynamically add/remove protocols from stack -->
+            <query value="remove-protocol=MERGE3"/>
+            <query value="insert-protocol=MERGE2=above=PING"/>
+            <!-- insert custom protocol (just for illustration -->
+            <query value="insert-protocol=org.radargun.protocols.SLAVE_PARTITION=above=UDP"/>
+            <!-- Print information per protocol -->
+            <query value="jmx=NAKACK2"/>
+            <!-- Print information for the whole stack -->
+            <query value="jmx"/>
+         </queries>
+      </j-groups-probe>
+   </scenario>
+
+</benchmark>

--- a/plugins/infinispan70/src/main/java/org/radargun/service/Infinispan70EmbeddedService.java
+++ b/plugins/infinispan70/src/main/java/org/radargun/service/Infinispan70EmbeddedService.java
@@ -1,6 +1,9 @@
 package org.radargun.service;
 
+import org.infinispan.remoting.transport.jgroups.JGroupsTransport;
+import org.jgroups.protocols.TP;
 import org.radargun.Service;
+import org.radargun.config.Property;
 import org.radargun.traits.ProvidesTrait;
 
 /**
@@ -8,6 +11,28 @@ import org.radargun.traits.ProvidesTrait;
  */
 @Service(doc = InfinispanEmbeddedService.SERVICE_DESCRIPTION)
 public class Infinispan70EmbeddedService extends Infinispan60EmbeddedService {
+
+   @Property(doc = "Enable diagnostics port for service probing (true/false/null). Default is null - use settings from ISPN configuration.")
+   protected Boolean enableDiagnostics;
+
+   @Override
+   protected void startCaches() throws Exception {
+      super.startCaches();
+      setDiagnostics();
+   }
+
+   protected void setDiagnostics() {
+      JGroupsTransport transport = (JGroupsTransport) cacheManager.getTransport();
+      TP transportprotocol = (TP) transport.getChannel().getProtocolStack().findProtocol(TP.class);
+      if (Boolean.TRUE.equals(enableDiagnostics)) {
+         transportprotocol.enableDiagnostics();
+         log.debug("Enabling diagnostics in the transport protocol");
+      } else if (Boolean.FALSE.equals(enableDiagnostics)) {
+         transportprotocol.disableDiagnostics();
+         log.debug("Disabling diagnostics in the transport protocol");
+      }
+   }
+
    @SuppressWarnings("rawtypes")
    @Override
    @ProvidesTrait


### PR DESCRIPTION
* Enable JGroups tuning via probe. Just a preview, may implement additional features (e.g. scheduling specified query task - similar to JGroupsDumper, but more general).
* Added custom infinispan configuration, as enable_diagnostics property of TP needs to be enabled  