### PR TITLE
Infinispan 8.x fixes - 2.x branch

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -14,7 +14,7 @@
 
    <properties>
       <version.log4j>1.2.16</version.log4j>
-      <version.log4j2>2.0-beta9</version.log4j2>
+      <version.log4j2>2.3</version.log4j2>
       <maven.test.skip>false</maven.test.skip>
    </properties>
 

--- a/core/src/main/java/org/radargun/config/InitHelper.java
+++ b/core/src/main/java/org/radargun/config/InitHelper.java
@@ -1,47 +1,110 @@
 package org.radargun.config;
 
+import org.radargun.logging.Log;
+import org.radargun.logging.LogFactory;
+
 import java.lang.reflect.Method;
-import java.util.Stack;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.LinkedList;
 
 /**
  * @author Radim Vansa &lt;rvansa@redhat.com&gt;
  */
 public class InitHelper {
+   private static final Log log = LogFactory.getLog(InitHelper.class);
+
    public static void init(Object target) {
-      if (target == null) throw new NullPointerException();
-      Stack<Method> inits = new Stack<Method>();
-      Class<?> clazz = target.getClass();
-      while (clazz != null) {
-         for (Method m : clazz.getDeclaredMethods()) {
-            if (m.getAnnotation(Init.class) != null) {
-               inits.push(m);
-            }
-         }
-         clazz = clazz.getSuperclass();
-      }
-      while (!inits.isEmpty()) {
-         try {
-            inits.pop().invoke(target);
-         } catch (Exception e) {
-            throw new RuntimeException(e);
-         }
-      }
+      processAnnotatedMethods(target, Init.class, false);
    }
 
    public static void destroy(Object target) {
+      processAnnotatedMethods(target, Destroy.class, true);
+   }
+
+   /**
+    * Looks for annotated methods of given type in the class hierarchy of given object and invokes them in specified
+    * order. The behavior is as follows:
+    *
+    * <ol>
+    *    <li>1. If overriden methods are detected, only the most specific one is invoked. This is generally aplicable.</li>
+    *    <li>2. If superclass contains annotated method, which is overriden in a sublclass and overriding method is not annotated,
+    *    invoke subclass method in place of superclass method (respecting superclass method priority).</li>
+    *    <li>2. If superclass contains annotated method, which is overriden in a sublclass and overriding method is annotated,
+    *    invoke subclass method only (respecting subclass method priority). Superclass method is not invoked</li>
+    * </ol>
+    *
+    * e.g.
+    * class A {
+    *    @Init
+    *    void foo() {
+    *       System.out.print("A");
+    *    }
+    * }
+    *
+    * class B extends A {
+    *    @Init
+    *    void fooB() {
+    *       System.out.print("B");
+    *    }
+    * }
+    *
+    * class C extends A {
+    *    @Override
+    *    void foo() {
+    *       System.out.print("C");
+    *    }
+    * }
+    *
+    *class D extends B {
+    *    @Init
+    *    @Override
+    *    void foo() {
+    *       System.out.print("D");
+    *    }
+    * }
+    *
+    * <ul>
+    *    <li>Invoking processAnnotatedMethods(new A(), Init.class, false) prints "A"</li>
+    *    <li>Invoking processAnnotatedMethods(new B(), Init.class, false) prints "AB"</li>
+    *    <li>Invoking processAnnotatedMethods(new C(), Init.class, false) prints "CB"</li>
+    *    <li>Invoking processAnnotatedMethods(new D(), Init.class, false) prints "BD"</li>
+    * </ul>
+    *
+    * @param target Object to invoke annotated methods on
+    * @param annotationClass Target annotation class to look for
+    * @param specializedClassFirst If set to true, annotated methods will be invoked in bottom-up approach
+    */
+   private static void processAnnotatedMethods(Object target, Class annotationClass, boolean specializedClassFirst) {
       if (target == null) throw new NullPointerException();
+      LinkedList<Method> annotatedMethods = new LinkedList<>();
       Class<?> clazz = target.getClass();
       while (clazz != null) {
          for (Method m : clazz.getDeclaredMethods()) {
-            if (m.getAnnotation(Destroy.class) != null) {
-               try {
-                  m.invoke(target);
-               } catch (Exception e) {
-                  throw new RuntimeException(e);
+            if (m.getAnnotation(annotationClass) != null) {
+               boolean overridden = false;
+               for (Method m2 : annotatedMethods) {
+                  if (m2.getName().equals(m.getName())
+                        && Arrays.equals(m2.getGenericParameterTypes(), m.getGenericParameterTypes())) {
+                     log.warnf("Method %s overrides %s but both are declared with @%s annotation: calling only once", m2, m, annotationClass.getSimpleName());
+                     overridden = true;
+                  }
+               }
+               m.setAccessible(true);
+               if (!overridden) {
+                  annotatedMethods.add(m);
                }
             }
          }
          clazz = clazz.getSuperclass();
+      }
+      Iterator<Method> iterator = specializedClassFirst ? annotatedMethods.listIterator() : annotatedMethods.descendingIterator();
+      while (iterator.hasNext()) {
+         try {
+            iterator.next().invoke(target);
+         } catch (Exception e) {
+            throw new RuntimeException(e);
+         }
       }
    }
 }

--- a/core/src/main/java/org/radargun/logging/Log4j2Log.java
+++ b/core/src/main/java/org/radargun/logging/Log4j2Log.java
@@ -42,7 +42,10 @@ public final class Log4j2Log implements Log {
 
    @Override
    public final void tracef(String format, Object... args) {
-      getLogger().trace(format, args);
+      Logger logger = getLogger();
+      if (logger.isTraceEnabled()) {
+         logger.trace(String.format(format, args));
+      }
    }
 
    @Override
@@ -68,7 +71,10 @@ public final class Log4j2Log implements Log {
 
    @Override
    public void debugf(String format, Object... args) {
-      getLogger().debug(format, args);
+      Logger logger = getLogger();
+      if (logger.isDebugEnabled()) {
+         logger.debug(String.format(format, args));
+      }
    }
 
    @Override
@@ -94,7 +100,10 @@ public final class Log4j2Log implements Log {
 
    @Override
    public void infof(String format, Object... args) {
-      getLogger().info(format, args);
+      Logger logger = getLogger();
+      if (logger.isInfoEnabled()) {
+         logger.info(String.format(format, args));
+      }
    }
 
    @Override
@@ -120,7 +129,10 @@ public final class Log4j2Log implements Log {
 
    @Override
    public void warnf(String format, Object... args) {
-      getLogger().warn(format, args);
+      Logger logger = getLogger();
+      if (logger.isWarnEnabled()) {
+         logger.warn(String.format(format, args));
+      }
    }
 
    @Override
@@ -146,7 +158,10 @@ public final class Log4j2Log implements Log {
 
    @Override
    public void errorf(String format, Object... args) {
-      getLogger().error(format, args);
+      Logger logger = getLogger();
+      if (logger.isErrorEnabled()) {
+         logger.error(String.format(format, args));
+      }
    }
 
    @Override
@@ -172,7 +187,10 @@ public final class Log4j2Log implements Log {
 
    @Override
    public void fatalf(String format, Object... args) {
-      getLogger().fatal(format, args);
+      Logger logger = getLogger();
+      if (logger.isFatalEnabled()) {
+         logger.fatal(String.format(format, args));
+      }
    }
 
    @Override

--- a/core/src/main/java/org/radargun/logging/PerNodeRollingRandomAccessFileAppender.java
+++ b/core/src/main/java/org/radargun/logging/PerNodeRollingRandomAccessFileAppender.java
@@ -6,6 +6,7 @@ import java.io.Serializable;
 import org.apache.logging.log4j.core.ErrorHandler;
 import org.apache.logging.log4j.core.Filter;
 import org.apache.logging.log4j.core.Layout;
+import org.apache.logging.log4j.core.LifeCycle;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.appender.RollingRandomAccessFileAppender;
 import org.apache.logging.log4j.core.appender.rolling.RolloverStrategy;
@@ -39,6 +40,7 @@ public final class PerNodeRollingRandomAccessFileAppender implements org.apache.
          @PluginAttribute("append") final String append,
          @PluginAttribute("name") final String name,
          @PluginAttribute("immediateFlush") final String immediateFlush,
+         @PluginAttribute("bufferSizeStr") final String bufferSizeStr,
          @PluginElement("Policy") final TriggeringPolicy policy,
          @PluginElement("Strategy") RolloverStrategy strategy,
          @PluginElement("Layout") Layout<? extends Serializable> layout,
@@ -48,8 +50,8 @@ public final class PerNodeRollingRandomAccessFileAppender implements org.apache.
          @PluginAttribute("advertiseURI") final String advertiseURI,
          @PluginConfiguration final Configuration config) {
       RollingRandomAccessFileAppender appender = RollingRandomAccessFileAppender.createAppender(
-            appendNodeIndex(fileName), appendNodeIndex(filePattern), append, name, immediateFlush, policy, strategy,
-            layout, filter, ignore, advertise, advertiseURI, config);
+            appendNodeIndex(fileName), appendNodeIndex(filePattern), append, name, immediateFlush, bufferSizeStr, policy,
+            strategy, layout, filter, ignore, advertise, advertiseURI, config);
       return new PerNodeRollingRandomAccessFileAppender(appender);
    }
 
@@ -101,6 +103,11 @@ public final class PerNodeRollingRandomAccessFileAppender implements org.apache.
    }
 
    @Override
+   public State getState() {
+      return appender.getState();
+   }
+
+   @Override
    public void start() {
       appender.start();
    }
@@ -113,5 +120,10 @@ public final class PerNodeRollingRandomAccessFileAppender implements org.apache.
    @Override
    public boolean isStarted() {
       return appender.isStarted();
+   }
+
+   @Override
+   public boolean isStopped() {
+      return appender.isStopped();
    }
 }

--- a/core/src/test/java/org/radargun/config/InitDestroyTest.java
+++ b/core/src/test/java/org/radargun/config/InitDestroyTest.java
@@ -1,0 +1,154 @@
+package org.radargun.config;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+
+import static org.testng.Assert.*;
+
+/**
+ * @author Radim Vansa &lt;rvansa@redhat.com&gt;
+ */
+@Test
+public class InitDestroyTest {
+   public static class A {
+      public ArrayList<Integer> invocations = new ArrayList<>();
+
+      @Init
+      public void init1() {
+         invocations.add(1);
+      }
+
+      @Init
+      public void init2() {
+         invocations.add(2);
+      }
+
+      @Destroy
+      public void destroy1() {
+         invocations.add(-1);
+      }
+
+      @Destroy
+      public void destroy2() {
+         invocations.add(-2);
+      }
+   }
+
+   public static class B extends A {
+      @Init
+      public void init3() {
+         invocations.add(3);
+      }
+
+      @Destroy
+      public void destroy3() {
+         invocations.add(-3);
+      }
+   }
+
+   public static class C extends B {
+      @Override
+      public void init1() {
+         invocations.add(4);
+      }
+
+      @Override
+      public void destroy1() {
+         invocations.add(-4);
+      }
+   }
+
+   public static class D extends B {
+      @Init
+      @Override
+      public void init1() {
+         invocations.add(4);
+      }
+
+      @Destroy
+      @Override
+      public void destroy1() {
+         invocations.add(-4);
+      }
+   }
+
+   public static class E {
+      public ArrayList<Integer> invocations = new ArrayList<>();
+
+      @Init
+      private void init1() {
+         invocations.add(1);
+      }
+
+      @Destroy
+      private void destroy1() {
+         invocations.add(-1);
+      }
+   }
+
+   public void testB() {
+      B b = new B();
+      List<Integer> expected = Arrays.asList(1, 2, 3);
+      InitHelper.init(b);
+      assertEquals(b.invocations.size(), 3);
+      assertListEqualsPermuted(b.invocations, expected, 0, 3);
+      assertListIndexEquals(b.invocations, expected, 2);
+
+      expected = Arrays.asList(-3, -2, -1);
+      b.invocations.clear();
+      InitHelper.destroy(b);
+      assertEquals(b.invocations.size(), 3);
+      assertListIndexEquals(b.invocations, expected, 0);
+      assertListEqualsPermuted(b.invocations, expected, 1, 3);
+   }
+
+   public void testC() {
+      C c = new C();
+      List<Integer> expected = Arrays.asList(4, 2, 3);
+      InitHelper.init(c);
+      assertEquals(c.invocations.size(), 3);
+      assertListEqualsPermuted(c.invocations, expected, 0, 2);
+      assertListIndexEquals(c.invocations, expected, 2);
+
+      expected = Arrays.asList(-3, -2, -4);
+      c.invocations.clear();
+      InitHelper.destroy(c);
+      assertEquals(c.invocations.size(), 3);
+      assertListIndexEquals(c.invocations, expected, 0);
+      assertListEqualsPermuted(c.invocations, expected, 1, 3);
+   }
+
+   public void testD() {
+      D e = new D();
+      List<Integer> expected = Arrays.asList(2, 3, 4);
+      InitHelper.init(e);
+      assertEquals(e.invocations.size(), 3);
+      assertEquals(e.invocations, expected);
+
+      expected = Arrays.asList(-4, -3, -2);
+      e.invocations.clear();
+      InitHelper.destroy(e);
+      assertEquals(e.invocations.size(), 3);
+      assertEquals(e.invocations, expected);
+   }
+
+   public void testE() {
+      E d = new E();
+      InitHelper.init(d);
+      InitHelper.destroy(d);
+      Assert.assertEquals(d.invocations, Arrays.asList(1, -1));
+   }
+
+   private void assertListIndexEquals(List<Integer> actual, List<Integer> expected, int index) {
+      assertEquals(actual.get(index), expected.get(index));
+   }
+
+   private void assertListEqualsPermuted(List<Integer> actual, List<Integer> expected, int fromIndex, int toIndex) {
+      Assert.assertEquals(new HashSet<>(actual.subList(fromIndex, toIndex)), new HashSet<>(expected.subList(fromIndex, toIndex)));
+   }
+}

--- a/plugins/infinispan60/src/main/java/org/radargun/service/Infinispan60EmbeddedService.java
+++ b/plugins/infinispan60/src/main/java/org/radargun/service/Infinispan60EmbeddedService.java
@@ -36,7 +36,7 @@ public class Infinispan60EmbeddedService extends Infinispan53EmbeddedService {
    protected boolean internalsExpositionEnabled = false;
 
    private JGroupsDumper jgroupsDumper;
-   private ScheduledExecutorService scheduledExecutor = Executors.newScheduledThreadPool(1);
+   protected ScheduledExecutorService scheduledExecutor = Executors.newScheduledThreadPool(1);
 
    @ProvidesTrait
    public InfinispanEmbeddedQueryable createQueryable() {

--- a/plugins/infinispan80/src/main/java/org/radargun/service/Infinispan80EmbeddedService.java
+++ b/plugins/infinispan80/src/main/java/org/radargun/service/Infinispan80EmbeddedService.java
@@ -1,0 +1,20 @@
+package org.radargun.service;
+
+import org.radargun.Service;
+import org.radargun.config.Destroy;
+import org.radargun.utils.Utils;
+
+import java.util.concurrent.ForkJoinPool;
+
+/**
+ * @author Matej Cimbora
+ */
+@Service(doc = InfinispanEmbeddedService.SERVICE_DESCRIPTION)
+public class Infinispan80EmbeddedService extends Infinispan70EmbeddedService {
+
+   @Destroy
+   public void destroy() {
+      Utils.shutdownAndWait(scheduledExecutor);
+      ForkJoinPool.commonPool().shutdownNow();
+   }
+}

--- a/plugins/infinispan80/src/main/resources/plugin.properties
+++ b/plugins/infinispan80/src/main/resources/plugin.properties
@@ -1,5 +1,5 @@
-service.default org.radargun.service.Infinispan70EmbeddedService
-service.embedded org.radargun.service.Infinispan70EmbeddedService
+service.default org.radargun.service.Infinispan80EmbeddedService
+service.embedded org.radargun.service.Infinispan80EmbeddedService
 service.server org.radargun.service.Infinispan60ServerService
 service.hotrod org.radargun.service.Infinispan71HotrodService
 service.jcache org.radargun.service.JCacheService

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -29,7 +29,7 @@
       <dependency>
          <groupId>org.jboss.logging</groupId>
          <artifactId>jboss-logging</artifactId>
-         <version>3.1.4.GA</version>
+         <version>3.3.0.Final</version>
       </dependency>
    </dependencies>
 </project>


### PR DESCRIPTION
- org.infinispan.commons.util.concurrent.jdk8backported.ForkJoinPool no longer present in ISPN 8
-- call @Destroy only once, if annotated method is overriden
- Update log4j2 & jboss logging versions