### PR TITLE
Add JDK 8 profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
       <plugins.jbosscache/>
       <plugins.jgroups/>
       <plugins.infinispan/>
+      <plugins.jdk18/>
       <plugins.jdg/>
       <plugins.coherence/>
       <plugins.process />
@@ -225,10 +226,24 @@
             <module>plugins/infinispan70</module>
             <module>plugins/infinispan71</module>
             <module>plugins/infinispan72</module>
+         </modules>
+         <properties>
+            <plugins.infinispan>infinispan4,infinispan50,infinispan51,infinispan52,infinispan53,infinispan60,infinispan70,infinispan71,infinispan72</plugins.infinispan>
+         </properties>
+      </profile>
+      <profile>
+         <id>jdk18</id>
+         <activation>
+            <jdk>1.8</jdk>
+            <property>
+               <name>!no-jdk18</name>
+            </property>
+         </activation>
+         <modules>
             <module>plugins/infinispan80</module>
          </modules>
          <properties>
-            <plugins.infinispan>infinispan4,infinispan50,infinispan51,infinispan52,infinispan53,infinispan60,infinispan70,infinispan71,infinispan72,infinispan80</plugins.infinispan>
+            <plugins.jdk18>infinispan80</plugins.jdk18>
          </properties>
       </profile>
       <profile>
@@ -466,7 +481,7 @@
                         </path>
 
                         <echo message="Packaging plugins: " />
-                        <ac:for list="${plugins.chm},${plugins.ehcache},${plugins.hazelcast},${plugins.jbosscache},${plugins.jgroups},${plugins.infinispan},${plugins.jdg},${plugins.coherence},${plugins.process},${plugins.spymemcached}" param="plugin" xmlns:ac="antlib:net.sf.antcontrib">
+                        <ac:for list="${plugins.chm},${plugins.ehcache},${plugins.hazelcast},${plugins.jbosscache},${plugins.jgroups},${plugins.infinispan},${plugins.jdk18},${plugins.jdg},${plugins.coherence},${plugins.process},${plugins.spymemcached}" param="plugin" xmlns:ac="antlib:net.sf.antcontrib">
                            <sequential>
                               <echo message="Packaging plugin @{plugin}..." />
                               <ac:if>


### PR DESCRIPTION
* This is required in order to skip build process of Java 8 based plugins (e.g. ISPN 8.x)