### PR TITLE
Scenario import from another file

### DIFF
--- a/core/src/main/java/org/radargun/LaunchMaster.java
+++ b/core/src/main/java/org/radargun/LaunchMaster.java
@@ -37,7 +37,7 @@ public class LaunchMaster {
       }
    }
 
-   private static String getConfigOrExit(String[] args) {
+   public static String getConfigOrExit(String[] args) {
       ArgsHolder.init(args, ArgsHolder.ArgType.LAUNCH_MASTER);
       if (ArgsHolder.getConfigFile() == null) {
          ArgsHolder.printUsageAndExit(ArgsHolder.ArgType.LAUNCH_MASTER);

--- a/core/src/main/java/org/radargun/Master.java
+++ b/core/src/main/java/org/radargun/Master.java
@@ -48,6 +48,10 @@ public class Master {
       Runtime.getRuntime().addShutdownHook(new ShutDownHook("Master process"));
    }
 
+   public MasterConfig getMasterConfig() {
+      return masterConfig;
+   }
+
    public void run() throws Exception {
       try {
          connection = new RemoteSlaveConnection(masterConfig.getMaxClusterSize(), masterConfig.getHost(), masterConfig.getPort());

--- a/core/src/main/java/org/radargun/Master.java
+++ b/core/src/main/java/org/radargun/Master.java
@@ -109,7 +109,7 @@ public class Master {
                }
             }
             log.info("Finished benchmarking configuration '" + configuration.name + "' in "
-                  + Utils.getMillisDurationString(TimeService.currentTimeMillis() - configStart));
+                    + Utils.getMillisDurationString(TimeService.currentTimeMillis() - configStart));
             if (exitFlag) {
                log.info("Exiting whole benchmark");
                break;
@@ -159,7 +159,7 @@ public class Master {
 
       if (result == StageResult.SUCCESS) {
          return stageId + 1;
-      } else if (result == StageResult.FAIL || result == StageResult.EXIT){
+      } else if (result == StageResult.FAIL || result == StageResult.EXIT) {
          returnCode = masterConfig.getConfigurations().indexOf(configuration) + 1;
          if (result == StageResult.EXIT) {
             exitFlag = true;

--- a/core/src/main/java/org/radargun/config/ConfigSchema.java
+++ b/core/src/main/java/org/radargun/config/ConfigSchema.java
@@ -17,6 +17,7 @@ interface ConfigSchema {
    String ATTR_TO = "to";
    String ATTR_TIMES = "times";
    String ATTR_TYPE = "type";
+   String ATTR_URL = "url";
 
    String ELEMENT_BENCHMARK = "benchmark";
    String ELEMENT_CLEANUP = "cleanup";
@@ -36,4 +37,5 @@ interface ConfigSchema {
    String ELEMENT_SCENARIO = "scenario";
    String ELEMENT_SETUP = "setup";
    String ELEMENT_VM_ARGS = "vm-args";
+   String ELEMENT_SCENARIO_COMPLEX = "scenarioComplex";
 }

--- a/core/src/main/java/org/radargun/config/Scenario.java
+++ b/core/src/main/java/org/radargun/config/Scenario.java
@@ -24,6 +24,10 @@ public class Scenario implements Serializable {
    private List<StageDescription> stages = new ArrayList<>();
    private Map<String, Integer> labels = new HashMap<>();
 
+   public List<StageDescription> getStages() {
+      return stages;
+   }
+
    /**
     * @param stageClass
     * @param properties Stage's attributes as written in configuration - evaluation takes place on slave.
@@ -112,7 +116,7 @@ public class Scenario implements Serializable {
       return id == null ? -1 : id;
    }
 
-   private static class StageDescription implements Serializable {
+   public static class StageDescription implements Serializable {
       Class<? extends org.radargun.Stage> stageClass;
       /* Common properties as specified in configuraion */
       Map<String, Definition> properties;

--- a/core/src/main/java/org/radargun/config/Scenario.java
+++ b/core/src/main/java/org/radargun/config/Scenario.java
@@ -31,8 +31,8 @@ public class Scenario implements Serializable {
    /**
     * @param stageClass
     * @param properties Stage's attributes as written in configuration - evaluation takes place on slave.
-    * @param labelName Label that should be used together with stage-defined prefix and suffix to uniquely
-    *                  identify this stage in the scenario. Can be null.
+    * @param labelName  Label that should be used together with stage-defined prefix and suffix to uniquely
+    *                   identify this stage in the scenario. Can be null.
     */
    public void addStage(Class<? extends Stage> stageClass, Map<String, Definition> properties, String labelName) {
       org.radargun.config.Stage annotation = stageClass.getAnnotation(org.radargun.config.Stage.class);
@@ -52,10 +52,10 @@ public class Scenario implements Serializable {
    /**
     * Get instance of stage with given ID, using additional properties (evaluable as ${foo}) from localExtras.
     *
-    * @param stageId ID of the executed stage.
-    * @param state Master's or slave's state - used to resolve the properties.
+    * @param stageId     ID of the executed stage.
+    * @param state       Master's or slave's state - used to resolve the properties.
     * @param localExtras Additional properties that could be used for property value resolution.
-    * @param report Report where the stage execution should be recorded.
+    * @param report      Report where the stage execution should be recorded.
     * @return Instance of the stage with properties set (not initialized and not injected with traits yet).
     */
    public org.radargun.Stage getStage(int stageId, StateBase state, Map<String, String> localExtras, Report report) {
@@ -67,7 +67,7 @@ public class Scenario implements Serializable {
          throw new RuntimeException("Cannot instantiate " + description.stageClass.getName(), e);
       }
       PropertyHelper.setPropertiesFromDefinitions(stage, description.properties,
-            localExtras, state != null ? state.asStringMap() : Collections.EMPTY_MAP);
+              localExtras, state != null ? state.asStringMap() : Collections.EMPTY_MAP);
 
       if (report != null) {
          Report.Stage reportStage = report.addStage(stage.getName());

--- a/core/src/main/java/org/radargun/config/ScenarioSchemaGenerator.java
+++ b/core/src/main/java/org/radargun/config/ScenarioSchemaGenerator.java
@@ -1,0 +1,114 @@
+package org.radargun.config;
+
+import org.radargun.Stage;
+import org.w3c.dom.Element;
+
+import java.lang.reflect.Modifier;
+import java.util.*;
+
+/**
+ * Generates XSD file describing RadarGun 3.0 scenario configuration.
+ * This file is expected to be run from command-line, or rather
+ * build script.
+ *
+ * @author Roman Macor &lt;rmacor@redhat.com&gt;
+ */
+public class ScenarioSchemaGenerator extends SchemaGenerator implements ConfigSchema {
+   private static final String TYPE_REPEAT = "repeat";
+   private static final String TYPE_STAGES = "stages";
+   private static final String VERSION = ConfigSchemaGenerator.VERSION;
+
+   private static Map<Class<? extends org.radargun.Stage>, String> stages = new TreeMap<>(new Comparator<Class<? extends org.radargun.Stage>>() {
+      @Override
+      public int compare(Class<? extends org.radargun.Stage> o1, Class<? extends Stage> o2) {
+         int c = o1.getSimpleName().compareTo(o2.getSimpleName());
+         return c != 0 ? c : o1.getCanonicalName().compareTo(o2.getCanonicalName());
+      }
+   });
+
+   @Override
+   protected String findDocumentation(Class<?> clazz) {
+      org.radargun.config.Stage stageAnnotation = clazz.getAnnotation(org.radargun.config.Stage.class);
+      if (stageAnnotation != null) return stageAnnotation.doc();
+      return null;
+   }
+
+   /**
+    * Generates scenario scheme file
+    */
+   @Override
+   protected void generate() {
+      Element schema = createSchemaElement("radargun-scenario:benchmark:" + VERSION);
+
+      intType = generateSimpleType(int.class, DefaultConverter.class);
+
+      Element scenarioElement = doc.createElementNS(NS_XS, XS_ELEMENT);
+      scenarioElement.setAttribute(XS_NAME, ELEMENT_SCENARIO);
+      schema.appendChild(scenarioElement);
+
+      Element scenarioComplex = createComplexType(schema, ELEMENT_SCENARIO_COMPLEX, RG_PREFIX + TYPE_STAGES, true, false, null);
+      createReference(schema, ELEMENT_SCENARIO_COMPLEX, RG_PREFIX + ELEMENT_SCENARIO_COMPLEX);
+
+      addAttribute(scenarioComplex, ATTR_URL, false);
+      scenarioElement.setAttribute(XS_TYPE, RG_PREFIX + ELEMENT_SCENARIO_COMPLEX);
+
+      Element stagesType = createComplexType(schema, TYPE_STAGES, null, true, true, null);
+      Element stagesChoice = createChoice(createSequence(stagesType), 1, -1);
+
+      Element repeatType = createComplexType(schema, TYPE_REPEAT, RG_PREFIX + TYPE_STAGES, true, false, null);
+      addAttribute(repeatType, ATTR_TIMES, intType, null, false);
+      addAttribute(repeatType, ATTR_FROM, intType, null, false);
+      addAttribute(repeatType, ATTR_TO, intType, null, false);
+      addAttribute(repeatType, ATTR_INC, intType, null, false);
+      addAttribute(repeatType, ATTR_NAME, false);
+      createReference(stagesChoice, ELEMENT_REPEAT, RG_PREFIX + TYPE_REPEAT);
+
+      generateStageDefinitions(new Element[]{stagesChoice});
+
+   }
+
+   private void generateStageDefinitions(Element[] parents) {
+      Set<Class<? extends Stage>> generatedStages = new HashSet<>();
+      for (Map.Entry<Class<? extends Stage>, String> entry : stages.entrySet()) {
+         generateStage(parents, entry.getKey(), generatedStages);
+      }
+   }
+
+   private void generateStage(Element[] parents, Class stage, Set<Class<? extends Stage>> generatedStages) {
+      if (generatedStages.contains(stage)) return;
+      boolean hasParentStage = Stage.class.isAssignableFrom(stage.getSuperclass());
+      if (hasParentStage) {
+         generateStage(parents, stage.getSuperclass(), generatedStages);
+      }
+      org.radargun.config.Stage stageAnnotation = (org.radargun.config.Stage) stage.getAnnotation(org.radargun.config.Stage.class);
+      if (stageAnnotation == null) return; // not a proper stage
+
+      String stageType = generateClass(stage);
+      if (!Modifier.isAbstract(stage.getModifiers()) && !stageAnnotation.internal()) {
+         for (Element parent : parents) {
+            createReference(parent, XmlHelper.camelCaseToDash(StageHelper.getStageName(stage)), stageType);
+         }
+         if (!stageAnnotation.deprecatedName().equals(org.radargun.config.Stage.NO_DEPRECATED_NAME)) {
+            for (Element parent : parents) {
+               createReference(parent, XmlHelper.camelCaseToDash(stageAnnotation.deprecatedName()), stageType);
+            }
+         }
+      }
+      generatedStages.add(stage);
+   }
+
+   /**
+    * Generate the XSD file for scenario. First argument is directory where the XSD file should be placed
+    * (it will be named radargunScenario-{version}.xsd.
+    */
+   public static void main(String[] args) {
+      if (args.length < 1 || args[0] == null)
+         throw new IllegalArgumentException("No schema location directory specified!");
+      System.out.println("ConfigSchemaGenerator argument" + args[0]);
+      for (Class<? extends org.radargun.Stage> stage : StageHelper.getStages().values()) {
+         stages.put(stage, stage.getProtectionDomain().getCodeSource().getLocation().getPath());
+      }
+      new ScenarioSchemaGenerator().generate(args[0], String.format("radargunScenario-%s.xsd", VERSION));
+
+   }
+}

--- a/core/src/main/java/org/radargun/config/SchemaGenerator.java
+++ b/core/src/main/java/org/radargun/config/SchemaGenerator.java
@@ -1,5 +1,14 @@
 package org.radargun.config;
 
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.*;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.PrintWriter;
@@ -8,20 +17,6 @@ import java.lang.reflect.Modifier;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.transform.OutputKeys;
-import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerConfigurationException;
-import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.dom.DOMSource;
-import javax.xml.transform.stream.StreamResult;
-
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
 
 /**
  * Base class for generators of schemas.
@@ -65,6 +60,8 @@ public abstract class SchemaGenerator {
    protected static final String XS_DOCUMENTATION = "documentation";
    protected static final String XS_NAMESPACE = "namespace";
    protected static final String XS_OTHER_NAMESPACE = "##other";
+   protected static final String XS_INCLUDE = "include";
+   protected static final String XS_SCHEMA_LOCATION = "schemaLocation";
 
    protected Document doc;
    protected Element schema;
@@ -91,7 +88,7 @@ public abstract class SchemaGenerator {
       schema.appendChild(doc.createComment("From " + source));
 
       Element typeElement = createComplexType(schema, typeName, superType, true,
-            Modifier.isAbstract(clazz.getModifiers()), findDocumentation(clazz));
+              Modifier.isAbstract(clazz.getModifiers()), findDocumentation(clazz));
       Element propertiesSequence = createSequence(typeElement);
       for (Map.Entry<String, Path> property : PropertyHelper.getDeclaredProperties(clazz, true, true).entrySet()) {
          generateProperty(typeElement, propertiesSequence, property.getKey(), property.getValue(), true);
@@ -252,7 +249,7 @@ public abstract class SchemaGenerator {
             converter = ctor.newInstance();
          } catch (Exception e) {
             System.err.printf("Cannot instantiate converter service %s: %s",
-                  converterClass.getName(), e.getMessage());
+                    converterClass.getName(), e.getMessage());
             return XS_STRING;
          }
          Element propertyPattern = doc.createElementNS(NS_XS, XS_PATTERN);
@@ -440,6 +437,8 @@ public abstract class SchemaGenerator {
       doc.appendChild(schema);
       return schema;
    }
-
+   /**
+    * Generates scheme file
+    */
    protected abstract void generate();
 }

--- a/core/src/test/java/org/radargun/config/AbstractConfigurationTest.java
+++ b/core/src/test/java/org/radargun/config/AbstractConfigurationTest.java
@@ -1,0 +1,238 @@
+package org.radargun.config;
+
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
+import org.powermock.modules.testng.PowerMockTestCase;
+import org.radargun.LaunchMaster;
+import org.radargun.logging.Log;
+import org.radargun.logging.LogFactory;
+import org.radargun.reporting.ReporterHelper;
+import org.radargun.stages.control.RepeatBeginStage;
+import org.radargun.stages.control.RepeatContinueStage;
+import org.radargun.stages.control.RepeatEndStage;
+import org.radargun.stages.lifecycle.ServiceStartStage;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.util.*;
+
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.*;
+
+/**
+ * Tests parsing of benchmark configuration file
+ *
+ * @author Roman Macor &lt;rmacor@redhat.com&gt;
+ */
+@Test
+@PowerMockIgnore({"javax.management.*"})
+@PrepareForTest(StageHelper.class)
+@SuppressStaticInitializationFor({"org.radargun.config.StageHelper", "org.radargun.reporting.ReporterHelper"})
+public abstract class AbstractConfigurationTest extends PowerMockTestCase {
+   protected static Log log = LogFactory.getLog(AbstractConfigurationTest.class);
+   protected MasterConfig masterConfig;
+   protected List<String> resources = new ArrayList<>();
+
+   protected abstract String getBenchmark();
+
+   /**
+    * Copies resources to the testing directory (such as benchmark file or scenario file)
+    * Parses benchmark file and mocks classes that are irrelevant to the tests
+    *
+    * @throws Exception
+    */
+   @BeforeClass
+   public void setUpClass() throws Exception {
+
+      PowerMockito.field(ReporterHelper.class, "reporters").set(ReporterHelper.class, mock(HashMap.class));
+
+      DomConfigParser configParser = Mockito.mock(DomConfigParser.class, CALLS_REAL_METHODS);
+      PowerMockito.mockStatic(StageHelper.class);
+      PowerMockito.when(StageHelper.getStageClassByDashedName(anyString())).thenAnswer(new Answer<Class<ServiceStartStage>>() {
+         @Override
+         public Class<ServiceStartStage> answer(InvocationOnMock invocationOnMock) throws Throwable {
+            return ServiceStartStage.class;
+         }
+      });
+      resources.add(getBenchmark());
+      copyResources();
+      String[] masterArgs = {"--config", getBenchmark()};
+      String config = LaunchMaster.getConfigOrExit(masterArgs);
+
+      log.info("Configuration file is: " + config);
+      log.info("Current directory is " + System.getProperty("user.dir"));
+
+      masterConfig = configParser.parseConfig(config);
+   }
+
+   /**
+    * Removes resource files that were copied to the testing directory in setUpClass method
+    */
+   @AfterClass
+   public void cleanUp() {
+      for (String file : resources) {
+         File benchmarkFile = new File(System.getProperty("user.dir") + File.separator + file);
+         benchmarkFile.delete();
+      }
+   }
+
+   /**
+    * Tests correct parsing of configuration
+    */
+   public void testConfiguration() {
+      List<Configuration> configurations = masterConfig.getConfigurations();
+
+      assertEquals(configurations.size(), 2);
+
+      Configuration infinispan52 = configurations.get(0);
+      assertEquals(infinispan52.name, "Infinispan 5.2 - distributed");
+
+      Configuration infinispan60 = configurations.get(1);
+      assertEquals(infinispan60.name, "Infinispan 6.0 - distributed");
+
+      assertConfiguration(infinispan52, "infinispan52");
+      assertConfiguration(infinispan60, "infinispan60");
+   }
+
+   /**
+    * Helper method to tests correct parsing of configuration
+    *
+    * @param configuration      benchmark configuration
+    * @param expectedPluginName plugin name
+    */
+   private void assertConfiguration(Configuration configuration, String expectedPluginName) {
+      assertEquals(configuration.getSetups().size(), 1);
+      Configuration.Setup setup = configuration.getSetups().get(0);
+
+      assertEquals(setup.plugin.toString(), expectedPluginName);
+      assertEquals(setup.service.toString(), "embedded");
+
+      assertEquals(setup.getProperties().size(), 1);
+      assertEquals(setup.getVmArgs().size(), 1);
+
+      assertTrue(setup.getProperties().containsKey("file"));
+      assertEquals(setup.getProperties().get("file").toString(), "dist-sync.xml");
+
+      assertTrue(setup.getVmArgs().containsKey("memory"));
+      assertEquals(setup.getVmArgs().get("memory").toString(), "max=4G");
+   }
+
+   /**
+    * Tests correct parsing of configuration
+    */
+   public void testHost() {
+      String host = masterConfig.getHost();
+      int port = masterConfig.getPort();
+      assertEquals(host, "127.0.0.1");
+      assertEquals(port, 2103);
+   }
+
+   /**
+    * Tests correct parsing of plugins configuration
+    */
+   public void testPlugins() {
+      Set<String> plugins = masterConfig.getPlugins();
+
+      assertEquals(plugins.size(), 2);
+
+      assertTrue(plugins.contains("infinispan52"));
+      assertTrue(plugins.contains("infinispan60"));
+   }
+
+   /**
+    * Tests correct parsing of clusters configuration
+    */
+   public void testClusters() {
+      List<Cluster> clusters = masterConfig.getClusters();
+
+      assertEquals(clusters.size(), 2);
+
+      assertEquals(clusters.get(0).toString(), "Cluster[default=2]");
+      assertEquals(clusters.get(1).toString(), "Cluster[default=3]");
+
+      assertEquals(masterConfig.getMaxClusterSize(), 3);
+   }
+
+   /**
+    * Tests correct parsing of scenario configuration
+    */
+   public void testScenario() {
+      Scenario scenario = masterConfig.getScenario();
+      assertEquals(scenario.getStageCount(), 14);
+      List<Scenario.StageDescription> stages = scenario.getStages();
+
+      Map<String, Definition> basicOperationTestProperties = stages.get(4).properties;
+      assertEquals(basicOperationTestProperties.size(), 4);
+
+      assertTrue(basicOperationTestProperties.containsKey("test-name"));
+      assertTrue(basicOperationTestProperties.containsKey("num-threads-per-node"));
+      assertTrue(basicOperationTestProperties.containsKey("num-requests"));
+      assertTrue(basicOperationTestProperties.containsKey("key-selector"));
+
+      for (Scenario.StageDescription stage : stages) {
+         Map<String, Definition> properties = stage.properties;
+         if (stage.stageClass.equals(RepeatBeginStage.class) || stage.stageClass.equals(RepeatContinueStage.class) ||
+                 stage.stageClass.equals(RepeatEndStage.class))
+            assertRepeatProperties(properties);
+      }
+   }
+
+   /**
+    * Tests correct parsing of repeat properties
+    *
+    * @param properties repeat stage properties
+    */
+   private void assertRepeatProperties(Map<String, Definition> properties) {
+      assertEquals(properties.size(), 3);
+
+      assertTrue(properties.containsKey("from"));
+      assertTrue(properties.containsKey("to"));
+      assertTrue(properties.containsKey("inc"));
+
+      assertFalse(properties.containsKey("madeUp"));
+
+      assertEquals(properties.get("from").toString(), "10");
+      assertEquals(properties.get("to").toString(), "30");
+      assertEquals(properties.get("inc").toString(), "10");
+   }
+
+   /**
+    * Tests correct parsing of report configuration
+    */
+   public void testReport() {
+      List<ReporterConfiguration> reporters = masterConfig.getReporters();
+
+      assertEquals(reporters.size(), 3);
+      assertEquals(reporters.get(0).type, "csv");
+      assertEquals(reporters.get(1).type, "html");
+      assertEquals(reporters.get(2).type, "serialized");
+   }
+
+   /**
+    * Copies resources to the current directory
+    *
+    * @throws IOException if file can not be copied
+    */
+   protected void copyResources() {
+      ClassLoader classLoader = getClass().getClassLoader();
+      for (String file : resources) {
+         try (InputStream source = classLoader.getResourceAsStream(file)) {
+            File destination = new File(System.getProperty("user.dir") + File.separator + file);
+            Files.copy(source, destination.toPath(), StandardCopyOption.REPLACE_EXISTING);
+         } catch (Exception e) {
+            log.error("Exception while copying resources", e);
+         }
+      }
+   }
+}

--- a/core/src/test/java/org/radargun/config/ConfigurationWithImportedScenarioFromAnotherBenchmarkTest.java
+++ b/core/src/test/java/org/radargun/config/ConfigurationWithImportedScenarioFromAnotherBenchmarkTest.java
@@ -1,0 +1,17 @@
+package org.radargun.config;
+
+/**
+ * Variation of AbstractConfigurationTest when scenario is imported from another benchmark file
+ *
+ * @author Roman Macor &lt;rmacor@redhat.com&gt;
+ */
+public class ConfigurationWithImportedScenarioFromAnotherBenchmarkTest extends AbstractConfigurationTest {
+   public ConfigurationWithImportedScenarioFromAnotherBenchmarkTest() {
+      resources.add("benchmark-test.xml");
+   }
+
+   @Override
+   protected String getBenchmark() {
+      return "benchmark-importedScenarioFromAnotherBenchmark.xml";
+   }
+}

--- a/core/src/test/java/org/radargun/config/ConfigurationWithImportedScenarioFromDesignatedScenarioFileTest.java
+++ b/core/src/test/java/org/radargun/config/ConfigurationWithImportedScenarioFromDesignatedScenarioFileTest.java
@@ -1,0 +1,18 @@
+package org.radargun.config;
+
+/**
+ * Variation of AbstractConfigurationTest when scenario is imported from file that contains only scenario
+ *
+ * @author Roman Macor &lt;rmacor@redhat.com&gt;
+ */
+public class ConfigurationWithImportedScenarioFromDesignatedScenarioFileTest extends AbstractConfigurationTest {
+
+   public ConfigurationWithImportedScenarioFromDesignatedScenarioFileTest() {
+      resources.add("designatedScenarioFile.xml");
+   }
+
+   @Override
+   protected String getBenchmark() {
+      return "benchmark-importedScenarioFromDesignatedScenarioFile.xml";
+   }
+}

--- a/core/src/test/java/org/radargun/config/ConfigurationWithScenarioInFileTest.java
+++ b/core/src/test/java/org/radargun/config/ConfigurationWithScenarioInFileTest.java
@@ -1,0 +1,14 @@
+package org.radargun.config;
+
+/**
+ * Variation of AbstractConfigurationTest when scenario is not imported
+ *
+ * @author Roman Macor &lt;rmacor@redhat.com&gt;
+ */
+public class ConfigurationWithScenarioInFileTest extends AbstractConfigurationTest {
+
+   @Override
+   protected String getBenchmark() {
+      return "benchmark-test.xml";
+   }
+}

--- a/core/src/test/java/org/radargun/config/ConfigurationWithURLImportedScenarioTest.java
+++ b/core/src/test/java/org/radargun/config/ConfigurationWithURLImportedScenarioTest.java
@@ -1,0 +1,14 @@
+package org.radargun.config;
+
+/**
+ * Variation of AbstractConfigurationTest when scenario is imported from URL
+ *
+ * @author Roman Macor &lt;rmacor@redhat.com&gt;
+ */
+public class ConfigurationWithURLImportedScenarioTest extends AbstractConfigurationTest {
+
+   @Override
+   protected String getBenchmark() {
+      return "benchmark-importedScenarioFromURL.xml";
+   }
+}

--- a/core/src/test/resources/benchmark-importedScenarioFromAnotherBenchmark.xml
+++ b/core/src/test/resources/benchmark-importedScenarioFromAnotherBenchmark.xml
@@ -1,0 +1,51 @@
+<!-- RadarGun 3.0 benchmark -->
+<benchmark xmlns="urn:radargun:benchmark:3.0">
+
+    <!-- Specifies where should the master open socket  -->
+    <master bindAddress="${master.address:127.0.0.1}" port="${master.port:2103}"/>
+
+    <!-- List of cluster configurations where the benchmark should run-->
+    <clusters>
+        <!-- Equivalent to <cluster size="2" /><cluster size="3" /> -->
+        <scale from="2" to="3" inc="1" >
+            <!-- No groups defined within the cluster -->
+            <cluster />
+        </scale>
+    </clusters>
+
+    <!-- List of configurations of the services -->
+    <configurations>
+        <config name="Infinispan 5.2 - distributed">
+            <!-- All slaves use the same configuration -->
+            <setup plugin="infinispan52">
+                <!-- You can set JVM arguments for slaves here. -->
+                <vm-args>
+                    <memory max="4G" />
+                </vm-args>
+                <embedded xmlns="urn:radargun:plugins:infinispan52:3.0" file="dist-sync.xml"/>
+            </setup>
+        </config>
+        <config name="Infinispan 6.0 - distributed">
+            <setup plugin="infinispan60">
+                <vm-args>
+                    <memory max="4G" />
+                </vm-args>
+                <embedded xmlns="urn:radargun:plugins:infinispan60:3.0" file="dist-sync.xml"/>
+            </setup>
+        </config>
+    </configurations>
+
+    <!-- Sequence of stages executed on the cluster -->
+    <scenario url="benchmark-test.xml"/>
+
+    <!-- How the statistics are reported -->
+    <reports>
+        <!-- Produce CSV statistics report -->
+        <reporter type="csv" />
+        <!-- Produce HTML statistics report -->
+        <reporter type="html" />
+        <!-- Store Java-serialized version of the results that can be used to re-run the report -->
+        <reporter type="serialized" />
+    </reports>
+
+</benchmark>

--- a/core/src/test/resources/benchmark-importedScenarioFromDesignatedScenarioFile.xml
+++ b/core/src/test/resources/benchmark-importedScenarioFromDesignatedScenarioFile.xml
@@ -1,0 +1,51 @@
+<!-- RadarGun 3.0 benchmark -->
+<benchmark xmlns="urn:radargun:benchmark:3.0">
+
+    <!-- Specifies where should the master open socket  -->
+    <master bindAddress="${master.address:127.0.0.1}" port="${master.port:2103}"/>
+
+    <!-- List of cluster configurations where the benchmark should run-->
+    <clusters>
+        <!-- Equivalent to <cluster size="2" /><cluster size="3" /> -->
+        <scale from="2" to="3" inc="1" >
+            <!-- No groups defined within the cluster -->
+            <cluster />
+        </scale>
+    </clusters>
+
+    <!-- List of configurations of the services -->
+    <configurations>
+        <config name="Infinispan 5.2 - distributed">
+            <!-- All slaves use the same configuration -->
+            <setup plugin="infinispan52">
+                <!-- You can set JVM arguments for slaves here. -->
+                <vm-args>
+                    <memory max="4G" />
+                </vm-args>
+                <embedded xmlns="urn:radargun:plugins:infinispan52:3.0" file="dist-sync.xml"/>
+            </setup>
+        </config>
+        <config name="Infinispan 6.0 - distributed">
+            <setup plugin="infinispan60">
+                <vm-args>
+                    <memory max="4G" />
+                </vm-args>
+                <embedded xmlns="urn:radargun:plugins:infinispan60:3.0" file="dist-sync.xml"/>
+            </setup>
+        </config>
+    </configurations>
+
+    <!-- Sequence of stages executed on the cluster -->
+    <scenario url="designatedScenarioFile.xml"/>
+
+    <!-- How the statistics are reported -->
+    <reports>
+        <!-- Produce CSV statistics report -->
+        <reporter type="csv" />
+        <!-- Produce HTML statistics report -->
+        <reporter type="html" />
+        <!-- Store Java-serialized version of the results that can be used to re-run the report -->
+        <reporter type="serialized" />
+    </reports>
+
+</benchmark>

--- a/core/src/test/resources/benchmark-importedScenarioFromURL.xml
+++ b/core/src/test/resources/benchmark-importedScenarioFromURL.xml
@@ -1,0 +1,51 @@
+<!-- RadarGun 3.0 benchmark -->
+<benchmark xmlns="urn:radargun:benchmark:3.0">
+
+    <!-- Specifies where should the master open socket  -->
+    <master bindAddress="${master.address:127.0.0.1}" port="${master.port:2103}"/>
+
+    <!-- List of cluster configurations where the benchmark should run-->
+    <clusters>
+        <!-- Equivalent to <cluster size="2" /><cluster size="3" /> -->
+        <scale from="2" to="3" inc="1" >
+            <!-- No groups defined within the cluster -->
+            <cluster />
+        </scale>
+    </clusters>
+
+    <!-- List of configurations of the services -->
+    <configurations>
+        <config name="Infinispan 5.2 - distributed">
+            <!-- All slaves use the same configuration -->
+            <setup plugin="infinispan52">
+                <!-- You can set JVM arguments for slaves here. -->
+                <vm-args>
+                    <memory max="4G" />
+                </vm-args>
+                <embedded xmlns="urn:radargun:plugins:infinispan52:3.0" file="dist-sync.xml"/>
+            </setup>
+        </config>
+        <config name="Infinispan 6.0 - distributed">
+            <setup plugin="infinispan60">
+                <vm-args>
+                    <memory max="4G" />
+                </vm-args>
+                <embedded xmlns="urn:radargun:plugins:infinispan60:3.0" file="dist-sync.xml"/>
+            </setup>
+        </config>
+    </configurations>
+
+    <!-- Sequence of stages executed on the cluster -->
+    <scenario url="https://raw.githubusercontent.com/radargun/radargun/master/core/src/main/resources/benchmark-dist.xml"/>
+
+    <!-- How the statistics are reported -->
+    <reports>
+        <!-- Produce CSV statistics report -->
+        <reporter type="csv" />
+        <!-- Produce HTML statistics report -->
+        <reporter type="html" />
+        <!-- Store Java-serialized version of the results that can be used to re-run the report -->
+        <reporter type="serialized" />
+    </reports>
+
+</benchmark>

--- a/core/src/test/resources/benchmark-test.xml
+++ b/core/src/test/resources/benchmark-test.xml
@@ -1,0 +1,85 @@
+<!-- RadarGun 3.0 benchmark -->
+<benchmark xmlns="urn:radargun:benchmark:3.0">
+
+   <!-- Specifies where should the master open socket  -->
+   <master bindAddress="${master.address:127.0.0.1}" port="${master.port:2103}"/>
+
+   <!-- List of cluster configurations where the benchmark should run-->
+   <clusters>
+      <!-- Equivalent to <cluster size="2" /><cluster size="3" /> -->
+      <scale from="2" to="3" inc="1" >
+         <!-- No groups defined within the cluster -->
+         <cluster />
+      </scale>
+   </clusters>
+
+   <!-- List of configurations of the services -->
+   <configurations>
+      <config name="Infinispan 5.2 - distributed">
+         <!-- All slaves use the same configuration -->
+         <setup plugin="infinispan52">
+            <!-- You can set JVM arguments for slaves here. -->
+            <vm-args>
+               <memory max="4G" />
+            </vm-args>
+            <embedded xmlns="urn:radargun:plugins:infinispan52:3.0" file="dist-sync.xml"/>
+         </setup>
+      </config>
+      <config name="Infinispan 6.0 - distributed">
+         <setup plugin="infinispan60">
+            <vm-args>
+               <memory max="4G" />
+            </vm-args>
+            <embedded xmlns="urn:radargun:plugins:infinispan60:3.0" file="dist-sync.xml"/>
+         </setup>
+      </config>
+   </configurations>
+
+   <!-- Sequence of stages executed on the cluster -->
+   <scenario>
+       <!--Start services on all nodes -->
+      <service-start />
+      <!-- Begin monitoring of CPU, memory usage and GC -->
+
+      <jvm-monitor-start />
+
+      <!-- Preload the cache with data -->
+      <load-data num-entries="5000"/>
+      <!-- 5 threads will execute total of 100,000 random requests against the default cache ('testCache')-->
+      <!-- As the test is called 'warmup', performance statistics won't be reported -->
+      <basic-operations-test test-name="warmup" num-requests="100000" num-threads-per-node="5">
+         <key-selector>
+            <concurrent-keys total-entries="5000" />
+         </key-selector>
+      </basic-operations-test>
+
+      <!-- Remove all data from the default cache -->
+      <clear-cache />
+      <!-- Again, preload the cache with data -->
+      <load-data num-entries="10000"/>
+
+      <!-- 10, 20 and 30 threads will execute random request for 1 minute against the default cache ('testCache') -->
+      <repeat from="10" to="30" inc="10">
+         <basic-operations-test test-name="stress-test" amend-test="true"
+                                duration="1m" num-threads-per-node="${repeat.counter}">
+            <key-selector>
+               <concurrent-keys total-entries="10000"/>
+            </key-selector>
+         </basic-operations-test>
+      </repeat>
+
+      <!--&lt;!&ndash; Stop JVM monitoring &ndash;&gt;-->
+      <jvm-monitor-stop />
+   </scenario>
+
+   <!-- How the statistics are reported -->
+   <reports>
+      <!-- Produce CSV statistics report -->
+      <reporter type="csv" />
+      <!-- Produce HTML statistics report -->
+      <reporter type="html" />
+      <!-- Store Java-serialized version of the results that can be used to re-run the report -->
+      <reporter type="serialized" />
+   </reports>
+
+</benchmark>

--- a/core/src/test/resources/designatedScenarioFile.xml
+++ b/core/src/test/resources/designatedScenarioFile.xml
@@ -1,0 +1,35 @@
+<scenario xmlns="urn:radargun-scenario:benchmark:3.0">
+    <!--Start services on all nodes -->
+    <service-start />
+    <!-- Begin monitoring of CPU, memory usage and GC -->
+
+    <jvm-monitor-start />
+
+    <!-- Preload the cache with data -->
+    <load-data num-entries="5000"/>
+    <!-- 5 threads will execute total of 100,000 random requests against the default cache ('testCache')-->
+    <!-- As the test is called 'warmup', performance statistics won't be reported -->
+    <basic-operations-test test-name="warmup" num-requests="100000" num-threads-per-node="5">
+        <key-selector>
+            <concurrent-keys total-entries="5000" />
+        </key-selector>
+    </basic-operations-test>
+
+    <!-- Remove all data from the default cache -->
+    <clear-cache />
+    <!-- Again, preload the cache with data -->
+    <load-data num-entries="10000"/>
+
+    <!-- 10, 20 and 30 threads will execute random request for 1 minute against the default cache ('testCache') -->
+    <repeat from="10" to="30" inc="10">
+        <basic-operations-test test-name="stress-test" amend-test="true"
+                               duration="1m" num-threads-per-node="${repeat.counter}">
+            <key-selector>
+                <concurrent-keys total-entries="10000"/>
+            </key-selector>
+        </basic-operations-test>
+    </repeat>
+
+    <!--&lt;!&ndash; Stop JVM monitoring &ndash;&gt;-->
+    <jvm-monitor-stop />
+</scenario>

--- a/pom.xml
+++ b/pom.xml
@@ -559,6 +559,10 @@
                            <sysproperty key="log4j.configuration" value="file:///${basedir}/core/target/distribution/radargun-core-bin/radargun-core/conf/log4j.xml" />
                            <arg value="${distribution.artifact}/schema" />
                         </java>
+                        <java classname="org.radargun.config.ScenarioSchemaGenerator" failonerror="true" classpathref="core_and_extensions">
+                           <sysproperty key="log4j.configuration" value="file:///${basedir}/core/target/distribution/radargun-core-bin/radargun-core/conf/log4j.xml" />
+                           <arg value="${distribution.artifact}/schema" />
+                        </java>
                         <copy todir="${distribution.artifact}/schema">
                            <fileset dir="." includes="*.xsd"/>
                         </copy>

--- a/radargunScenario-3.0.xsd
+++ b/radargunScenario-3.0.xsd
@@ -1,0 +1,1 @@
+target/distribution/RadarGun-3.0.0-SNAPSHOT/schema/radargunScenario-3.0.xsd


### PR DESCRIPTION
This PR will allow for scenario in benchmark configuration to be imported from another file. Import is possible from another benchmark file or from designated scenario file - containing only scenario. PR also creates separate XML scheme for scenario and tests for scenario parsing including tests for: scenario imported from URL, from another benchmark, from designated file and without scenario import.