### PR TITLE
Query aggregations - preview

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -14,7 +14,7 @@
 
    <properties>
       <version.log4j>1.2.16</version.log4j>
-      <version.log4j2>2.0-beta9</version.log4j2>
+      <version.log4j2>2.3</version.log4j2>
       <maven.test.skip>false</maven.test.skip>
    </properties>
 

--- a/core/src/main/java/org/radargun/config/InitHelper.java
+++ b/core/src/main/java/org/radargun/config/InitHelper.java
@@ -1,34 +1,42 @@
 package org.radargun.config;
 
+import org.radargun.logging.Log;
+import org.radargun.logging.LogFactory;
+
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Stack;
-
-import org.radargun.logging.Log;
-import org.radargun.logging.LogFactory;
 
 /**
  * @author Radim Vansa &lt;rvansa@redhat.com&gt;
  */
 public class InitHelper {
+
    private static final Log log = LogFactory.getLog(InitHelper.class);
 
    public static void init(Object target) {
+      processAnnotatedMethods(target, Init.class);
+   }
+
+   public static void destroy(Object target) {
+      processAnnotatedMethods(target, Destroy.class);
+   }
+
+   private static void processAnnotatedMethods(Object target, Class annotationClass) {
       if (target == null) throw new NullPointerException();
-      Stack<Method> inits = new Stack<Method>();
+      Stack<Method> inits = new Stack<>();
       Class<?> clazz = target.getClass();
       while (clazz != null) {
          for (Method m : clazz.getDeclaredMethods()) {
-            if (m.isAnnotationPresent(Init.class)) {
+            if (m.getAnnotation(annotationClass) != null) {
                boolean overridden = false;
                for (Method m2 : inits) {
                   if (m2.getName().equals(m.getName())
                         && Arrays.equals(m2.getGenericParameterTypes(), m.getGenericParameterTypes())) {
-                     log.warnf("Method %s overrides %s but both are declared with @Init annotation: calling only once", m2, m);
+                     log.warnf("Method %s overrides %s but both are declared with @%s annotation: calling only once", m2, m, annotationClass.getSimpleName());
                      overridden = true;
                   }
                }
-               m.setAccessible(true);
                if (!overridden) {
                   inits.push(m);
                }
@@ -42,24 +50,6 @@ public class InitHelper {
          } catch (Exception e) {
             throw new RuntimeException(e);
          }
-      }
-   }
-
-   public static void destroy(Object target) {
-      if (target == null) throw new NullPointerException();
-      Class<?> clazz = target.getClass();
-      while (clazz != null) {
-         for (Method m : clazz.getDeclaredMethods()) {
-            if (m.isAnnotationPresent(Destroy.class)) {
-               m.setAccessible(true);
-               try {
-                  m.invoke(target);
-               } catch (Exception e) {
-                  throw new RuntimeException(e);
-               }
-            }
-         }
-         clazz = clazz.getSuperclass();
       }
    }
 }

--- a/core/src/main/java/org/radargun/logging/Log4j2Log.java
+++ b/core/src/main/java/org/radargun/logging/Log4j2Log.java
@@ -42,7 +42,10 @@ public final class Log4j2Log implements Log {
 
    @Override
    public final void tracef(String format, Object... args) {
-      getLogger().trace(format, args);
+      Logger logger = getLogger();
+      if (logger.isTraceEnabled()) {
+         logger.trace(String.format(format, args));
+      }
    }
 
    @Override
@@ -68,7 +71,10 @@ public final class Log4j2Log implements Log {
 
    @Override
    public void debugf(String format, Object... args) {
-      getLogger().debug(format, args);
+      Logger logger = getLogger();
+      if (logger.isDebugEnabled()) {
+         logger.debug(String.format(format, args));
+      }
    }
 
    @Override
@@ -94,7 +100,10 @@ public final class Log4j2Log implements Log {
 
    @Override
    public void infof(String format, Object... args) {
-      getLogger().info(format, args);
+      Logger logger = getLogger();
+      if (logger.isInfoEnabled()) {
+         logger.info(String.format(format, args));
+      }
    }
 
    @Override
@@ -120,7 +129,10 @@ public final class Log4j2Log implements Log {
 
    @Override
    public void warnf(String format, Object... args) {
-      getLogger().warn(format, args);
+      Logger logger = getLogger();
+      if (logger.isWarnEnabled()) {
+         logger.warn(String.format(format, args));
+      }
    }
 
    @Override
@@ -146,7 +158,10 @@ public final class Log4j2Log implements Log {
 
    @Override
    public void errorf(String format, Object... args) {
-      getLogger().error(format, args);
+      Logger logger = getLogger();
+      if (logger.isErrorEnabled()) {
+         logger.error(String.format(format, args));
+      }
    }
 
    @Override
@@ -172,7 +187,10 @@ public final class Log4j2Log implements Log {
 
    @Override
    public void fatalf(String format, Object... args) {
-      getLogger().fatal(format, args);
+      Logger logger = getLogger();
+      if (logger.isFatalEnabled()) {
+         logger.fatal(String.format(format, args));
+      }
    }
 
    @Override

--- a/core/src/main/java/org/radargun/logging/PerNodeRollingRandomAccessFileAppender.java
+++ b/core/src/main/java/org/radargun/logging/PerNodeRollingRandomAccessFileAppender.java
@@ -6,6 +6,7 @@ import java.io.Serializable;
 import org.apache.logging.log4j.core.ErrorHandler;
 import org.apache.logging.log4j.core.Filter;
 import org.apache.logging.log4j.core.Layout;
+import org.apache.logging.log4j.core.LifeCycle;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.appender.RollingRandomAccessFileAppender;
 import org.apache.logging.log4j.core.appender.rolling.RolloverStrategy;
@@ -39,6 +40,7 @@ public final class PerNodeRollingRandomAccessFileAppender implements org.apache.
          @PluginAttribute("append") final String append,
          @PluginAttribute("name") final String name,
          @PluginAttribute("immediateFlush") final String immediateFlush,
+         @PluginAttribute("bufferSizeStr") final String bufferSizeStr,
          @PluginElement("Policy") final TriggeringPolicy policy,
          @PluginElement("Strategy") RolloverStrategy strategy,
          @PluginElement("Layout") Layout<? extends Serializable> layout,
@@ -48,8 +50,8 @@ public final class PerNodeRollingRandomAccessFileAppender implements org.apache.
          @PluginAttribute("advertiseURI") final String advertiseURI,
          @PluginConfiguration final Configuration config) {
       RollingRandomAccessFileAppender appender = RollingRandomAccessFileAppender.createAppender(
-            appendNodeIndex(fileName), appendNodeIndex(filePattern), append, name, immediateFlush, policy, strategy,
-            layout, filter, ignore, advertise, advertiseURI, config);
+            appendNodeIndex(fileName), appendNodeIndex(filePattern), append, name, immediateFlush, bufferSizeStr, policy,
+            strategy, layout, filter, ignore, advertise, advertiseURI, config);
       return new PerNodeRollingRandomAccessFileAppender(appender);
    }
 
@@ -101,6 +103,11 @@ public final class PerNodeRollingRandomAccessFileAppender implements org.apache.
    }
 
    @Override
+   public State getState() {
+      return appender.getState();
+   }
+
+   @Override
    public void start() {
       appender.start();
    }
@@ -113,5 +120,10 @@ public final class PerNodeRollingRandomAccessFileAppender implements org.apache.
    @Override
    public boolean isStarted() {
       return appender.isStarted();
+   }
+
+   @Override
+   public boolean isStopped() {
+      return appender.isStopped();
    }
 }

--- a/core/src/main/java/org/radargun/traits/Queryable.java
+++ b/core/src/main/java/org/radargun/traits/Queryable.java
@@ -27,30 +27,73 @@ public interface Queryable {
 
    /**
     * The instance should be reusable, but not thread-safe.
+    * Conditions defined after groupBy call are meant to be part of the HAVING clause.
     */
    interface QueryBuilder {
       QueryBuilder subquery();
-      QueryBuilder eq(String attribute, Object value);
-      QueryBuilder lt(String attribute, Object value);
-      QueryBuilder le(String attribute, Object value);
-      QueryBuilder gt(String attribute, Object value);
-      QueryBuilder ge(String attribute, Object value);
-      QueryBuilder between(String attribute, Object lowerBound, boolean lowerInclusive, Object upperBound, boolean upperInclusive);
-      QueryBuilder isNull(String attribute);
-      QueryBuilder like(String attribute, String pattern);
-      QueryBuilder contains(String attribute, Object value);
+      QueryBuilder eq(Attribute attribute, Object value);
+      QueryBuilder lt(Attribute attribute, Object value);
+      QueryBuilder le(Attribute attribute, Object value);
+      QueryBuilder gt(Attribute attribute, Object value);
+      QueryBuilder ge(Attribute attribute, Object value);
+      QueryBuilder between(Attribute Attribute, Object lowerBound, boolean lowerInclusive, Object upperBound, boolean upperInclusive);
+      QueryBuilder isNull(Attribute attribute);
+      QueryBuilder like(Attribute attribute, String pattern);
+      QueryBuilder contains(Attribute attribute, Object value);
       QueryBuilder not(QueryBuilder subquery);
       QueryBuilder any(QueryBuilder... subqueries);
-      QueryBuilder orderBy(String attribute, SortOrder order);
-      QueryBuilder projection(String... attribute);
+      QueryBuilder orderBy(Attribute attribute, SortOrder order);
+      QueryBuilder projection(Attribute... attribute);
+      QueryBuilder groupBy(String[] attribute);
       QueryBuilder offset(long offset);
       QueryBuilder limit(long limit);
       Query build();
    }
 
+   class Attribute {
+      public String attribute;
+      public AggregationFunction function;
+
+      public Attribute(String attribute) {
+         this(attribute, AggregationFunction.NONE);
+      }
+
+      public Attribute(String attribute, AggregationFunction function) {
+         this.attribute = attribute;
+         this.function = function;
+      }
+   }
+
    enum SortOrder {
       ASCENDING,
       DESCENDING
+   }
+
+   enum AggregationFunction {
+      NONE,
+      COUNT,
+      SUM,
+      AVG,
+      MIN,
+      MAX;
+
+      public static AggregationFunction parseFunction(String string) {
+         AggregationFunction result;
+         if (string.equalsIgnoreCase("COUNT")) {
+            result = Queryable.AggregationFunction.COUNT;
+         } else if (string.equalsIgnoreCase("AVG")) {
+            result = Queryable.AggregationFunction.AVG;
+         } else if (string.equalsIgnoreCase("SUM")) {
+            result = Queryable.AggregationFunction.SUM;
+         } else if (string.equalsIgnoreCase("MIN")) {
+            result = Queryable.AggregationFunction.MIN;
+         } else if (string.equalsIgnoreCase("MAX")) {
+            result = Queryable.AggregationFunction.MAX;
+         } else {
+            throw new IllegalArgumentException("Aggregation function not recognized: " + string);
+         }
+         return result;
+      }
    }
 
    /**

--- a/core/src/main/resources/query-composed-indexed.xml
+++ b/core/src/main/resources/query-composed-indexed.xml
@@ -1,0 +1,359 @@
+<benchmark xmlns="urn:radargun:benchmark:2.1">
+
+   <master bindAddress="${master.address:127.0.0.1}" port="${master.port:2103}" />
+
+   <clusters>
+      <cluster size="4" />
+   </clusters>
+
+   <configurations>
+      <!--<config name="JDG 6.5 dist">-->
+         <!--<setup plugin="jdg65">-->
+            <!--<embedded xmlns="urn:radargun:plugins:jdg65:2.0"-->
+                      <!--file="query-batch-indexed.xml"-->
+                      <!--cache="dist_lucene_repl" />-->
+         <!--</setup>-->
+      <!--</config>-->
+      <config name="${dist.config.name:JDG_6.6_dist}">
+         <setup plugin="${plugin.name:jdg66}">
+            <embedded xmlns="urn:radargun:plugins:jdg66:2.0"
+                      file="query-no-tx-indexed.xml"
+                      cache="dist_lucene_repl"
+                      preregistered-query-classes="org.radargun.query.NumberObject,org.radargun.query.TextObject,org.radargun.query.ComposedObject"/>
+         </setup>
+      </config>
+      <!--<config name="JDG 6.5 repl">-->
+         <!--<setup plugin="jdg65">-->
+            <!--<embedded xmlns="urn:radargun:plugins:jdg65:2.0"-->
+                      <!--file="query-batch-indexed.xml"-->
+                      <!--cache="repl_ram" />-->
+         <!--</setup>-->
+      <!--</config>-->
+      <config name="${repl.config.name:JDG_6.6_repl}">
+         <setup plugin="${plugin.name:jdg66}">
+            <embedded xmlns="urn:radargun:plugins:jdg66:2.0"
+                      file="query-no-tx-indexed.xml"
+                      cache="repl_ram"
+                      preregistered-query-classes="org.radargun.query.NumberObject,org.radargun.query.TextObject,org.radargun.query.ComposedObject"/>
+         </setup>
+      </config>
+   </configurations>
+
+   <scenario>
+      <jvm-monitor-start />
+      <service-start/>
+
+      <define var="entry.count" value="${entry.count:100000}"/>
+      <define var="warmup.duration" value="${warmup.duration:5m}" />
+      <define var="test.duration" value="${test.duration:3m}" />
+
+      <load-data num-entries="#{${entry.count} / 2}" entry-size="0" seed="12345"
+                 transaction-size="${tx.size:500}" use-transactions="${tx.type:NEVER}">
+         <value-generator>
+            <composed>
+               <class>org.radargun.query.ComposedObject</class>
+               <text-class>org.radargun.query.TextObject</text-class>
+               <number-class>org.radargun.query.NumberObject</number-class>
+               <nested-collection-size>1</nested-collection-size>
+               <number-object-generator>
+                  <number-object int-min="0" int-max="123455"/>
+               </number-object-generator>
+               <single-word-generator>
+                  <single-word file="${animals.file:/test-data/animals.txt}" />
+               </single-word-generator>
+            </composed>
+         </value-generator>
+      </load-data>
+
+      <load-data num-entries="#{${entry.count} / 2 - 10}" key-id-offset="#{${entry.count} / 2 + 10}" entry-size="0" seed="12345"
+                 transaction-size="${tx.size:500}" use-transactions="${tx.type:NEVER}">
+         <value-generator>
+            <composed>
+               <class>org.radargun.query.ComposedObject</class>
+               <text-class>org.radargun.query.TextObject</text-class>
+               <number-class>org.radargun.query.NumberObject</number-class>
+               <nested-collection-size>1</nested-collection-size>
+               <number-object-generator>
+                  <number-object int-min="123466" int-max="999999" />
+               </number-object-generator>
+               <single-word-generator>
+                  <single-word file="${animals.file:/test-data/animals.txt}" />
+               </single-word-generator>
+            </composed>
+         </value-generator>
+      </load-data>
+
+      <load-data num-entries="1" key-id-offset="#{${entry.count} / 2}" entry-size="0" seed="12345"
+                 transaction-size="${tx.size:500}" use-transactions="${tx.type:NEVER}">
+         <value-generator>
+            <composed>
+               <class>org.radargun.query.ComposedObject</class>
+               <text-class>org.radargun.query.TextObject</text-class>
+               <number-class>org.radargun.query.NumberObject</number-class>
+               <nested-collection-size>1</nested-collection-size>
+               <number-object-generator>
+                  <number-object int-min="123456" int-max="123456" />
+               </number-object-generator>
+               <single-word-generator>
+                  <single-word words="Wildfly" />
+               </single-word-generator>
+            </composed>
+         </value-generator>
+      </load-data>
+
+      <repeat from="1" to="9">
+         <load-data seed="12345" key-id-offset="#{${entry.count} / 2 + ${repeat.counter}}" num-entries="1"
+                    num-threads="1" entry-size="0" transaction-size="${tx.size:500}" use-transactions="${tx.type:NEVER}"
+                    max-load-attempts="50">
+            <value-generator>
+               <composed>
+                  <class>org.radargun.query.ComposedObject</class>
+                  <text-class>org.radargun.query.TextObject</text-class>
+                  <number-class>org.radargun.query.NumberObject</number-class>
+                  <nested-collection-size>1</nested-collection-size>
+                  <number-object-generator>
+                     <number-object int-min="#{123456 + ${repeat.counter}}" int-max="#{123456 + ${repeat.counter}}" />
+                  </number-object-generator>
+                  <single-word-generator>
+                     <single-word file="${animals.file:/test-data/animals.txt}" />
+                  </single-word-generator>
+               </composed>
+            </value-generator>
+         </load-data>
+      </repeat>
+
+      <sleep time="${sleep.time:10s}"/>
+
+      <query test-name="warmup"
+             duration="${warmup.duration}"
+             num-threads-per-node="10"
+             query-object-class="org.radargun.query.ComposedObject"
+             use-transactions="${tx.type:NEVER}">
+         <conditions>
+            <lt path="numberObject.doubleValue" value="double 0.00001" />
+            <le path="numberObject.doubleValue" value="double 0.00001" />
+            <lt path="numberObject.integerValue" value="int 1" />
+            <le path="numberObject.integerValue" value="int 2" />
+            <eq path="numberObject.doubleValue" value="double 0" />
+            <lt path="numberObjectList.doubleValue" value="double 0.00001" />
+            <le path="numberObjectList.doubleValue" value="double 0.00001" />
+            <lt path="numberObjectList.integerValue" value="int 1" />
+            <le path="numberObjectList.integerValue" value="int 2" />
+            <eq path="numberObjectList.doubleValue" value="double 0" />
+            <any>
+               <eq path="numberObject.integerValue" value="1000000" />
+               <gt path="numberObject.integerValue" value="999999" />
+               <gt path="numberObject.doubleValue" value="double 0.99999" />
+               <eq path="numberObjectList.integerValue" value="1000000" />
+               <gt path="numberObjectList.integerValue" value="999999" />
+               <gt path="numberObjectList.doubleValue" value="double 0.99999" />
+            </any>
+         </conditions>
+      </query>
+
+      <query test-name="warmup"
+             duration="${warmup.duration}"
+             num-threads-per-node="10"
+             query-object-class="org.radargun.query.ComposedObject"
+             use-transactions="${tx.type:NEVER}"
+            >
+         <conditions>
+            <eq path="textObject.text" value="string Wildfly" />
+            <like path="textObject.text" value="Wildfly" />
+            <like path="textObject.text" value="W%d_l%" />
+            <eq path="textObjectList.text" value="string Wildfly" />
+            <like path="textObjectList.text" value="Wildfly" />
+            <like path="textObjectList.text" value="W%d_l%" />
+         </conditions>
+      </query>
+
+      <query test-name="int-single-eq"
+             duration="${test.duration}"
+             num-threads-per-node="10"
+             query-object-class="org.radargun.query.ComposedObject"
+             use-transactions="${tx.type:NEVER}"
+             >
+         <conditions>
+            <eq path="numberObject.integerValue" value="int 123456"/>
+         </conditions>
+      </query>
+
+      <query test-name="int-between"
+             duration="${test.duration}"
+             num-threads-per-node="10"
+             query-object-class="org.radargun.query.ComposedObject"
+             use-transactions="${tx.type:NEVER}"
+             >
+         <conditions>
+            <between path="numberObject.integerValue" lower-bound="int 123456" upper-bound="123465" />
+         </conditions>
+      </query>
+
+      <query test-name="int-range"
+             duration="${test.duration}"
+             num-threads-per-node="10"
+             query-object-class="org.radargun.query.ComposedObject"
+             use-transactions="${tx.type:NEVER}"
+             >
+         <conditions>
+            <ge path="numberObject.integerValue" value="int 123456"/>
+            <le path="numberObject.integerValue" value="int 123465"/>
+         </conditions>
+      </query>
+
+      <query test-name="int-composed-single-eq"
+             duration="${test.duration}"
+             num-threads-per-node="10"
+             query-object-class="org.radargun.query.ComposedObject"
+             use-transactions="${tx.type:NEVER}"
+             >
+         <conditions>
+            <eq path="numberObjectList.integerValue" value="int 123456"/>
+         </conditions>
+      </query>
+
+      <query test-name="int-composed-between"
+             duration="${test.duration}"
+             num-threads-per-node="10"
+             query-object-class="org.radargun.query.ComposedObject"
+             use-transactions="${tx.type:NEVER}"
+             >
+         <conditions>
+            <between path="numberObjectList.integerValue" lower-bound="int 123456" upper-bound="123465" />
+         </conditions>
+      </query>
+
+      <query test-name="int-composed-range"
+             duration="${test.duration}"
+             num-threads-per-node="10"
+             query-object-class="org.radargun.query.ComposedObject"
+             use-transactions="${tx.type:NEVER}"
+             >
+         <conditions>
+            <ge path="numberObjectList.integerValue" value="int 123456"/>
+            <le path="numberObjectList.integerValue" value="int 123465"/>
+         </conditions>
+      </query>
+
+      <query test-name="string-exact"
+             num-threads-per-node="10"
+             duration="${test.duration}"
+             query-object-class="org.radargun.query.ComposedObject"
+             use-transactions="${tx.type:NEVER}"
+             >
+         <conditions>
+            <eq path="textObject.text" value="string Wildfly" />
+         </conditions>
+      </query>
+
+      <query test-name="string-no-match"
+             num-threads-per-node="10"
+             duration="${test.duration}"
+             query-object-class="org.radargun.query.ComposedObject"
+             use-transactions="${tx.type:NEVER}"
+             >
+         <conditions>
+            <eq path="textObject.text" value="string NonExistent" />
+         </conditions>
+      </query>
+
+      <query test-name="string-like-exact"
+             num-threads-per-node="10"
+             duration="${test.duration}"
+             query-object-class="org.radargun.query.ComposedObject"
+             use-transactions="${tx.type:NEVER}"
+             >
+         <conditions>
+            <like path="textObject.text" value="Wildfly" />
+         </conditions>
+      </query>
+
+      <query test-name="string-like-regexp"
+             num-threads-per-node="10"
+             duration="${test.duration}"
+             query-object-class="org.radargun.query.ComposedObject"
+             use-transactions="${tx.type:NEVER}"
+             >
+         <conditions>
+            <like path="textObject.text" value="W%d_l%" />
+         </conditions>
+      </query>
+
+      <query test-name="string-composed-exact"
+             num-threads-per-node="10"
+             duration="${test.duration}"
+             query-object-class="org.radargun.query.ComposedObject"
+             use-transactions="${tx.type:NEVER}"
+             >
+         <conditions>
+            <eq path="textObjectList.text" value="string Wildfly" />
+         </conditions>
+      </query>
+
+      <query test-name="string-composed-no-match"
+             num-threads-per-node="10"
+             duration="${test.duration}"
+             query-object-class="org.radargun.query.ComposedObject"
+             use-transactions="${tx.type:NEVER}"
+             >
+         <conditions>
+            <eq path="textObjectList.text" value="string NonExistent" />
+         </conditions>
+      </query>
+
+      <query test-name="string-composed-like-exact"
+             num-threads-per-node="10"
+             duration="${test.duration}"
+             query-object-class="org.radargun.query.ComposedObject"
+             use-transactions="${tx.type:NEVER}"
+             >
+         <conditions>
+            <like path="textObjectList.text" value="Wildfly" />
+         </conditions>
+      </query>
+
+      <query test-name="string-composed-like-regexp"
+             num-threads-per-node="10"
+             duration="${test.duration}"
+             query-object-class="org.radargun.query.ComposedObject"
+             use-transactions="${tx.type:NEVER}"
+             >
+         <conditions>
+            <like path="textObjectList.text" value="W%d_l%" />
+         </conditions>
+      </query>
+   </scenario>
+
+   <reports>
+      <reporter type="html">
+         <html xmlns="urn:radargun:reporters:reporter-default:2.0"
+               target-dir="${env.PWD}/results/html">
+         </html>
+      </reporter>
+      <reporter type="csv">
+         <csv xmlns="urn:radargun:reporters:reporter-default:2.0"
+              target-dir="${env.PWD}/results/csv"/>
+      </reporter>
+      <reporter type="serialized">
+         <serialized xmlns="urn:radargun:reporters:reporter-default:2.0"
+                     target-dir="${env.PWD}/results/serialized" />
+      </reporter>
+      <reporter type="perfrepo">
+         <perfrepo xmlns="urn:radargun:reporters:reporter-perfrepo:2.1">
+            <perf-repo-host>${perfrepo.host:perfrepo.mw.lab.eng.bos.redhat.com}</perf-repo-host>
+            <perf-repo-port>${perfrepo.port:8080}</perf-repo-port>
+            <perf-repo-auth>${perfrepo.auth:bWNpbWJvcmE6amRn}</perf-repo-auth>
+            <perf-repo-test>${perfrepo.test:jdg_rg_query_test}</perf-repo-test>
+            <perf-repo-tag>${perfrepo.tag:lib;composed}</perf-repo-tag>
+            <exclude-attachments>true</exclude-attachments>
+            <exclude-build-params>true</exclude-build-params>
+            <exclude-normalized-configs>true</exclude-normalized-configs>
+            <separate-test-iterations>true</separate-test-iterations>
+            <metric-name-mapping>
+               <map operation="Queryable.Query" representation="throughput-net" to="jdg_rg_query_throughput"/>
+            </metric-name-mapping>
+         </perfrepo>
+      </reporter>
+   </reports>
+
+</benchmark>

--- a/core/src/main/resources/query-text-indexed.xml
+++ b/core/src/main/resources/query-text-indexed.xml
@@ -1,0 +1,467 @@
+<benchmark xmlns="urn:radargun:benchmark:2.0">
+
+   <master bindAddress="${master.address:127.0.0.1}" port="${master.port:2103}" />
+
+   <clusters>
+      <!--<cluster size="2" />-->
+      <cluster size="4" />
+      <!--<cluster size="8" />-->
+   </clusters>
+
+   <configurations>
+      <!--<config name="Hazelcast dist">-->
+         <!--<setup plugin="hazelcast3">-->
+            <!--<hazelcast xmlns="urn:radargun:plugins:hazelcast3:2.0"-->
+                       <!--file="dist-sync-object-format.xml">-->
+               <!--<indices>-->
+                  <!--<index path="text" />-->
+               <!--</indices>-->
+            <!--</hazelcast>-->
+         <!--</setup>-->
+      <!--</config>-->
+
+      <!--<config name="Infinispan 7.0 dist">-->
+         <!--<setup plugin="infinispan70">-->
+            <!--<embedded xmlns="urn:radargun:plugins:infinispan70:2.0"-->
+                      <!--file="query-batch-indexed.xml"-->
+                      <!--cache="dist_lucene_repl" />-->
+         <!--</setup>-->
+      <!--</config>-->
+      <!--<config name="Infinispan 7.0 repl">-->
+         <!--<setup plugin="infinispan70">-->
+            <!--<embedded xmlns="urn:radargun:plugins:infinispan70:2.0"-->
+                      <!--file="query-batch-indexed.xml"-->
+                      <!--cache="repl_ram" />-->
+         <!--</setup>-->
+      <!--</config>-->
+      <!--<config name="Infinispan 7.0 local">-->
+         <!--<setup plugin="infinispan70" file="query-no-tx-indexless.xml">-->
+            <!--<property name="cache">local_indexless</property>-->
+         <!--</setup>-->
+      <!--</config>-->
+
+      <!--<config name="JDG 6.3 dist">-->
+         <!--<setup plugin="jdg63">-->
+            <!--<embedded xmlns="urn:radargun:plugins:jdg63:2.0"-->
+                      <!--file="query-batch-indexed.xml"-->
+                      <!--cache="dist_lucene_repl" />-->
+         <!--</setup>-->
+      <!--</config>-->
+      <!--<config name="JDG 6.3 repl">-->
+         <!--<setup plugin="jdg63">-->
+            <!--<embedded xmlns="urn:radargun:plugins:jdg63:2.0"-->
+                      <!--file="query-batch-indexed.xml"-->
+                      <!--cache="repl_ram" />-->
+         <!--</setup>-->
+      <!--</config>-->
+      <!--<config name="JDG 6.3 local">-->
+         <!--<setup plugin="jdg63" file="query-no-tx-indexless.xml">-->
+            <!--<property name="cache">local_indexless</property>-->
+         <!--</setup>-->
+      <!--</config>-->
+
+      <!--<config name="Coherence 12 dist POF">-->
+         <!--<setup plugin="coherence12">-->
+            <!--<coherence xmlns="urn:radargun:plugins:coherence12:2.0"-->
+                       <!--file="dist.xml" />-->
+         <!--</setup>-->
+      <!--</config>-->
+      <!--<config name="Coherence 12 repl POF">-->
+         <!--<setup plugin="coherence12">-->
+            <!--<coherence xmlns="urn:radargun:plugins:coherence12:2.0"-->
+                       <!--file="repl.xml" />-->
+         <!--</setup>-->
+      <!--</config>-->
+      <!--<config name="Coherence 12 local">-->
+         <!--<setup plugin="coherence12" file="local.xml" />-->
+      <!--</config>-->
+      <!--<config name="JDG 6.5 dist">-->
+         <!--<setup plugin="jdg65">-->
+            <!--<embedded xmlns="urn:radargun:plugins:jdg65:2.0"-->
+                      <!--file="query-batch-indexed.xml"-->
+                      <!--cache="dist_lucene_repl" />-->
+         <!--</setup>-->
+      <!--</config>-->
+      <config name="${dist.config.name:JDG_6.6_dist}">
+         <setup plugin="${plugin.name:infinispan80}">
+            <embedded xmlns="urn:radargun:plugins:jdg66:2.0"
+                      file="query-no-tx-indexed.xml"
+                      cache="dist_lucene_repl" />
+         </setup>
+      </config>
+      <!--<config name="JDG 6.5 repl">-->
+         <!--<setup plugin="jdg65">-->
+            <!--<embedded xmlns="urn:radargun:plugins:jdg65:2.0"-->
+                      <!--file="query-batch-indexed.xml"-->
+                      <!--cache="repl_ram" />-->
+         <!--</setup>-->
+      <!--</config>-->
+      <config name="${repl.config.name:JDG_6.6_repl}">
+         <setup plugin="${plugin.name:infinispan80}">
+            <embedded xmlns="urn:radargun:plugins:jdg66:2.0"
+                      file="query-no-tx-indexed.xml"
+                      cache="repl_ram" />
+         </setup>
+      </config>
+   </configurations>
+
+   <scenario>
+      <jvm-monitor-start />
+      <service-start/>
+
+      <define var="singleword.entries" value="${singleword.entries:100000}" />
+      <define var="haystack.entries" value="${haystack.entries:10000}" />
+      <define var="warmup.duration" value="${warmup.duration:5m}" />
+      <define var="test.duration" value="${test.duration:1m}" />
+      <define var="animals.file" value="${env.PWD}/etc/radargun/query/animals.txt" />
+      <!--<define var="warmup.duration" value="10s" />-->
+      <!--<define var="test.duration" value="10s" />-->
+      <!--<define var="animals.file" value="/home/rvansa/workspace/etc/radargun/query/animals.txt" />-->
+
+      <!-- Preload the cache deterministically -->
+      <load-data seed="12345" num-entries="${singleword.entries}" num-threads="10" entry-size="0"
+                 transaction-size="${tx.size:0}" max-load-attempts="50" use-transactions="${tx.type:NEVER}">
+         <value-generator>
+            <single-word file="${animals.file}" />
+         </value-generator>
+      </load-data>
+
+      <!-- Override key 500000 the word Wildfly; this is not in animals.txt -->
+      <load-data num-entries="1" num-threads="1" entry-size="0" key-id-offset="#{${singleword.entries} / 2}"
+                 max-load-attempts="50" use-transactions="${tx.type:NEVER}">
+         <value-generator>
+            <single-word words="Wildfly" />
+         </value-generator>
+      </load-data>
+      <sleep time="${sleep.time:10s}"/>
+      <check-cache-data entry-size="0" num-entries="${singleword.entries}" />
+
+      <!-- Warmup -->
+      <query test-name="warmup"
+             num-threads-per-node="40"
+             duration="${warmup.duration}"
+             query-object-class="org.radargun.query.TextObject"
+             use-transactions="${tx.type:NEVER}">
+         <conditions>
+            <any>
+               <eq path="text" value="string Wildfly" />
+               <like path="text" value="%W_l%y"/>
+               <all>
+                  <like path="text" value="Wild%" />
+                  <like path="text" value="%fly" />
+               </all>
+            </any>
+         </conditions>
+      </query>
+
+
+      <!-- Logic does only queries - we don't have to specify any generator -->
+      <query test-name="exact"
+             num-threads-per-node="10"
+             duration="${test.duration}"
+             query-object-class="org.radargun.query.TextObject"
+             use-transactions="${tx.type:NEVER}">
+         <conditions>
+            <eq path="text" value="string Wildfly" />
+         </conditions>
+      </query>
+
+      <query test-name="no-match"
+             num-threads-per-node="10"
+             duration="${test.duration}"
+             query-object-class="org.radargun.query.TextObject"
+             use-transactions="${tx.type:NEVER}">
+         <conditions>
+            <eq path="text" value="string NonExistent" />
+         </conditions>
+      </query>
+
+      <query test-name="like-exact"
+             num-threads-per-node="10"
+             duration="${test.duration}"
+             query-object-class="org.radargun.query.TextObject"
+             use-transactions="${tx.type:NEVER}">
+         <conditions>
+            <like path="text" value="Wildfly" />
+         </conditions>
+      </query>
+
+      <query test-name="like-regexp"
+             num-threads-per-node="10"
+             duration="${test.duration}"
+             query-object-class="org.radargun.query.TextObject"
+             use-transactions="${tx.type:NEVER}">
+         <conditions>
+            <like path="text" value="W%d_l%" />
+         </conditions>
+      </query>
+
+      <!--<repeat from="1" to="${repeat.to:10}">-->
+      <clear-cache/>
+      <load-data seed="12345" num-entries="${haystack.entries}" num-threads="10"
+                 entry-size="10"
+                 transaction-size="${tx.size:0}" use-transactions="${tx.type:NEVER}" max-load-attempts="50">
+         <value-generator>
+            <word-in-haystack file="${animals.file}"/>
+         </value-generator>
+      </load-data>
+      <load-data seed="12345" num-entries="1" num-threads="1" entry-size="10"
+                 key-id-offset="#{${haystack.entries} / 2}" use-transactions="${tx.type:NEVER}" max-load-attempts="50">
+         <value-generator>
+            <word-in-haystack words="Wildfly"/>
+         </value-generator>
+      </load-data>
+      <sleep time="${sleep.time:10s}"/>
+
+      <query test-name="like-haystack-contains" amend-test="true"
+             num-threads-per-node="10"
+             duration="${test.duration}"
+             query-object-class="org.radargun.query.TextObject"
+             use-transactions="${tx.type:NEVER}">
+         <conditions>
+            <like path="text" value="%Wildfly%"/>
+         </conditions>
+      </query>
+
+      <!-- like-haystack-starts and like-haystack-ends probably won't return any results as there's
+           very low probability that the haystack generator would put them on beginning/end -->
+      <query test-name="like-haystack-starts" amend-test="true"
+             num-threads-per-node="10"
+             duration="${test.duration}"
+             query-object-class="org.radargun.query.TextObject"
+             use-transactions="${tx.type:NEVER}">
+         <conditions>
+            <like path="text" value="Wildfly%"/>
+         </conditions>
+      </query>
+
+      <query test-name="like-haystack-ends" amend-test="true"
+             num-threads-per-node="10"
+             duration="${test.duration}"
+             query-object-class="org.radargun.query.TextObject"
+             use-transactions="${tx.type:NEVER}">
+         <conditions>
+            <like path="text" value="%Wildfly"/>
+         </conditions>
+      </query>
+
+      <query test-name="like-haystack-regexp" amend-test="true"
+             num-threads-per-node="10"
+             duration="${test.duration}"
+             query-object-class="org.radargun.query.TextObject"
+             use-transactions="${tx.type:NEVER}">
+         <conditions>
+            <like path="text" value="%Wi_d%ly%"/>
+         </conditions>
+      </query>
+
+      <!--<repeat from="1" to="${repeat.to:10}">-->
+      <clear-cache/>
+      <load-data seed="12345" num-entries="${haystack.entries}" num-threads="10"
+                 entry-size="80"
+                 transaction-size="${tx.size:0}" use-transactions="${tx.type:NEVER}" max-load-attempts="50">
+         <value-generator>
+            <word-in-haystack file="${animals.file}"/>
+         </value-generator>
+      </load-data>
+      <load-data seed="12345" num-entries="1" num-threads="1" entry-size="80"
+                 key-id-offset="#{${haystack.entries} / 2}" use-transactions="${tx.type:NEVER}" max-load-attempts="50">
+         <value-generator>
+            <word-in-haystack words="Wildfly"/>
+         </value-generator>
+      </load-data>
+      <sleep time="${sleep.time:10s}"/>
+
+      <query test-name="like-haystack-contains" amend-test="true"
+             num-threads-per-node="10"
+             duration="${test.duration}"
+             query-object-class="org.radargun.query.TextObject"
+             use-transactions="${tx.type:NEVER}">
+         <conditions>
+            <like path="text" value="%Wildfly%"/>
+         </conditions>
+      </query>
+
+      <!-- like-haystack-starts and like-haystack-ends probably won't return any results as there's
+           very low probability that the haystack generator would put them on beginning/end -->
+      <query test-name="like-haystack-starts" amend-test="true"
+             num-threads-per-node="10"
+             duration="${test.duration}"
+             query-object-class="org.radargun.query.TextObject"
+             use-transactions="${tx.type:NEVER}">
+         <conditions>
+            <like path="text" value="Wildfly%"/>
+         </conditions>
+      </query>
+
+      <query test-name="like-haystack-ends" amend-test="true"
+             num-threads-per-node="10"
+             duration="${test.duration}"
+             query-object-class="org.radargun.query.TextObject"
+             use-transactions="${tx.type:NEVER}">
+         <conditions>
+            <like path="text" value="%Wildfly"/>
+         </conditions>
+      </query>
+
+      <query test-name="like-haystack-regexp" amend-test="true"
+             num-threads-per-node="10"
+             duration="${test.duration}"
+             query-object-class="org.radargun.query.TextObject"
+             use-transactions="${tx.type:NEVER}">
+         <conditions>
+            <like path="text" value="%Wi_d%ly%"/>
+         </conditions>
+      </query>
+
+
+      <clear-cache />
+      <load-data seed="12345" num-entries="${haystack.entries}" num-threads="10" entry-size="640"
+                 transaction-size="${tx.size:0}" use-transactions="${tx.type:NEVER}" max-load-attempts="50">
+         <value-generator>
+            <word-in-haystack file="${animals.file}" />
+         </value-generator>
+      </load-data>
+      <load-data seed="12345" num-entries="1" num-threads="1" entry-size="640"
+                 key-id-offset="#{${haystack.entries} / 2}" use-transactions="${tx.type:NEVER}" max-load-attempts="50">
+         <value-generator>
+            <word-in-haystack words="Wildfly"/>
+         </value-generator>
+      </load-data>
+      <sleep time="${sleep.time:10s}"/>
+
+      <query test-name="like-haystack-contains" amend-test="true"
+             num-threads-per-node="10"
+             duration="${test.duration}"
+             query-object-class="org.radargun.query.TextObject"
+             use-transactions="${tx.type:NEVER}">
+         <conditions>
+            <like path="text" value="%Wildfly%" />
+         </conditions>
+      </query>
+
+      <!-- like-haystack-starts and like-haystack-ends probably won't return any results as there's
+           very low probability that the haystack generator would put them on beginning/end -->
+      <query test-name="like-haystack-starts" amend-test="true"
+             num-threads-per-node="10"
+             duration="${test.duration}"
+             query-object-class="org.radargun.query.TextObject"
+             use-transactions="${tx.type:NEVER}">
+         <conditions>
+            <like path="text" value="Wildfly%" />
+         </conditions>
+      </query>
+
+      <query test-name="like-haystack-ends" amend-test="true"
+             num-threads-per-node="10"
+             duration="${test.duration}"
+             query-object-class="org.radargun.query.TextObject"
+             use-transactions="${tx.type:NEVER}">
+         <conditions>
+            <like path="text" value="%Wildfly" />
+         </conditions>
+      </query>
+
+      <query test-name="like-haystack-regexp" amend-test="true"
+             num-threads-per-node="10"
+             duration="${test.duration}"
+             query-object-class="org.radargun.query.TextObject"
+             use-transactions="${tx.type:NEVER}">
+         <conditions>
+            <like path="text" value="%Wi_d%ly%" />
+         </conditions>
+      </query>
+
+      <clear-cache />
+      <load-data seed="12345" num-entries="${haystack.entries}" num-threads="10" entry-size="5120"
+                 transaction-size="${tx.size:0}" use-transactions="${tx.type:NEVER}" max-load-attempts="50">
+         <value-generator>
+            <word-in-haystack file="${animals.file}" />
+         </value-generator>
+      </load-data>
+      <load-data seed="12345" num-entries="1" num-threads="1" entry-size="5120"
+                 key-id-offset="#{${haystack.entries} / 2}" use-transactions="${tx.type:NEVER}" max-load-attempts="50">
+         <value-generator>
+            <word-in-haystack words="Wildfly"/>
+         </value-generator>
+      </load-data>
+      <sleep time="${sleep.time:10s}"/>
+
+      <query test-name="like-haystack-contains" amend-test="true"
+             num-threads-per-node="10"
+             duration="${test.duration}"
+             query-object-class="org.radargun.query.TextObject"
+             use-transactions="${tx.type:NEVER}">
+         <conditions>
+            <like path="text" value="%Wildfly%" />
+         </conditions>
+      </query>
+
+      <!-- like-haystack-starts and like-haystack-ends probably won't return any results as there's
+           very low probability that the haystack generator would put them on beginning/end -->
+      <query test-name="like-haystack-starts" amend-test="true"
+             num-threads-per-node="10"
+             duration="${test.duration}"
+             query-object-class="org.radargun.query.TextObject"
+             use-transactions="${tx.type:NEVER}">
+         <conditions>
+            <like path="text" value="Wildfly%" />
+         </conditions>
+      </query>
+
+      <query test-name="like-haystack-ends" amend-test="true"
+             num-threads-per-node="10"
+             duration="${test.duration}"
+             query-object-class="org.radargun.query.TextObject"
+             use-transactions="${tx.type:NEVER}">
+         <conditions>
+            <like path="text" value="%Wildfly" />
+         </conditions>
+      </query>
+
+      <query test-name="like-haystack-regexp" amend-test="true"
+             num-threads-per-node="10"
+             duration="${test.duration}"
+             query-object-class="org.radargun.query.TextObject"
+             use-transactions="${tx.type:NEVER}">
+         <conditions>
+            <like path="text" value="%Wi_d%ly%" />
+         </conditions>
+      </query>
+      <!--</repeat>-->
+   </scenario>
+
+   <cleanup heap-dump-dir="/home_local/tmp"/>
+
+   <reports>
+      <reporter type="html">
+         <html xmlns="urn:radargun:reporters:reporter-default:2.0"
+               target-dir="${env.PWD}/results/html" />
+      </reporter>
+      <reporter type="csv">
+         <csv xmlns="urn:radargun:reporters:reporter-default:2.0"
+               target-dir="${env.PWD}/results/csv" />
+      </reporter>
+      <reporter type="serialized">
+         <serialized xmlns="urn:radargun:reporters:reporter-default:2.0"
+               target-dir="${env.PWD}/results/serialized" />
+      </reporter>
+      <reporter type="perfrepo">
+         <perfrepo xmlns="urn:radargun:reporters:reporter-perfrepo:2.1">
+            <perf-repo-host>${perfrepo.host:perfrepo.mw.lab.eng.bos.redhat.com}</perf-repo-host>
+            <perf-repo-port>${perfrepo.port:8080}</perf-repo-port>
+            <perf-repo-auth>${perfrepo.auth:bWNpbWJvcmE6amRn}</perf-repo-auth>
+            <perf-repo-test>${perfrepo.test:jdg_rg_query_test}</perf-repo-test>
+            <perf-repo-tag>${perfrepo.tag:lib;text}</perf-repo-tag>
+            <exclude-attachments>true</exclude-attachments>
+            <exclude-build-params>true</exclude-build-params>
+            <exclude-normalized-configs>true</exclude-normalized-configs>
+            <separate-test-iterations>true</separate-test-iterations>
+            <metric-name-mapping>
+               <map operation="Queryable.Query" representation="throughput-net" to="jdg_rg_query_throughput"/>
+            </metric-name-mapping>
+         </perfrepo>
+      </reporter>
+   </reports>
+
+</benchmark>

--- a/plugins/infinispan60/src/main/java/org/radargun/service/Infinispan60EmbeddedService.java
+++ b/plugins/infinispan60/src/main/java/org/radargun/service/Infinispan60EmbeddedService.java
@@ -36,7 +36,7 @@ public class Infinispan60EmbeddedService extends Infinispan53EmbeddedService {
    protected boolean internalsExpositionEnabled = false;
 
    private JGroupsDumper jgroupsDumper;
-   private ScheduledExecutorService scheduledExecutor = Executors.newScheduledThreadPool(1);
+   protected ScheduledExecutorService scheduledExecutor = Executors.newScheduledThreadPool(1);
 
    @ProvidesTrait
    public InfinispanEmbeddedQueryable createQueryable() {

--- a/plugins/infinispan80/pom.xml
+++ b/plugins/infinispan80/pom.xml
@@ -23,6 +23,12 @@
          <groupId>org.radargun</groupId>
          <artifactId>plugin-infinispan72</artifactId>
          <version>${project.version}</version>
+          <exclusions>
+              <exclusion>
+                  <groupId>org.infinispan</groupId>
+                  <artifactId>infinispan*</artifactId>
+              </exclusion>
+          </exclusions>
       </dependency>
 
       <dependency>
@@ -65,6 +71,13 @@
       <dependency>
          <groupId>org.infinispan</groupId>
          <artifactId>infinispan-query</artifactId>
+         <version>${version.infinispan}</version>
+         <optional>true</optional>
+      </dependency>
+
+      <dependency>
+         <groupId>org.infinispan</groupId>
+         <artifactId>infinispan-query-dsl</artifactId>
          <version>${version.infinispan}</version>
          <optional>true</optional>
       </dependency>
@@ -116,7 +129,7 @@
             </property>
          </activation>
          <properties>
-            <version.infinispan>8.0.0.Beta1</version.infinispan>
+            <version.infinispan>8.0.0.Final</version.infinispan>
          </properties>
       </profile>
       <profile>

--- a/plugins/infinispan80/src/main/java/org/radargun/service/Infinispan80EmbeddedQueryable.java
+++ b/plugins/infinispan80/src/main/java/org/radargun/service/Infinispan80EmbeddedQueryable.java
@@ -1,0 +1,94 @@
+package org.radargun.service;
+
+import org.infinispan.query.Search;
+import org.infinispan.query.dsl.Expression;
+import org.infinispan.query.dsl.FilterConditionEndContext;
+import org.infinispan.query.dsl.QueryFactory;
+
+/**
+ * Adds support for aggregations.
+ *
+ * @author Jakub Markos &lt;jmarkos@redhat.com&gt;
+ */
+public class Infinispan80EmbeddedQueryable extends Infinispan70EmbeddedQueryable {
+   public Infinispan80EmbeddedQueryable(Infinispan80EmbeddedService service) {
+      super(service);
+   }
+
+   @Override
+   public QueryBuilder getBuilder(String cacheName, Class<?> clazz) {
+      return new QueryBuilder80Impl(Search.getQueryFactory(service.getCache(cacheName)), clazz);
+   }
+
+   protected static class QueryBuilder80Impl extends QueryBuilderImpl {
+      public QueryBuilder80Impl(QueryFactory factory, Class<?> clazz) {
+         super(factory, clazz);
+      }
+
+      protected QueryBuilder80Impl(QueryFactory factory) {
+         super(factory);
+      }
+
+      protected Expression attributeToExpression(Attribute attribute) {
+         switch (attribute.function) {
+            case NONE:
+               return Expression.property(attribute.attribute);
+            case COUNT:
+               return Expression.count(attribute.attribute);
+            case AVG:
+               return Expression.avg(attribute.attribute);
+            case SUM:
+               return Expression.sum(attribute.attribute);
+            case MIN:
+               return Expression.min(attribute.attribute);
+            case MAX:
+               return Expression.max(attribute.attribute);
+            default:
+               throw new RuntimeException("Unknown aggregation function: " + attribute.function);
+         }
+      }
+
+      @Override
+      protected FilterConditionEndContext getEndContext(Attribute attribute) {
+         FilterConditionEndContext endContext;
+         if (context != null) {
+            endContext = context.and().having(attributeToExpression(attribute));
+         } else if (builder != null) {
+            endContext = builder.having(attributeToExpression(attribute));
+         } else {
+            endContext = factory.having(attributeToExpression(attribute));
+         }
+         return endContext;
+      }
+
+      @Override
+      public QueryBuilder projection(Attribute... attributes) {
+         if (builder == null)
+            throw new IllegalArgumentException("You have to call projection() on root query builder!");
+         Expression[] projections = new Expression[attributes.length];
+         for (int i = 0; i < attributes.length; i++) {
+            projections[i] = attributeToExpression(attributes[i]);
+         }
+         builder.select(projections);
+         return this;
+      }
+
+      @Override
+      public QueryBuilder groupBy(String... attributes) {
+         if (builder == null)
+            throw new IllegalArgumentException("You have to call groupBy() on root query builder!");
+         builder.groupBy(attributes);
+         context = null; // all further 'having' conditions will start a new .having() context
+         return this;
+      }
+
+      @Override
+      public QueryBuilder orderBy(Attribute attribute, SortOrder order) {
+         if (builder == null) throw new IllegalArgumentException("You have to call orderBy() on root query builder!");
+         builder.orderBy(attributeToExpression(attribute), order == SortOrder.ASCENDING ?
+                  org.infinispan.query.dsl.SortOrder.ASC : org.infinispan.query.dsl.SortOrder.DESC);
+         return this;
+      }
+   }
+
+}

--- a/plugins/infinispan80/src/main/java/org/radargun/service/Infinispan80EmbeddedService.java
+++ b/plugins/infinispan80/src/main/java/org/radargun/service/Infinispan80EmbeddedService.java
@@ -1,0 +1,17 @@
+package org.radargun.service;
+
+import org.radargun.Service;
+import org.radargun.config.Destroy;
+import org.radargun.utils.Utils;
+
+/**
+ * @author Matej Cimbora
+ */
+@Service(doc = InfinispanEmbeddedService.SERVICE_DESCRIPTION)
+public class Infinispan80EmbeddedService extends Infinispan70EmbeddedService {
+
+   @Destroy
+   public void destroy() {
+      Utils.shutdownAndWait(scheduledExecutor);
+   }
+}

--- a/plugins/infinispan80/src/main/java/org/radargun/service/Infinispan80EmbeddedService.java
+++ b/plugins/infinispan80/src/main/java/org/radargun/service/Infinispan80EmbeddedService.java
@@ -2,6 +2,7 @@ package org.radargun.service;
 
 import org.radargun.Service;
 import org.radargun.config.Destroy;
+import org.radargun.traits.ProvidesTrait;
 import org.radargun.utils.Utils;
 
 /**
@@ -9,6 +10,12 @@ import org.radargun.utils.Utils;
  */
 @Service(doc = InfinispanEmbeddedService.SERVICE_DESCRIPTION)
 public class Infinispan80EmbeddedService extends Infinispan70EmbeddedService {
+
+   @Override
+   @ProvidesTrait
+   public InfinispanEmbeddedQueryable createQueryable() {
+      return new Infinispan80EmbeddedQueryable(this);
+   }
 
    @Destroy
    public void destroy() {

--- a/plugins/infinispan80/src/main/resources/jgroups-udp-custom.xml
+++ b/plugins/infinispan80/src/main/resources/jgroups-udp-custom.xml
@@ -1,0 +1,95 @@
+<!--
+  ~ JBoss, Home of Professional Open Source
+  ~ Copyright 2010 Red Hat Inc. and/or its affiliates and other
+  ~ contributors as indicated by the @author tags. All rights reserved.
+  ~ See the copyright.txt in the distribution for a full listing of
+  ~ individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<config xmlns="urn:org:jgroups"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+   <UDP
+        bind_addr="${jgroups.udp.bind_addr:localhost}"
+        bind_port="${jgroups.udp.bind_port:52000}"
+        loopback="true"
+        port_range="200"
+        mcast_addr="${jgroups.udp.mcast_addr:234.99.54.14}"
+        mcast_port="${jgroups.udp.mcast_port:45688}"
+        receive_on_all_interfaces="true"
+        tos="8"
+        ucast_recv_buf_size="20m"
+        ucast_send_buf_size="640k"
+        mcast_recv_buf_size="25m"
+        mcast_send_buf_size="640k"
+        ip_ttl="${jgroups.udp.ip_ttl:2}"
+        thread_naming_pattern="pl"
+        max_bundle_size="64000"
+        enable_diagnostics="false"
+        bundler_type="${jgroups.bundler.type:sender-sends-with-timer}"
+
+        thread_pool.enabled="true"
+        thread_pool.min_threads="${jgroups.thread_pool.min_threads:20}"
+        thread_pool.max_threads="${jgroups.thread_pool.max_threads:200}"
+        thread_pool.keep_alive_time="60000"
+        thread_pool.queue_enabled="false"
+        thread_pool.queue_max_size="100"
+        thread_pool.rejection_policy="Discard"
+
+        internal_thread_pool.enabled="true"
+        internal_thread_pool.min_threads="${jgroups.internal_thread_pool.min_threads:5}"
+        internal_thread_pool.max_threads="${jgroups.internal_thread_pool.max_threads:20}"
+        internal_thread_pool.keep_alive_time="60000"
+        internal_thread_pool.queue_enabled="true"
+        internal_thread_pool.queue_max_size="500"
+
+        oob_thread_pool.enabled="true"
+        oob_thread_pool.min_threads="${jgroups.oob_thread_pool.min_threads:100}"
+        oob_thread_pool.max_threads="${jgroups.oob_thread_pool.max_threads:500}"
+        oob_thread_pool.keep_alive_time="60000"
+        oob_thread_pool.queue_enabled="false"
+        oob_thread_pool.queue_max_size="100"
+        oob_thread_pool.rejection_policy="Discard"
+        />
+
+   <PING timeout="10000" num_initial_members="40"/>
+   <MERGE3 min_interval="${jgroups.merge3.min_interval:10000}"
+           max_interval="${jgroups.merge3.max_interval:30000}" />
+   <FD_SOCK/>
+   <FD_ALL timeout="${jgroups.fd_all.timeout:60000}"
+           interval="${jgroups.fd_all.interval:15000}"
+           timeout_check_interval="${jgroups.fd_all.timetou_check_interval:5000}" />
+   <VERIFY_SUSPECT timeout="5000"/>
+   <pbcast.NAKACK2
+                   xmit_interval="1000"
+                   xmit_table_num_rows="100"
+                   xmit_table_msgs_per_row="10000"
+                   xmit_table_max_compaction_time="10000"
+                   max_msg_batch_size="100"/>
+   <UNICAST3 xmit_interval="500"
+             xmit_table_num_rows="20"
+             xmit_table_msgs_per_row="10000"
+             xmit_table_max_compaction_time="10000"
+             max_msg_batch_size="100"
+             conn_expiry_timeout="0"/>
+   <pbcast.STABLE stability_delay="500" desired_avg_gossip="5000" max_bytes="1m"/>
+   <pbcast.GMS print_local_addr="false" join_timeout="15000" view_bundling="true"/>
+   <!-- !!! Beware: max_credits * min_threshold must be > frag_size !!! -->
+   <UFC max_credits="${jgroups.ufc.max_credits:2M}"  min_threshold="0.40"/>
+   <MFC max_credits="${jgroups.mfc.max_credits:2M}" min_threshold="0.40"/>
+   <FRAG2 frag_size="60k"  />
+   <RSVP timeout="60000" resend_interval="500" ack_on_delivery="false" />
+</config>

--- a/plugins/infinispan80/src/main/resources/plugin.properties
+++ b/plugins/infinispan80/src/main/resources/plugin.properties
@@ -1,5 +1,5 @@
-service.default org.radargun.service.Infinispan70EmbeddedService
-service.embedded org.radargun.service.Infinispan70EmbeddedService
+service.default org.radargun.service.Infinispan80EmbeddedService
+service.embedded org.radargun.service.Infinispan80EmbeddedService
 service.server org.radargun.service.Infinispan60ServerService
 service.hotrod org.radargun.service.Infinispan71HotrodService
 service.jcache org.radargun.service.JCacheService

--- a/plugins/infinispan80/src/main/resources/query-no-tx-indexed.xml
+++ b/plugins/infinispan80/src/main/resources/query-no-tx-indexed.xml
@@ -1,0 +1,185 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this library; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA
+  -->
+
+<infinispan
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="urn:infinispan:config:7.0 http://www.infinispan.org/schemas/infinispan-config-7.0.xsd"
+        xmlns="urn:infinispan:config:7.0">
+
+    <jgroups>
+        <stack-file name="jgroupsStack" path="${infinispan.jgroups.config:jgroups-udp-custom.xml}"/>
+    </jgroups>
+
+    <cache-container name="default" default-cache="default">
+        <transport stack="jgroupsStack" lock-timeout="600000" cluster="default" />
+        <serialization></serialization>
+        <jmx duplicate-domains="true">
+            <property name="enabled">true</property>
+        </jmx>
+        <local-cache name="default" />
+
+       <distributed-cache name="dist_lucene" owners="2" segments="512">
+          <locking acquire-timeout="3000" concurrency-level="1000" />
+          <transaction mode="NONE"/>
+
+          <indexing index="LOCAL">
+             <property name="default.indexmanager">org.infinispan.query.indexmanager.InfinispanIndexManager</property>
+             <property name="default.exclusive_index_use">true</property>
+             <property name="default.metadata_cachename">lucene_metadata_repl</property>
+             <property name="default.data_cachename">lucene_data_dist</property>
+             <property name="default.locking_cachename">lucene_locking_repl</property>
+          </indexing>
+       </distributed-cache>
+
+       <distributed-cache name="dist_lucene_repl" owners="2" segments="512">
+          <locking acquire-timeout="3000" concurrency-level="1000" />
+          <transaction mode="NONE"/>
+
+          <indexing index="LOCAL">
+             <property name="default.indexmanager">org.infinispan.query.indexmanager.InfinispanIndexManager</property>
+             <property name="default.exclusive_index_use">true</property>
+             <property name="default.metadata_cachename">lucene_metadata_repl_for_repl</property>
+             <property name="default.data_cachename">lucene_data_repl</property>
+             <property name="default.locking_cachename">lucene_locking_repl_for_repl</property>
+          </indexing>
+       </distributed-cache>
+
+       <distributed-cache name="dist_lucene_repl_async1" owners="2" segments="512">
+          <locking acquire-timeout="3000" concurrency-level="1000" />
+          <transaction mode="NONE"/>
+
+          <indexing index="LOCAL">
+             <property name="default.indexmanager">org.infinispan.query.indexmanager.InfinispanIndexManager</property>
+             <property name="default.exclusive_index_use">true</property>
+             <property name="default.worker.execution">async</property>
+             <property name="default.worker.thread_pool.size">8</property>
+             <property name="default.worker.buffer_queue.max">1000</property>
+             <property name="default.metadata_cachename">lucene_metadata_repl_for_repl_async1</property>
+             <property name="default.data_cachename">lucene_data_repl_async1</property>
+             <property name="default.locking_cachename">lucene_locking_repl_for_repl_async1</property>
+          </indexing>
+       </distributed-cache>
+
+       <distributed-cache name="dist_lucene_repl_async8" owners="2" segments="512">
+          <locking acquire-timeout="3000" concurrency-level="1000" />
+          <transaction mode="NONE"/>
+
+          <indexing index="LOCAL">
+             <property name="default.indexmanager">org.infinispan.query.indexmanager.InfinispanIndexManager</property>
+             <property name="default.exclusive_index_use">true</property>
+             <property name="default.worker.execution">async</property>
+             <property name="default.worker.thread_pool.size">8</property>
+             <property name="default.worker.buffer_queue.max">1000</property>
+             <property name="default.metadata_cachename">lucene_metadata_repl_for_repl_async8</property>
+             <property name="default.data_cachename">lucene_data_repl_async8</property>
+             <property name="default.locking_cachename">lucene_locking_repl_for_repl_async8</property>
+          </indexing>
+       </distributed-cache>
+
+       <replicated-cache name="repl_ram">
+          <locking acquire-timeout="3000" concurrency-level="1000" />
+          <transaction mode="NONE"/>
+
+          <indexing index="ALL">
+             <property name="default.directory_provider">ram</property>
+             <property name="default.indexmanager">near-real-time</property>
+             <property name="default.exclusive_index_use">true</property>
+          </indexing>
+       </replicated-cache>
+
+       <replicated-cache name="repl_fs">
+          <locking acquire-timeout="3000" concurrency-level="1000" />
+          <transaction mode="NONE"/>
+
+          <indexing index="ALL">
+             <property name="default.directory_provider">filesystem</property>
+             <property name="default.indexmanager">near-real-time</property>
+             <property name="default.indexBase">/tmp/ispn_fs_index/${log4j.file.prefix}</property>
+             <property name="default.exclusive_index_use">true</property>
+          </indexing>
+       </replicated-cache>
+
+
+       <local-cache name="local_ram">
+          <locking acquire-timeout="3000" concurrency-level="1000" />
+          <transaction mode="NONE"/>
+
+          <indexing index="ALL">
+             <property name="default.directory_provider">ram</property>
+             <property name="default.indexmanager">near-real-time</property>
+             <property name="default.exclusive_index_use">true</property>
+          </indexing>
+       </local-cache>
+
+       <local-cache name="local_fs">
+          <locking acquire-timeout="3000" concurrency-level="1000" />
+          <transaction mode="NONE"/>
+
+          <indexing index="ALL">
+             <property name="default.directory_provider">filesystem</property>
+             <property name="default.indexmanager">near-real-time</property>
+             <property name="default.indexBase">/tmp/ispn_fs_index/${log4j.file.prefix}</property>
+             <property name="default.exclusive_index_use">true</property>
+          </indexing>
+       </local-cache>
+
+       <replicated-cache name="lucene_metadata_repl" mode="SYNC" remote-timeout="25000">
+          <indexing index="NONE" />
+       </replicated-cache>
+       <distributed-cache name="lucene_data_dist" mode="SYNC" remote-timeout="25000">
+          <indexing index="NONE" />
+       </distributed-cache>
+       <replicated-cache name="lucene_locking_repl" mode="SYNC" remote-timeout="25000">
+          <indexing index="NONE" />
+       </replicated-cache>
+
+       <replicated-cache name="lucene_metadata_repl_for_repl" mode="SYNC" remote-timeout="25000">
+          <indexing index="NONE" />
+       </replicated-cache>
+       <replicated-cache name="lucene_data_repl" mode="SYNC" remote-timeout="25000">
+          <indexing index="NONE" />
+       </replicated-cache>
+       <replicated-cache name="lucene_locking_repl_for_repl" mode="SYNC" remote-timeout="25000">
+          <indexing index="NONE" />
+       </replicated-cache>
+
+       <replicated-cache name="lucene_metadata_repl_for_repl_async1" mode="SYNC" remote-timeout="25000">
+          <indexing index="NONE" />
+       </replicated-cache>
+       <replicated-cache name="lucene_data_repl_async1" mode="SYNC" remote-timeout="25000">
+          <indexing index="NONE" />
+       </replicated-cache>
+       <replicated-cache name="lucene_locking_repl_for_repl_async1" mode="SYNC" remote-timeout="25000">
+          <indexing index="NONE" />
+       </replicated-cache>
+
+       <replicated-cache name="lucene_metadata_repl_for_repl_async8" mode="SYNC" remote-timeout="25000">
+          <indexing index="NONE" />
+       </replicated-cache>
+       <replicated-cache name="lucene_data_repl_async8" mode="SYNC" remote-timeout="25000">
+          <indexing index="NONE" />
+       </replicated-cache>
+       <replicated-cache name="lucene_locking_repl_for_repl_async8" mode="SYNC" remote-timeout="25000">
+          <indexing index="NONE" />
+       </replicated-cache>
+
+    </cache-container>
+
+</infinispan>

--- a/plugins/jdg65/src/main/resources/jgroups-udp-custom.xml
+++ b/plugins/jdg65/src/main/resources/jgroups-udp-custom.xml
@@ -1,0 +1,59 @@
+<!--
+  ~ JBoss, Home of Professional Open Source
+  ~ Copyright 2010 Red Hat Inc. and/or its affiliates and other
+  ~ contributors as indicated by the @author tags. All rights reserved.
+  ~ See the copyright.txt in the distribution for a full listing of
+  ~ individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<config xmlns="urn:org:jgroups"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+   <UDP
+        bind_addr="${jgroups.udp.bind_addr:localhost}"
+        bind_port="${jgroups.udp.bind_port:52000}"
+        mcast_addr="${jgroups.udp.mcast_addr:234.99.54.14}"
+        mcast_port="${jgroups.udp.mcast_port:45688}"
+        ip_ttl="${jgroups.udp.ip_ttl:8}"
+        thread_naming_pattern="pl"
+        enable_diagnostics="false"
+        ucast_send_buf_size="1M"
+        mcast_send_buf_size="1M"
+
+        thread_pool.max_threads="${jgroups.thread_pool.max_threads:200}"
+
+        internal_thread_pool.max_threads="${jgroups.internal_thread_pool.max_threads:20}"
+        internal_thread_pool.queue_enabled="false"
+        internal_thread_pool.rejection_policy="Abort"
+
+        oob_thread_pool.max_threads="${jgroups.oob_thread_pool.max_threads:500}"
+        oob_thread_pool.queue_enabled="false"
+        />
+
+   <PING />
+   <MERGE3 min_interval="10000" max_interval="30000" />
+   <FD_SOCK />
+   <FD_ALL timeout="60000" interval="15000" timeout_check_interval="5000" />
+   <VERIFY_SUSPECT />
+   <pbcast.NAKACK2 use_mcast_xmit="false"/>
+   <UNICAST3 />
+   <pbcast.STABLE />
+   <pbcast.GMS join_timeout="15000" />
+   <!-- !!! Beware: max_credits * min_threshold must be > frag_size !!! -->
+   <UFC max_credits="${jgroups.ufc.max_credits:2M}" min_threshold="0.40" />
+   <MFC max_credits="${jgroups.mfc.max_credits:2M}" min_threshold="0.40" />
+   <FRAG2 />
+</config>

--- a/plugins/jdg65/src/main/resources/query-no-tx-indexed.xml
+++ b/plugins/jdg65/src/main/resources/query-no-tx-indexed.xml
@@ -1,0 +1,226 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this library; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA
+  -->
+
+<infinispan
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="urn:infinispan:config:6.0 http://www.infinispan.org/schemas/infinispan-config-6.0.xsd"
+        xmlns="urn:infinispan:config:6.0">
+
+   <global>
+      <transport clusterName="default" distributedSyncTimeout="600000">
+         <properties>
+            <property name="configurationFile" value="${infinispan.jgroups.config:jgroups-udp-custom.xml}"/>
+         </properties>
+      </transport>
+      <globalJmxStatistics allowDuplicateDomains="true" />
+   </global>
+
+   <default/>
+
+   <namedCache name="dist_lucene">
+      <transaction transactionMode="NON_TRANSACTIONAL"/>
+      <clustering mode="DIST">
+         <hash numOwners="2" />
+      </clustering>
+      <locking lockAcquisitionTimeout="3000" concurrencyLevel="1000" />
+
+      <indexing enabled="true" indexLocalOnly="true">
+         <properties>
+            <property name="default.indexmanager" value="org.infinispan.query.indexmanager.InfinispanIndexManager" />
+            <property name="default.exclusive_index_use" value="true" />
+            <property name="default.metadata_cachename" value="lucene_metadata_repl" />
+            <property name="default.data_cachename" value="lucene_data_dist" />
+            <property name="default.locking_cachename" value="lucene_locking_repl" />
+            <property name="lucene_version" value="LUCENE_36" />
+         </properties>
+      </indexing>
+   </namedCache>
+
+   <namedCache name="dist_lucene_repl">
+      <transaction transactionMode="NON_TRANSACTIONAL"/>
+      <clustering mode="DIST">
+         <hash numOwners="2" />
+      </clustering>
+      <locking lockAcquisitionTimeout="3000" concurrencyLevel="1000" />
+
+      <indexing enabled="true" indexLocalOnly="true">
+         <properties>
+            <property name="default.indexmanager" value="org.infinispan.query.indexmanager.InfinispanIndexManager" />
+            <property name="default.exclusive_index_use" value="true" />
+            <property name="default.metadata_cachename" value="lucene_metadata_repl_for_repl" />
+            <property name="default.data_cachename" value="lucene_data_repl" />
+            <property name="default.locking_cachename" value="lucene_locking_repl_for_repl" />
+            <property name="lucene_version" value="LUCENE_36" />
+         </properties>
+      </indexing>
+   </namedCache>
+
+   <namedCache name="dist_lucene_repl_async1">
+      <transaction transactionMode="NON_TRANSACTIONAL"/>
+      <clustering mode="DIST">
+         <hash numOwners="2" />
+      </clustering>
+      <locking lockAcquisitionTimeout="3000" concurrencyLevel="1000" />
+
+      <indexing enabled="true" indexLocalOnly="true">
+         <properties>
+            <property name="default.indexmanager" value="org.infinispan.query.indexmanager.InfinispanIndexManager" />
+            <property name="default.worker.execution" value="async" />
+            <property name="default.worker.thread_pool.size" value="1" />
+            <!--<property name="default.worker.buffer_queue.max" value="1000"/>-->
+
+            <property name="default.max_queue_length" value="10000" />
+            <property name="default.indexwriter.merge_factor" value="30" />
+            <property name="default.index_flush_interval" value="2000" />
+            <property name="default.indexwriter.merge_max_size" value="1024" />
+            <property name="default.indexwriter.ram_buffer_size" value="512" />
+
+            <property name="default.exclusive_index_use" value="true" />
+            <property name="default.metadata_cachename" value="lucene_metadata_repl_for_repl_async1" />
+            <property name="default.data_cachename" value="lucene_data_repl_async1" />
+            <property name="default.locking_cachename" value="lucene_locking_repl_for_repl_async1" />
+            <property name="lucene_version" value="LUCENE_36" />
+         </properties>
+      </indexing>
+   </namedCache>
+
+   <namedCache name="dist_lucene_repl_async8">
+      <transaction transactionMode="NON_TRANSACTIONAL"/>
+      <clustering mode="DIST">
+         <hash numOwners="2" />
+      </clustering>
+      <locking lockAcquisitionTimeout="3000" concurrencyLevel="1000" />
+
+      <indexing enabled="true" indexLocalOnly="true">
+         <properties>
+            <property name="default.indexmanager" value="org.infinispan.query.indexmanager.InfinispanIndexManager" />
+            <property name="default.worker.execution" value="async" />
+            <property name="default.worker.thread_pool.size" value="8" />
+            <property name="default.worker.buffer_queue.max" value="1000"/>
+            <property name="default.exclusive_index_use" value="true" />
+            <property name="default.metadata_cachename" value="lucene_metadata_repl_for_repl_async8" />
+            <property name="default.data_cachename" value="lucene_data_repl_async8" />
+            <property name="default.locking_cachename" value="lucene_locking_repl_for_repl_async8" />
+            <property name="lucene_version" value="LUCENE_36" />
+         </properties>
+      </indexing>
+   </namedCache>
+
+
+   <namedCache name="repl_ram">
+      <transaction transactionMode="NON_TRANSACTIONAL"/>
+      <clustering mode="REPL" />
+      <locking lockAcquisitionTimeout="3000" concurrencyLevel="1000" />
+
+      <indexing enabled="true" indexLocalOnly="false">
+         <properties>
+            <property name="default.directory_provider" value="ram" />
+            <property name="default.indexmanager" value="near-real-time" />
+            <property name="default.exclusive_index_use" value="true" />
+         </properties>
+      </indexing>
+   </namedCache>
+
+   <namedCache name="repl_fs">
+      <transaction transactionMode="NON_TRANSACTIONAL"/>
+      <clustering mode="REPL" />
+      <locking lockAcquisitionTimeout="3000" concurrencyLevel="1000" />
+
+      <indexing enabled="true" indexLocalOnly="false">
+         <properties>
+            <property name="default.directory_provider" value="filesystem" />
+            <property name="default.indexmanager" value="near-real-time" />
+            <property name="default.exclusive_index_use" value="true" />
+            <property name="default.indexBase" value="/tmp/ispn_fs_index/${log4j.file.prefix}"/>
+         </properties>
+      </indexing>
+   </namedCache>
+
+   <namedCache name="local_ram">
+      <transaction transactionMode="NON_TRANSACTIONAL"/>
+      <clustering mode="local" />
+      <locking lockAcquisitionTimeout="3000" concurrencyLevel="1000" />
+
+      <indexing enabled="true">
+         <properties>
+            <property name="default.directory_provider" value="ram" />
+            <property name="default.indexmanager" value="near-real-time" />
+            <property name="default.exclusive_index_use" value="true" />
+         </properties>
+      </indexing>
+   </namedCache>
+
+   <namedCache name="local_fs">
+      <transaction transactionMode="NON_TRANSACTIONAL"/>
+      <clustering mode="local" />
+      <locking lockAcquisitionTimeout="3000" concurrencyLevel="1000" />
+
+      <indexing enabled="true">
+         <properties>
+            <property name="default.directory_provider" value="filesystem" />
+            <property name="default.indexmanager" value="near-real-time" />
+            <property name="default.exclusive_index_use" value="true" />
+            <property name="default.indexBase" value="/tmp/ispn_fs_index/${log4j.file.prefix}"/>
+         </properties>
+      </indexing>
+   </namedCache>
+
+   <namedCache name="lucene_metadata_repl">
+      <clustering mode="REPL" />
+   </namedCache>
+   <namedCache name="lucene_data_dist">
+      <clustering mode="DIST">
+         <hash numOwners="2" />
+      </clustering>
+   </namedCache>
+   <namedCache name="lucene_locking_repl">
+      <clustering mode="REPL" />
+   </namedCache>
+
+   <namedCache name="lucene_metadata_repl_for_repl">
+      <clustering mode="REPL" />
+   </namedCache>
+   <namedCache name="lucene_data_repl">
+      <clustering mode="REPL" />
+   </namedCache>
+   <namedCache name="lucene_locking_repl_for_repl">
+      <clustering mode="REPL" />
+   </namedCache>
+
+   <namedCache name="lucene_metadata_repl_for_repl_async1">
+      <clustering mode="REPL" />
+   </namedCache>
+   <namedCache name="lucene_data_repl_async1">
+      <clustering mode="REPL" />
+   </namedCache>
+   <namedCache name="lucene_locking_repl_for_repl_async1">
+      <clustering mode="REPL" />
+   </namedCache>
+
+   <namedCache name="lucene_metadata_repl_for_repl_async8">
+      <clustering mode="REPL" />
+   </namedCache>
+   <namedCache name="lucene_data_repl_async8">
+      <clustering mode="REPL" />
+   </namedCache>
+   <namedCache name="lucene_locking_repl_for_repl_async8">
+      <clustering mode="REPL" />
+   </namedCache>
+</infinispan>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -29,7 +29,7 @@
       <dependency>
          <groupId>org.jboss.logging</groupId>
          <artifactId>jboss-logging</artifactId>
-         <version>3.1.4.GA</version>
+         <version>3.3.0.Final</version>
       </dependency>
    </dependencies>
 </project>


### PR DESCRIPTION
This is a preview - hazelcast plugin still needs to be updated, plus merging with @vjuranek CQ support will be needed (and for 3.x branch also with @rvansa changes).
ProjectionConverter is just a converter for a list of AttributeConverters, but I didn't figure out if they can be somehow merged.
The QueryBuilder interface doesn't have any new having() methods - the filtering that happens before .groupBy() is the WHERE clause, and filtering after groupBy is meant as the HAVING clause.

Example query:
```html
       <query test-name="lala"
              duration="5s"
              num-threads-per-node="1"
              projection="integerValue,sum(integerValue),max(integerValue)"
              group-by="integerValue" 
              query-object-class="org.radargun.query.NumberObject">
           <conditions>
               <le path="integerValue" value="999999"/>
           </conditions>
           <having>
              <gt path="sum(integerValue)" value="50000" />
           </having>
       </query>
```