### PR TITLE
Revert "#242 Use also env. veriable for evaluting variables"

### DIFF
--- a/core/src/main/java/org/radargun/config/Evaluator.java
+++ b/core/src/main/java/org/radargun/config/Evaluator.java
@@ -149,8 +149,6 @@ public class Evaluator {
       String strValue = System.getProperty(property);
       if (strValue != null && !strValue.isEmpty()) {
          value = new Value(strValue.trim());
-      } else if (System.getenv().containsKey(property)) {
-         value = new Value(System.getenv(property).trim());
       } else {
          if (property.startsWith("env.")) {
             String env = System.getenv(property.substring(4));


### PR DESCRIPTION
This reverts commit c5554156969cac77123229a2e0c665e9dedb1f1a.

After further discussion with Radim, previous commit was a result
of misunderstanding of our prior conversation and enviroment
variables should always have previx `env.`. The only correct way
how to pass some variables to the scenario without `env.` prefix
is to use Java properties.