### PR TITLE
Query aggregations

### DIFF
--- a/core/src/main/java/org/radargun/stages/cache/test/AbstractQueryStage.java
+++ b/core/src/main/java/org/radargun/stages/cache/test/AbstractQueryStage.java
@@ -84,12 +84,11 @@ public abstract class AbstractQueryStage extends TestStage {
         }
         if (orderBy != null) {
             for (SortElement se : orderBy) {
-                builder.orderBy(new Queryable.SelectExpression(se.attribute), se.asc ? Queryable.SortOrder.ASCENDING : Queryable.SortOrder.DESCENDING);
+                builder.orderBy(new Queryable.SelectExpression(se.attribute, se.asc));
             }
         } else if (orderByAggregatedColumns != null) {
             for (OrderedSelectExpressionElement orderByAggregatedColumn : orderByAggregatedColumns) {
-                builder.orderBy(orderByAggregatedColumn.toSelectExpression(), orderByAggregatedColumn.toSelectExpression().asc ?
-                      Queryable.SortOrder.ASCENDING : Queryable.SortOrder.DESCENDING);
+                builder.orderBy(orderByAggregatedColumn.toSelectExpression());
             }
         }
         if (projection != null) {

--- a/core/src/main/java/org/radargun/stages/cache/test/AbstractQueryStage.java
+++ b/core/src/main/java/org/radargun/stages/cache/test/AbstractQueryStage.java
@@ -19,22 +19,36 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Base class for stages which contain queries
+ *
+ * The conditions field are the standard conditions that you would expect in a WHERE clause.
+ * Having refers to the conditions which follow the GROUP BY clause, and can make use
+ * of aggregations
  */
 public abstract class AbstractQueryStage extends TestStage {
 
     @Property(optional = false, doc = "Full class name of the object that should be queried. Mandatory.")
     protected String queryObjectClass;
 
-    @Property(optional = false, doc = "Conditions used in the query", complexConverter = ConditionConverter.class)
+    @Property(optional = false, doc = "Conditions used in the query.", complexConverter = ConditionConverter.class)
     protected List<Condition> conditions;
+
+    @Property(doc = "Conditions applied to groups when using group-by, can use aggregations.", complexConverter = ConditionConverter.class)
+    protected List<Condition> having;
 
     @Property(doc = "Use projection instead of returning full object. Default is without projection.")
     protected String[] projection;
+
+    @Property(doc = "Projection, possibly with aggregations.",
+            complexConverter = ProjectionConverter.class)
+    protected List<SelectExpressionElement>  aggregatedProjection;
 
     @Property(doc = "Use sorting order, in form [attribute[:(ASC|DESC)]][,attribute[:(ASC|DESC)]]*. " +
             "Without specifying ASC or DESC the sort order defaults to ASC. Default is unordereded.",
             converter = SortConverter.class)
     protected List<SortElement> orderBy;
+
+    @Property(doc = "Use grouping, in form [attribute][,attribute]*. Default is without grouping.")
+    protected String[] groupBy;
 
     @Property(doc = "Offset in the results. Default is none.")
     protected long offset = -1;
@@ -61,8 +75,25 @@ public abstract class AbstractQueryStage extends TestStage {
     }
 
     protected static abstract class PathCondition extends Condition {
-        @Property(doc = "Target path (field on the queried object or path through embedded objects)", optional = false)
+        @Property(doc = "Target path (field on the queried object or path through embedded objects)")
         public String path;
+
+        @Property(doc = "Target path, can be aggregated.", complexConverter = SelectExpressionConverter.class)
+        public SelectExpressionElement aggregatedPath;
+
+        Queryable.SelectExpression resolvedPath;
+
+        public void apply(Queryable.QueryBuilder builder) {
+            if (path != null) {
+                resolvedPath = new Queryable.SelectExpression(path);
+            }
+            if (aggregatedPath != null) {
+                resolvedPath = aggregatedPath.toSelectExpression();
+            }
+            if (resolvedPath == null) {
+                throw new IllegalStateException("You need to specify a target path for the condition!");
+            }
+        }
     }
 
     @DefinitionElement(name = "eq", doc = "Target is equal to value")
@@ -72,7 +103,8 @@ public abstract class AbstractQueryStage extends TestStage {
 
         @Override
         public void apply(Queryable.QueryBuilder builder) {
-            builder.eq(path, value);
+            super.apply(builder);
+            builder.eq(resolvedPath, value);
         }
     }
 
@@ -86,7 +118,8 @@ public abstract class AbstractQueryStage extends TestStage {
     protected static class Lt extends PathNumberCondition {
         @Override
         public void apply(Queryable.QueryBuilder builder) {
-            builder.lt(path, value);
+            super.apply(builder);
+            builder.lt(resolvedPath, value);
         }
     }
 
@@ -94,7 +127,8 @@ public abstract class AbstractQueryStage extends TestStage {
     protected static class Le extends PathNumberCondition {
         @Override
         public void apply(Queryable.QueryBuilder builder) {
-            builder.le(path, value);
+            super.apply(builder);
+            builder.le(resolvedPath, value);
         }
     }
 
@@ -102,7 +136,8 @@ public abstract class AbstractQueryStage extends TestStage {
     protected static class Gt extends PathNumberCondition {
         @Override
         public void apply(Queryable.QueryBuilder builder) {
-            builder.gt(path, value);
+            super.apply(builder);
+            builder.gt(resolvedPath, value);
         }
     }
 
@@ -110,7 +145,8 @@ public abstract class AbstractQueryStage extends TestStage {
     protected static class Ge extends PathNumberCondition {
         @Override
         public void apply(Queryable.QueryBuilder builder) {
-            builder.ge(path, value);
+            super.apply(builder);
+            builder.ge(resolvedPath, value);
         }
     }
 
@@ -130,7 +166,8 @@ public abstract class AbstractQueryStage extends TestStage {
 
         @Override
         public void apply(Queryable.QueryBuilder builder) {
-            builder.between(path, lowerBound, lowerInclusive, upperBound, upperInclusive);
+            super.apply(builder);
+            builder.between(resolvedPath, lowerBound, lowerInclusive, upperBound, upperInclusive);
         }
     }
 
@@ -141,7 +178,8 @@ public abstract class AbstractQueryStage extends TestStage {
 
         @Override
         public void apply(Queryable.QueryBuilder builder) {
-            builder.like(path, value);
+            super.apply(builder);
+            builder.like(resolvedPath, value);
         }
     }
 
@@ -152,7 +190,8 @@ public abstract class AbstractQueryStage extends TestStage {
 
         @Override
         public void apply(Queryable.QueryBuilder builder) {
-            builder.contains(path, value);
+            super.apply(builder);
+            builder.contains(resolvedPath, value);
         }
     }
 
@@ -160,7 +199,8 @@ public abstract class AbstractQueryStage extends TestStage {
     protected static class IsNull extends PathCondition {
         @Override
         public void apply(Queryable.QueryBuilder builder) {
-            builder.isNull(path);
+            super.apply(builder);
+            builder.isNull(resolvedPath);
         }
     }
 
@@ -197,7 +237,7 @@ public abstract class AbstractQueryStage extends TestStage {
         }
     }
 
-    @DefinitionElement(name = "all", doc = "All inner conditions are false", resolveType = DefinitionElement.ResolveType.PASS_BY_DEFINITION)
+    @DefinitionElement(name = "all", doc = "All inner conditions are true", resolveType = DefinitionElement.ResolveType.PASS_BY_DEFINITION)
     protected static class All extends Condition {
         @Property(name = "", doc = "Inner conditions", complexConverter = ConditionConverter.class)
         public final List<Condition> subs = new ArrayList<Condition>();
@@ -213,6 +253,80 @@ public abstract class AbstractQueryStage extends TestStage {
     protected static class ConditionConverter extends ReflexiveConverters.ListConverter {
         public ConditionConverter() {
             super(new Class[] {Eq.class, Lt.class, Le.class, Gt.class, Ge.class, Between.class, Like.class, Contains.class, IsNull.class, Not.class, Any.class, All.class});
+        }
+    }
+
+    protected static abstract class SelectExpressionElement {
+        @Property(doc = "Target path (field on the queried object or path through embedded objects)", optional = false)
+        public String path;
+
+        public abstract Queryable.SelectExpression toSelectExpression();
+
+        public String toString() {
+            return PropertyHelper.getDefinitionElementName(getClass()) + PropertyHelper.toString(this);
+        }
+    }
+
+    @DefinitionElement(name = "attribute", doc = "Simple attribute projection, with no aggregation function.")
+    protected static class Attribute extends SelectExpressionElement {
+        @Override
+        public Queryable.SelectExpression toSelectExpression() {
+            return new Queryable.SelectExpression(path, Queryable.AggregationFunction.NONE);
+        }
+    }
+
+    @DefinitionElement(name = "count", doc = "Count aggregation.")
+    protected static class Count extends SelectExpressionElement {
+        @Override
+        public Queryable.SelectExpression toSelectExpression() {
+            return new Queryable.SelectExpression(path, Queryable.AggregationFunction.COUNT
+            );
+        }
+    }
+
+    @DefinitionElement(name = "sum", doc = "Sum aggregation.")
+    protected static class Sum extends SelectExpressionElement {
+        @Override
+        public Queryable.SelectExpression toSelectExpression() {
+            return new Queryable.SelectExpression(path, Queryable.AggregationFunction.SUM);
+        }
+    }
+
+    @DefinitionElement(name = "avg", doc = "Average aggregation.")
+    protected static class Avg extends SelectExpressionElement {
+        @Override
+        public Queryable.SelectExpression toSelectExpression() {
+            return new Queryable.SelectExpression(path, Queryable.AggregationFunction.AVG);
+        }
+    }
+
+    @DefinitionElement(name = "min", doc = "Minimum aggregation.")
+    protected static class Min extends SelectExpressionElement {
+        @Override
+        public Queryable.SelectExpression toSelectExpression() {
+            return new Queryable.SelectExpression(path, Queryable.AggregationFunction.MIN);
+        }
+    }
+
+    @DefinitionElement(name = "max", doc = "Max aggregation.")
+    protected static class Max extends SelectExpressionElement {
+        @Override
+        public Queryable.SelectExpression toSelectExpression() {
+            return new Queryable.SelectExpression(path, Queryable.AggregationFunction.MAX);
+        }
+    }
+
+    protected static Class<? extends SelectExpressionElement>[]  SELECT_EXPRESSIONS = new Class[] {Attribute.class, Count.class, Sum.class, Avg.class, Min.class, Max.class};
+
+    protected static class ProjectionConverter extends ReflexiveConverters.ListConverter {
+        public ProjectionConverter() {
+            super(SELECT_EXPRESSIONS);
+        }
+    }
+
+    protected static class SelectExpressionConverter extends ReflexiveConverters.ObjectConverter {
+        public SelectExpressionConverter() {
+            super(SELECT_EXPRESSIONS);
         }
     }
 

--- a/core/src/main/java/org/radargun/stages/cache/test/ContinuousQueryStage.java
+++ b/core/src/main/java/org/radargun/stages/cache/test/ContinuousQueryStage.java
@@ -127,12 +127,22 @@ public class ContinuousQueryStage extends AbstractQueryStage {
         }
         if (orderBy != null) {
             for (SortElement se : orderBy) {
-                builder.orderBy(se.attribute, se.asc ? Queryable.SortOrder.ASCENDING : Queryable.SortOrder.DESCENDING);
+                builder.orderBy(new Queryable.SelectExpression(se.attribute), se.asc ? Queryable.SortOrder.ASCENDING : Queryable.SortOrder.DESCENDING);
             }
         }
-        if (projection != null) {
-            builder.projection(projection);
-        }
+       if (projection != null) {
+          Queryable.SelectExpression[] projections = new Queryable.SelectExpression[projection.length];
+          for (int i = 0; i < projection.length; i++) {
+             projections[i] = new Queryable.SelectExpression(projection[i]);
+          }
+          builder.projection(projections);
+       } else if (aggregatedProjection != null && !aggregatedProjection.isEmpty()) {
+          Queryable.SelectExpression[] projections = new Queryable.SelectExpression[aggregatedProjection.size()];
+          for (int i = 0; i < aggregatedProjection.size(); i++) {
+             projections[i] = aggregatedProjection.get(i).toSelectExpression();
+          }
+          builder.projection(projections);
+       }
         if (offset >= 0) {
             builder.offset(offset);
         }

--- a/core/src/main/java/org/radargun/stages/cache/test/QueryStage.java
+++ b/core/src/main/java/org/radargun/stages/cache/test/QueryStage.java
@@ -89,8 +89,10 @@ public class QueryStage extends AbstractQueryStage {
             throw new IllegalArgumentException("Cannot load class " + queryObjectClass, e);
          }
          builder = queryable.getBuilder(null, clazz);
-         for (Condition condition : conditions) {
-            condition.apply(builder);
+         if (conditions != null) {
+            for (Condition condition : conditions) {
+               condition.apply(builder);
+            }
          }
          if (orderBy != null) {
             for (SortElement se : orderBy) {

--- a/core/src/main/java/org/radargun/stages/cache/test/QueryStage.java
+++ b/core/src/main/java/org/radargun/stages/cache/test/QueryStage.java
@@ -83,49 +83,7 @@ public class QueryStage extends AbstractQueryStage {
       public void init(Stressor stressor) {
          super.init(stressor);
          Class<?> clazz;
-         try {
-            clazz = slaveState.getClassLoader().loadClass(queryObjectClass);
-         } catch (ClassNotFoundException e) {
-            throw new IllegalArgumentException("Cannot load class " + queryObjectClass, e);
-         }
-         builder = queryable.getBuilder(null, clazz);
-         if (conditions != null) {
-            for (Condition condition : conditions) {
-               condition.apply(builder);
-            }
-         }
-         if (orderBy != null) {
-            for (SortElement se : orderBy) {
-               builder.orderBy(new Queryable.SelectExpression(se.attribute), se.asc ? Queryable.SortOrder.ASCENDING : Queryable.SortOrder.DESCENDING);
-            }
-         }
-         if (projection != null) {
-            Queryable.SelectExpression[] projections = new Queryable.SelectExpression[projection.length];
-            for (int i = 0; i < projection.length; i++) {
-               projections[i] = new Queryable.SelectExpression(projection[i]);
-            }
-            builder.projection(projections);
-         } else if (aggregatedProjection != null && !aggregatedProjection.isEmpty()) {
-            Queryable.SelectExpression[] projections = new Queryable.SelectExpression[aggregatedProjection.size()];
-            for (int i = 0; i < aggregatedProjection.size(); i++) {
-               projections[i] = aggregatedProjection.get(i).toSelectExpression();
-            }
-            builder.projection(projections);
-         }
-         if (groupBy != null) {
-            builder.groupBy(groupBy);
-            if (having != null) {
-               for (Condition condition : having) {
-                  condition.apply(builder);
-               }
-            }
-         }
-         if (offset >= 0) {
-            builder.offset(offset);
-         }
-         if (limit >= 0) {
-            builder.limit(limit);
-         }
+         builder = constructBuilder();
       }
 
       @Override

--- a/core/src/main/java/org/radargun/traits/Queryable.java
+++ b/core/src/main/java/org/radargun/traits/Queryable.java
@@ -50,17 +50,26 @@ public interface Queryable {
       Query build();
    }
 
+   /**
+    * Used to represent aggregated attributes and also order by expressions
+    */
    class SelectExpression {
       public String attribute;
       public AggregationFunction function;
+      public boolean asc;
 
       public SelectExpression(String attribute) {
-         this(attribute, AggregationFunction.NONE);
+         this(attribute, AggregationFunction.NONE, true);
       }
 
       public SelectExpression(String attribute, AggregationFunction function) {
+         this(attribute, function, true);
+      }
+
+      public SelectExpression(String attribute, AggregationFunction function, boolean asc) {
          this.attribute = attribute;
          this.function = function;
+         this.asc = asc;
       }
    }
 

--- a/core/src/main/java/org/radargun/traits/Queryable.java
+++ b/core/src/main/java/org/radargun/traits/Queryable.java
@@ -27,25 +27,50 @@ public interface Queryable {
 
    /**
     * The instance should be reusable, but not thread-safe.
+    * Conditions defined after groupBy call are meant to be part of the HAVING clause.
     */
    interface QueryBuilder {
       QueryBuilder subquery();
-      QueryBuilder eq(String attribute, Object value);
-      QueryBuilder lt(String attribute, Object value);
-      QueryBuilder le(String attribute, Object value);
-      QueryBuilder gt(String attribute, Object value);
-      QueryBuilder ge(String attribute, Object value);
-      QueryBuilder between(String attribute, Object lowerBound, boolean lowerInclusive, Object upperBound, boolean upperInclusive);
-      QueryBuilder isNull(String attribute);
-      QueryBuilder like(String attribute, String pattern);
-      QueryBuilder contains(String attribute, Object value);
+      QueryBuilder eq(SelectExpression selectExpression, Object value);
+      QueryBuilder lt(SelectExpression selectExpression, Object value);
+      QueryBuilder le(SelectExpression selectExpression, Object value);
+      QueryBuilder gt(SelectExpression selectExpression, Object value);
+      QueryBuilder ge(SelectExpression selectExpression, Object value);
+      QueryBuilder between(SelectExpression selectExpression, Object lowerBound, boolean lowerInclusive, Object upperBound, boolean upperInclusive);
+      QueryBuilder isNull(SelectExpression selectExpression);
+      QueryBuilder like(SelectExpression selectExpression, String pattern);
+      QueryBuilder contains(SelectExpression selectExpression, Object value);
       QueryBuilder not(QueryBuilder subquery);
       QueryBuilder any(QueryBuilder... subqueries);
-      QueryBuilder orderBy(String attribute, SortOrder order);
-      QueryBuilder projection(String... attribute);
+      QueryBuilder orderBy(SelectExpression selectExpression, SortOrder order);
+      QueryBuilder projection(SelectExpression... selectExpressions);
+      QueryBuilder groupBy(String[] attribute);
       QueryBuilder offset(long offset);
       QueryBuilder limit(long limit);
       Query build();
+   }
+
+   class SelectExpression {
+      public String attribute;
+      public AggregationFunction function;
+
+      public SelectExpression(String attribute) {
+         this(attribute, AggregationFunction.NONE);
+      }
+
+      public SelectExpression(String attribute, AggregationFunction function) {
+         this.attribute = attribute;
+         this.function = function;
+      }
+   }
+
+   enum AggregationFunction {
+      NONE,
+      COUNT,
+      SUM,
+      AVG,
+      MIN,
+      MAX;
    }
 
    enum SortOrder {

--- a/core/src/main/java/org/radargun/traits/Queryable.java
+++ b/core/src/main/java/org/radargun/traits/Queryable.java
@@ -42,7 +42,7 @@ public interface Queryable {
       QueryBuilder contains(SelectExpression selectExpression, Object value);
       QueryBuilder not(QueryBuilder subquery);
       QueryBuilder any(QueryBuilder... subqueries);
-      QueryBuilder orderBy(SelectExpression selectExpression, SortOrder order);
+      QueryBuilder orderBy(SelectExpression selectExpression);
       QueryBuilder projection(SelectExpression... selectExpressions);
       QueryBuilder groupBy(String[] attribute);
       QueryBuilder offset(long offset);
@@ -66,6 +66,10 @@ public interface Queryable {
          this(attribute, function, true);
       }
 
+      public SelectExpression(String attribute, boolean asc) {
+         this(attribute, AggregationFunction.NONE, asc);
+      }
+
       public SelectExpression(String attribute, AggregationFunction function, boolean asc) {
          this.attribute = attribute;
          this.function = function;
@@ -80,11 +84,6 @@ public interface Queryable {
       AVG,
       MIN,
       MAX;
-   }
-
-   enum SortOrder {
-      ASCENDING,
-      DESCENDING
    }
 
 }

--- a/core/src/main/resources/benchmark-query-aggregations.xml
+++ b/core/src/main/resources/benchmark-query-aggregations.xml
@@ -24,7 +24,7 @@
                  num-threads="10" entry-size="0"
                  transaction-size="${tx.size:500}" use-transactions="${tx.type:NEVER}" max-load-attempts="50">
          <value-generator>
-            <number-object int-min="0" int-max="10000" double-min="0" double-max="20"/>
+            <number-object int-min="0" int-max="20" double-min="0" double-max="10000"/>
          </value-generator>
       </load-data>
 
@@ -32,25 +32,25 @@
            GROUP BY doubleValue HAVING sum(integerValue)>50000 ORDER BY sum(integerValue) -->
       <query test-name="globalSum"
              duration="30s"
-             group-by="doubleValue"
+             group-by="integerValue"
              num-threads-per-node="10"
              query-object-class="org.radargun.query.NumberObject">
          <projection-aggregated>
-            <sum path="integerValue"/>
+            <sum path="doubleValue"/>
          </projection-aggregated>
          <conditions>
-            <lt path="integerValue" value="50000"/>
-            <lt path="doubleValue" value="10"/>
+            <lt path="doubleValue" value="50000"/>
+            <lt path="integerValue" value="10"/>
          </conditions>
          <having>
             <gt value="50000">
                <aggregated-path>
-                  <sum path="integerValue"/>
+                  <sum path="doubleValue"/>
                </aggregated-path>
             </gt>
          </having>
          <order-by-aggregated-columns>
-            <sum path="integerValue"/>
+            <sum path="doubleValue"/>
          </order-by-aggregated-columns>
       </query>
    </scenario>

--- a/core/src/main/resources/benchmark-query-aggregations.xml
+++ b/core/src/main/resources/benchmark-query-aggregations.xml
@@ -1,0 +1,63 @@
+<benchmark xmlns="urn:radargun:benchmark:2.2">
+
+   <master bindAddress="${master.address:127.0.0.1}" port="${master.port:2103}" />
+
+   <clusters>
+      <scale from="1" to="2">
+         <cluster/>
+      </scale>
+   </clusters>
+
+   <configurations>
+      <config name="Infinispan80">
+         <setup plugin="infinispan80">
+            <default xmlns="urn:radargun:plugins:infinispan80:2.2" file="query-aggregations.xml" cache="dist_indexless"/>
+         </setup>
+      </config>
+   </configurations>
+
+   <scenario>
+      <service-start />
+
+      <!-- Loading the data -->
+      <load-data seed="1" num-entries="5000"
+                 num-threads="10" entry-size="0"
+                 transaction-size="${tx.size:500}" use-transactions="${tx.type:NEVER}" max-load-attempts="50">
+         <value-generator>
+            <number-object int-min="0" int-max="10000" double-min="0" double-max="20"/>
+         </value-generator>
+      </load-data>
+
+      <!-- SELECT sum(integerValue) FROM NumberObject WHERE integerValue<50000 AND doubleValue<2
+           GROUP BY doubleValue HAVING sum(integerValue)>50000 ORDER BY sum(integerValue) -->
+      <query test-name="globalSum"
+             duration="30s"
+             group-by="doubleValue"
+             num-threads-per-node="10"
+             query-object-class="org.radargun.query.NumberObject">
+         <projection-aggregated>
+            <sum path="integerValue"/>
+         </projection-aggregated>
+         <conditions>
+            <lt path="integerValue" value="50000"/>
+            <lt path="doubleValue" value="10"/>
+         </conditions>
+         <having>
+            <gt value="50000">
+               <aggregated-path>
+                  <sum path="integerValue"/>
+               </aggregated-path>
+            </gt>
+         </having>
+         <order-by-aggregated-columns>
+            <sum path="integerValue"/>
+         </order-by-aggregated-columns>
+      </query>
+   </scenario>
+
+   <reports>
+      <reporter type="html"/>
+      <reporter type="csv"/>
+   </reports>
+
+</benchmark>

--- a/plugins/hazelcast3/pom.xml
+++ b/plugins/hazelcast3/pom.xml
@@ -16,7 +16,7 @@
       <dependency>
          <groupId>com.hazelcast</groupId>
          <artifactId>hazelcast</artifactId>
-         <version>3.4.2</version>
+         <version>3.5.2</version>
       </dependency>
       <dependency>
          <groupId>org.radargun</groupId>

--- a/plugins/hazelcast3/src/main/java/org/radargun/service/HazelcastQueryable.java
+++ b/plugins/hazelcast3/src/main/java/org/radargun/service/HazelcastQueryable.java
@@ -159,8 +159,8 @@ public class HazelcastQueryable implements Queryable {
       }
 
       @Override
-      public QueryBuilder orderBy(SelectExpression selectExpression, SortOrder order) {
-         if (order == SortOrder.DESCENDING) {
+      public QueryBuilder orderBy(SelectExpression selectExpression) {
+         if (!selectExpression.asc) {
             comparator = new InverseComparator(selectExpression.attribute);
          } else {
             comparator = new RegularComparator(selectExpression.attribute);

--- a/plugins/hazelcast3/src/main/java/org/radargun/service/HazelcastQueryable.java
+++ b/plugins/hazelcast3/src/main/java/org/radargun/service/HazelcastQueryable.java
@@ -1,17 +1,10 @@
 package org.radargun.service;
 
-import java.io.IOException;
-import java.io.Serializable;
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
-
 import com.hazelcast.core.IMap;
+import com.hazelcast.mapreduce.aggregation.Aggregation;
+import com.hazelcast.mapreduce.aggregation.Aggregations;
+import com.hazelcast.mapreduce.aggregation.PropertyExtractor;
+import com.hazelcast.mapreduce.aggregation.Supplier;
 import com.hazelcast.query.PagingPredicate;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.Predicates;
@@ -22,8 +15,29 @@ import org.radargun.traits.Queryable;
 import org.radargun.utils.OptimizedMap;
 import org.radargun.utils.Projections;
 
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.io.Serializable;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
 /**
+ *
+ * Hazelcast has a limited support for aggregations - only a single aggregation can be executed per query, without any grouping,
+ * and because of an existing bug, also without filtering:
+ * http://stackoverflow.com/questions/29481508/hazelcast-aggregations-api-results-in-classcastexception-with-predicates
+ * Additionaly, indexes are not used in aggregations.
+ *
  * @author Radim Vansa &lt;rvansa@redhat.com&gt;
+ * @author Jakub Markoš &lt;jmarkos@redhat.com&gt;
  */
 public class HazelcastQueryable implements Queryable {
    private static final Log log = LogFactory.getLog(HazelcastQueryable.class);
@@ -35,7 +49,7 @@ public class HazelcastQueryable implements Queryable {
 
    @Override
    public QueryBuilder getBuilder(String mapName, Class<?> clazz) {
-      return new HazelcastQueryBuilder(service.getMap(mapName));
+      return new HazelcastQueryBuilder(service.getMap(mapName), clazz);
    }
 
    @Override
@@ -45,19 +59,21 @@ public class HazelcastQueryable implements Queryable {
 
    private class HazelcastQueryBuilder implements QueryBuilder {
       private final IMap map;
+      private final Class<?> clazz;
       private Predicate predicate;
       private Comparator comparator;
       private int limit = -1;
       private int offset = 0;
-      private String[] projection;
+      private SelectExpression[] projection;
 
-      private HazelcastQueryBuilder(IMap<Object, Object> map) {
+      private HazelcastQueryBuilder(IMap<Object, Object> map, Class<?> clazz) {
          this.map = map;
+         this.clazz = clazz;
       }
 
       @Override
       public QueryBuilder subquery() {
-         return new HazelcastQueryBuilder(null);
+         return new HazelcastQueryBuilder(null, clazz);
       }
 
       private void implicitAnd(Predicate p) {
@@ -69,56 +85,56 @@ public class HazelcastQueryable implements Queryable {
       }
 
       @Override
-      public QueryBuilder eq(String attribute, Object value) {
-         implicitAnd(Predicates.equal(attribute, (Comparable) value));
+      public QueryBuilder eq(SelectExpression selectExpression, Object value) {
+         implicitAnd(Predicates.equal(selectExpression.attribute, (Comparable) value));
          return this;
       }
 
       @Override
-      public QueryBuilder lt(String attribute, Object value) {
-         implicitAnd(Predicates.lessThan(attribute, (Comparable) value));
+      public QueryBuilder lt(SelectExpression selectExpression, Object value) {
+         implicitAnd(Predicates.lessThan(selectExpression.attribute, (Comparable) value));
          return this;
       }
 
       @Override
-      public QueryBuilder le(String attribute, Object value) {
-         implicitAnd(Predicates.lessEqual(attribute, (Comparable) value));
+      public QueryBuilder le(SelectExpression selectExpression, Object value) {
+         implicitAnd(Predicates.lessEqual(selectExpression.attribute, (Comparable) value));
          return this;
       }
 
       @Override
-      public QueryBuilder gt(String attribute, Object value) {
-         implicitAnd(Predicates.greaterThan(attribute, (Comparable) value));
+      public QueryBuilder gt(SelectExpression selectExpression, Object value) {
+         implicitAnd(Predicates.greaterThan(selectExpression.attribute, (Comparable) value));
          return this;
       }
 
       @Override
-      public QueryBuilder ge(String attribute, Object value) {
-         implicitAnd(Predicates.greaterEqual(attribute, (Comparable) value));
+      public QueryBuilder ge(SelectExpression selectExpression, Object value) {
+         implicitAnd(Predicates.greaterEqual(selectExpression.attribute, (Comparable) value));
          return this;
       }
 
       @Override
-      public QueryBuilder between(String attribute, Object lowerBound, boolean lowerInclusive, Object upperBound, boolean upperInclusive) {
+      public QueryBuilder between(SelectExpression selectExpression, Object lowerBound, boolean lowerInclusive, Object upperBound, boolean upperInclusive) {
          if (!lowerInclusive || !upperInclusive) throw new IllegalArgumentException("Hazelcast supports only inclusive bounds");
-         implicitAnd(Predicates.between(attribute, (Comparable) lowerBound, (Comparable) upperBound));
+         implicitAnd(Predicates.between(selectExpression.attribute, (Comparable) lowerBound, (Comparable) upperBound));
          return this;
       }
 
       @Override
-      public QueryBuilder isNull(String attribute) {
-         implicitAnd(Predicates.equal(attribute, null));
+      public QueryBuilder isNull(SelectExpression selectExpression) {
+         implicitAnd(Predicates.equal(selectExpression.attribute, null));
          return this;
       }
 
       @Override
-      public QueryBuilder like(String attribute, String pattern) {
-         implicitAnd(Predicates.like(attribute, pattern));
+      public QueryBuilder like(SelectExpression selectExpression, String pattern) {
+         implicitAnd(Predicates.like(selectExpression.attribute, pattern));
          return this;
       }
 
       @Override
-      public QueryBuilder contains(String attribute, Object value) {
+      public QueryBuilder contains(SelectExpression selectExpression, Object value) {
          throw new UnsupportedOperationException();
       }
 
@@ -143,20 +159,29 @@ public class HazelcastQueryable implements Queryable {
       }
 
       @Override
-      public QueryBuilder orderBy(String attribute, SortOrder order) {
+      public QueryBuilder orderBy(SelectExpression selectExpression, SortOrder order) {
          if (order == SortOrder.DESCENDING) {
-            comparator = new InverseComparator(attribute);
+            comparator = new InverseComparator(selectExpression.attribute);
          } else {
-            comparator = new RegularComparator(attribute);
+            comparator = new RegularComparator(selectExpression.attribute);
          }
          return this;
       }
 
       @Override
-      public QueryBuilder projection(String... attributes) {
+      public QueryBuilder projection(SelectExpression... selectExpressions) {
          log.warn("Projection is emulated; no native support for projection.");
-         this.projection = attributes;
+         for (SelectExpression selectExpression : selectExpressions) {
+            if (selectExpression.function != AggregationFunction.NONE && selectExpressions.length != 1)
+               throw new RuntimeException("Hazelcast only supports a single aggregation per query!");
+         }
+         this.projection = selectExpressions;
          return this;
+      }
+
+      @Override
+      public QueryBuilder groupBy(String[] attribute) {
+         throw new UnsupportedOperationException();
       }
 
       @Override
@@ -174,6 +199,9 @@ public class HazelcastQueryable implements Queryable {
 
       @Override
       public Query build() {
+         if (projection != null && projection.length == 1 && projection[0].function != AggregationFunction.NONE) {
+            return new HazelcastAggregationQuery(map, clazz, predicate, projection[0]);
+         }
          Predicate finalPredicate;
          if (comparator == null) {
             if (limit < 0) finalPredicate = predicate;
@@ -182,7 +210,11 @@ public class HazelcastQueryable implements Queryable {
             if (limit < 0) finalPredicate = new PagingPredicate(predicate, comparator, Integer.MAX_VALUE);
             else finalPredicate = new PagingPredicate(predicate, comparator, limit);
          }
-         return new HazelcastQuery(map, finalPredicate, offset, projection);
+         String[] stringProjection = new String[projection.length];
+         for (int i = 0; i < projection.length; i++) {
+            stringProjection[i] = projection[i].attribute;
+         }
+         return new HazelcastQuery(map, finalPredicate, offset, stringProjection);
       }
    }
 
@@ -203,6 +235,70 @@ public class HazelcastQueryable implements Queryable {
       public QueryResult execute() {
          if (predicate == null) return new HazelcastQueryResult(map.values(), offset, projection);
          else return new HazelcastQueryResult(map.values(predicate), offset, projection);
+      }
+   }
+
+   private class HazelcastAggregationQuery implements Query {
+      private final IMap map;
+      private final PropertyExtractor propertyExtractor;
+      Aggregation aggregation;
+      Supplier supplier;
+
+      public HazelcastAggregationQuery(IMap map, Class<?> clazz, Predicate predicate, SelectExpression aggregatedAttribute) {
+         this.map = map;
+         Accessor accessor = getAccessor(clazz, aggregatedAttribute.attribute);
+         propertyExtractor = new ReflexivePropertyExtractor(accessor);
+
+         Supplier reflexiveSupplier = Supplier.all(propertyExtractor);
+         if (predicate != null) {
+            supplier = Supplier.fromPredicate(predicate, reflexiveSupplier);
+         } else {
+            supplier = reflexiveSupplier;
+         }
+
+         AggregationFunction function = aggregatedAttribute.function;
+         String type = accessor.getReturnType().getSimpleName();
+
+         aggregation = null;
+         if (function == AggregationFunction.NONE)
+            throw new IllegalStateException("Aggregated query needs an aggregation!");
+         if (function == AggregationFunction.COUNT)
+            aggregation = Aggregations.count();
+         if (function == AggregationFunction.SUM && (type.equals("Integer") || type.equals("int")))
+            aggregation = Aggregations.integerSum();
+         if (function == AggregationFunction.SUM && type.equalsIgnoreCase("double"))
+            aggregation = Aggregations.doubleSum();
+         if (function == AggregationFunction.SUM && type.equalsIgnoreCase("long"))
+            aggregation = Aggregations.longSum();
+         if (function == AggregationFunction.AVG && (type.equals("Integer") || type.equals("int")))
+            aggregation = Aggregations.integerAvg();
+         if (function == AggregationFunction.AVG && type.equalsIgnoreCase("double"))
+            aggregation = Aggregations.doubleAvg();
+         if (function == AggregationFunction.AVG && type.equalsIgnoreCase("long"))
+            aggregation = Aggregations.longAvg();
+         if (function == AggregationFunction.MAX && (type.equals("Integer") || type.equals("int")))
+            aggregation = Aggregations.integerMax();
+         if (function == AggregationFunction.MAX && type.equalsIgnoreCase("double"))
+            aggregation = Aggregations.doubleMax();
+         if (function == AggregationFunction.MAX && type.equalsIgnoreCase("long"))
+            aggregation = Aggregations.longMax();
+         if (function == AggregationFunction.MAX && type.equals("String"))
+            aggregation = Aggregations.comparableMax();
+         if (function == AggregationFunction.MIN && (type.equals("Integer") || type.equals("int")))
+            aggregation = Aggregations.integerMin();
+         if (function == AggregationFunction.MIN && type.equalsIgnoreCase("double"))
+            aggregation = Aggregations.doubleMin();
+         if (function == AggregationFunction.MIN && type.equalsIgnoreCase("long"))
+            aggregation = Aggregations.longMin();
+         if (function == AggregationFunction.MIN && type.equals("String"))
+            aggregation = Aggregations.comparableMin();
+      }
+
+      @Override
+      public QueryResult execute() {
+         ArrayList result = new ArrayList<>();
+         result.add(map.aggregate(supplier, aggregation));
+         return new HazelcastQueryResult(result, 0, null);
       }
    }
 
@@ -357,12 +453,30 @@ public class HazelcastQueryable implements Queryable {
 
    private interface Accessor {
       Object get(Object o);
+
+      Class<?> getReturnType();
+
    }
 
-   private static class FieldAccessor implements Accessor {
-      private final Field f;
+   private static class ReflexivePropertyExtractor<T> implements PropertyExtractor<Object, T> {
+      private Accessor accessor;
 
-      private FieldAccessor(Field f) {
+      public ReflexivePropertyExtractor(Accessor accessor) {
+         this.accessor = accessor;
+      }
+
+      public T extract(Object value) {
+         return (T) accessor.get(value);
+      }
+   }
+
+   private static class FieldAccessor implements Accessor, Externalizable {
+
+      public Field f;
+
+      public FieldAccessor() {}
+
+      public FieldAccessor(Field f) {
          this.f = f;
       }
 
@@ -375,10 +489,33 @@ public class HazelcastQueryable implements Queryable {
             throw new RuntimeException(e);
          }
       }
+
+      @Override
+      public Class<?> getReturnType() {
+         return f.getType();
+      }
+
+      @Override
+      public void writeExternal(ObjectOutput objectOutput) throws IOException {
+         objectOutput.writeObject(f.getDeclaringClass());
+         objectOutput.writeObject(f.getName());
+      }
+
+      @Override
+      public void readExternal(ObjectInput objectInput) throws IOException, ClassNotFoundException {
+         try {
+            f = ((Class) objectInput.readObject()).getDeclaredField((String) objectInput.readObject());
+            f.setAccessible(true);
+         } catch (NoSuchFieldException e) {
+            e.printStackTrace();
+         }
+      }
    }
 
-   private static class MethodAccessor implements Accessor {
-      private final Method m;
+   private static class MethodAccessor implements Accessor, Externalizable {
+      public Method m;
+
+      private MethodAccessor() {}
 
       private MethodAccessor(Method m) {
          this.m = m;
@@ -393,10 +530,33 @@ public class HazelcastQueryable implements Queryable {
             throw new RuntimeException(e);
          }
       }
+
+      @Override
+      public Class<?> getReturnType() {
+         return m.getReturnType();
+      }
+
+      @Override
+      public void writeExternal(ObjectOutput objectOutput) throws IOException {
+         objectOutput.writeObject(m.getDeclaringClass());
+         objectOutput.writeObject(m.getName());
+      }
+
+      @Override
+      public void readExternal(ObjectInput objectInput) throws IOException, ClassNotFoundException {
+         try {
+            m = ((Class) objectInput.readObject()).getDeclaredMethod((String) objectInput.readObject());
+            m.setAccessible(true);
+         } catch (NoSuchMethodException e) {
+            e.printStackTrace();
+         }
+      }
    }
 
-   private static class ChainedAccessor implements Accessor {
-      private final List<Accessor> accessors;
+   private static class ChainedAccessor implements Accessor, Externalizable {
+      public List<Accessor> accessors;
+
+      public ChainedAccessor(){}
 
       public ChainedAccessor(List<Accessor> list) {
          this.accessors = list;
@@ -409,5 +569,21 @@ public class HazelcastQueryable implements Queryable {
          }
          return o;
       }
+
+      @Override
+      public Class<?> getReturnType() {
+         return accessors.get(accessors.size() - 1).getReturnType();
+      }
+
+      @Override
+      public void writeExternal(ObjectOutput objectOutput) throws IOException {
+         objectOutput.writeObject(accessors);
+      }
+
+      @Override
+      public void readExternal(ObjectInput objectInput) throws IOException, ClassNotFoundException {
+         accessors = (List<Accessor>) objectInput.readObject();
+      }
    }
+
 }

--- a/plugins/hazelcast3/src/main/resources/dist-sync-object-format.xml
+++ b/plugins/hazelcast3/src/main/resources/dist-sync-object-format.xml
@@ -22,10 +22,9 @@
         </join>
     </network>
 
-    <executor-service>
-        <core-pool-size>16</core-pool-size>
-        <max-pool-size>64</max-pool-size>
-        <keep-alive-seconds>60</keep-alive-seconds>
+    <executor-service name="mapreduce::hz::hz::aggregation-map-default">
+        <pool-size>16</pool-size>
+        <queue-capacity>0</queue-capacity>
     </executor-service>
 
     <map name="default">

--- a/plugins/hazelcast3/src/main/resources/dist-sync-object-format.xml
+++ b/plugins/hazelcast3/src/main/resources/dist-sync-object-format.xml
@@ -22,6 +22,11 @@
         </join>
     </network>
 
+    <executor-service>
+        <pool-size>64</pool-size>
+        <queue-capacity>0</queue-capacity>
+    </executor-service>
+
     <executor-service name="mapreduce::hz::hz::aggregation-map-default">
         <pool-size>16</pool-size>
         <queue-capacity>0</queue-capacity>

--- a/plugins/infinispan60/src/main/java/org/radargun/service/AbstractInfinispanQueryable.java
+++ b/plugins/infinispan60/src/main/java/org/radargun/service/AbstractInfinispanQueryable.java
@@ -144,6 +144,7 @@ public abstract class AbstractInfinispanQueryable implements Queryable {
       @Override
       public QueryBuilder orderBy(SelectExpression selectExpression, SortOrder order) {
          if (builder == null) throw new IllegalArgumentException("You have to call orderBy() on root query builder!");
+         if (selectExpression.function != AggregationFunction.NONE) throw new IllegalArgumentException("This version of infinispan doesn't support aggregations!");
          builder.orderBy(selectExpression.attribute, order == SortOrder.ASCENDING ?
                org.infinispan.query.dsl.SortOrder.ASC : org.infinispan.query.dsl.SortOrder.DESC);
          return this;
@@ -154,6 +155,9 @@ public abstract class AbstractInfinispanQueryable implements Queryable {
          if (builder == null) throw new IllegalArgumentException("You have to call projection() on root query builder!");
          String[] stringAttributes = new String[selectExpressions.length];
          for (int i = 0; i < selectExpressions.length; i++) {
+            if (selectExpressions[i].function != AggregationFunction.NONE) {
+               throw new IllegalArgumentException("This version of infinispan doesn't support aggregations!");
+            }
             stringAttributes[i] = selectExpressions[i].attribute;
          }
          builder.setProjection(stringAttributes);

--- a/plugins/infinispan60/src/main/java/org/radargun/service/AbstractInfinispanQueryable.java
+++ b/plugins/infinispan60/src/main/java/org/radargun/service/AbstractInfinispanQueryable.java
@@ -142,10 +142,10 @@ public abstract class AbstractInfinispanQueryable implements Queryable {
       }
 
       @Override
-      public QueryBuilder orderBy(SelectExpression selectExpression, SortOrder order) {
+      public QueryBuilder orderBy(SelectExpression selectExpression) {
          if (builder == null) throw new IllegalArgumentException("You have to call orderBy() on root query builder!");
          if (selectExpression.function != AggregationFunction.NONE) throw new IllegalArgumentException("This version of infinispan doesn't support aggregations!");
-         builder.orderBy(selectExpression.attribute, order == SortOrder.ASCENDING ?
+         builder.orderBy(selectExpression.attribute, selectExpression.asc ?
                org.infinispan.query.dsl.SortOrder.ASC : org.infinispan.query.dsl.SortOrder.DESC);
          return this;
       }

--- a/plugins/infinispan60/src/main/java/org/radargun/service/AbstractInfinispanQueryable.java
+++ b/plugins/infinispan60/src/main/java/org/radargun/service/AbstractInfinispanQueryable.java
@@ -17,9 +17,9 @@ import org.radargun.traits.Queryable;
 public abstract class AbstractInfinispanQueryable implements Queryable {
 
    protected static class QueryBuilderImpl implements QueryBuilder {
-      private final QueryFactory factory;
-      private final org.infinispan.query.dsl.QueryBuilder builder;
-      private FilterConditionContext context;
+      protected final QueryFactory factory;
+      protected final org.infinispan.query.dsl.QueryBuilder builder;
+      protected FilterConditionContext context;
 
       public QueryBuilderImpl(QueryFactory factory, Class<?> clazz) {
          this.factory = factory;
@@ -31,14 +31,14 @@ public abstract class AbstractInfinispanQueryable implements Queryable {
          this.builder = null;
       }
 
-      private FilterConditionEndContext getEndContext(String attribute) {
+      protected FilterConditionEndContext getEndContext(SelectExpression selectExpression) {
          FilterConditionEndContext endContext;
          if (context != null) {
-            endContext = context.and().having(attribute);
+            endContext = context.and().having(selectExpression.attribute);
          } else if (builder != null) {
-            endContext = builder.having(attribute);
+            endContext = builder.having(selectExpression.attribute);
          } else {
-            endContext = factory.having(attribute);
+            endContext = factory.having(selectExpression.attribute);
          }
          return endContext;
       }
@@ -49,56 +49,56 @@ public abstract class AbstractInfinispanQueryable implements Queryable {
       }
 
       @Override
-      public QueryBuilder eq(String attribute, Object value) {
-         context = getEndContext(attribute).eq(value);
+      public QueryBuilder eq(SelectExpression selectExpression, Object value) {
+         context = getEndContext(selectExpression).eq(value);
          return this;
       }
 
       @Override
-      public QueryBuilder lt(String attribute, Object value) {
-         context = getEndContext(attribute).lt(value);
+      public QueryBuilder lt(SelectExpression selectExpression, Object value) {
+         context = getEndContext(selectExpression).lt(value);
          return this;
       }
 
       @Override
-      public QueryBuilder le(String attribute, Object value) {
-         context = getEndContext(attribute).lte(value);
+      public QueryBuilder le(SelectExpression selectExpression, Object value) {
+         context = getEndContext(selectExpression).lte(value);
          return this;
       }
 
       @Override
-      public QueryBuilder gt(String attribute, Object value) {
-         context = getEndContext(attribute).gt(value);
+      public QueryBuilder gt(SelectExpression selectExpression, Object value) {
+         context = getEndContext(selectExpression).gt(value);
          return this;
       }
 
       @Override
-      public QueryBuilder ge(String attribute, Object value) {
-         context = getEndContext(attribute).gte(value);
+      public QueryBuilder ge(SelectExpression selectExpression, Object value) {
+         context = getEndContext(selectExpression).gte(value);
          return this;
       }
 
       @Override
-      public QueryBuilder between(String attribute, Object lowerBound, boolean lowerInclusive, Object upperBound, boolean upperInclusive) {
-         context = getEndContext(attribute).between(lowerBound, upperBound).includeLower(lowerInclusive).includeUpper(upperInclusive);
+      public QueryBuilder between(SelectExpression selectExpression, Object lowerBound, boolean lowerInclusive, Object upperBound, boolean upperInclusive) {
+         context = getEndContext(selectExpression).between(lowerBound, upperBound).includeLower(lowerInclusive).includeUpper(upperInclusive);
          return this;
       }
 
       @Override
-      public QueryBuilder isNull(String attribute) {
-         context = getEndContext(attribute).isNull();
+      public QueryBuilder isNull(SelectExpression selectExpression) {
+         context = getEndContext(selectExpression).isNull();
          return this;
       }
 
       @Override
-      public QueryBuilder like(String attribute, String pattern) {
-         context = getEndContext(attribute).like(pattern);
+      public QueryBuilder like(SelectExpression selectExpression, String pattern) {
+         context = getEndContext(selectExpression).like(pattern);
          return this;
       }
 
       @Override
-      public QueryBuilder contains(String attribute, Object value) {
-         context = getEndContext(attribute).contains(value);
+      public QueryBuilder contains(SelectExpression selectExpression, Object value) {
+         context = getEndContext(selectExpression).contains(value);
          return this;
       }
 
@@ -142,18 +142,27 @@ public abstract class AbstractInfinispanQueryable implements Queryable {
       }
 
       @Override
-      public QueryBuilder orderBy(String attribute, SortOrder order) {
+      public QueryBuilder orderBy(SelectExpression selectExpression, SortOrder order) {
          if (builder == null) throw new IllegalArgumentException("You have to call orderBy() on root query builder!");
-         builder.orderBy(attribute, order == SortOrder.ASCENDING ?
+         builder.orderBy(selectExpression.attribute, order == SortOrder.ASCENDING ?
                org.infinispan.query.dsl.SortOrder.ASC : org.infinispan.query.dsl.SortOrder.DESC);
          return this;
       }
 
       @Override
-      public QueryBuilder projection(String... attributes) {
+      public QueryBuilder projection(SelectExpression... selectExpressions) {
          if (builder == null) throw new IllegalArgumentException("You have to call projection() on root query builder!");
-         builder.setProjection(attributes);
+         String[] stringAttributes = new String[selectExpressions.length];
+         for (int i = 0; i < selectExpressions.length; i++) {
+            stringAttributes[i] = selectExpressions[i].attribute;
+         }
+         builder.setProjection(stringAttributes);
          return this;
+      }
+
+      @Override
+      public QueryBuilder groupBy(String... attributes) {
+         throw new RuntimeException("Grouping is not implemented in this version of infinispan.");
       }
 
       @Override
@@ -173,7 +182,7 @@ public abstract class AbstractInfinispanQueryable implements Queryable {
       @Override
       public Query build() {
          if (builder == null) throw new IllegalArgumentException("You have to call build() on root query builder!");
-         return new QueryImpl(context.toBuilder().build());
+         return new QueryImpl(builder.build());
       }
    }
 

--- a/plugins/infinispan60/src/main/resources/query.xml
+++ b/plugins/infinispan60/src/main/resources/query.xml
@@ -1,22 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  ~ Copyright 2013 Red Hat, Inc. and/or its affiliates.
-  ~
-  ~ This is free software; you can redistribute it and/or modify it
-  ~ under the terms of the GNU Lesser General Public License as
-  ~ published by the Free Software Foundation; either version 2.1 of
-  ~ the License, or (at your option) any later version.
-  ~
-  ~ This software is distributed in the hope that it will be useful,
-  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
-  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-  ~ Lesser General Public License for more details.
-  ~
-  ~ You should have received a copy of the GNU Lesser General Public
-  ~ License along with this library; if not, write to the Free Software
-  ~ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
-  ~ 02110-1301 USA
-  -->
 
 <infinispan
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/plugins/infinispan70/src/main/resources/query.xml
+++ b/plugins/infinispan70/src/main/resources/query.xml
@@ -1,22 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  ~ Copyright 2013 Red Hat, Inc. and/or its affiliates.
-  ~
-  ~ This is free software; you can redistribute it and/or modify it
-  ~ under the terms of the GNU Lesser General Public License as
-  ~ published by the Free Software Foundation; either version 2.1 of
-  ~ the License, or (at your option) any later version.
-  ~
-  ~ This software is distributed in the hope that it will be useful,
-  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
-  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-  ~ Lesser General Public License for more details.
-  ~
-  ~ You should have received a copy of the GNU Lesser General Public
-  ~ License along with this library; if not, write to the Free Software
-  ~ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
-  ~ 02110-1301 USA
-  -->
 
 <infinispan
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/plugins/infinispan80/pom.xml
+++ b/plugins/infinispan80/pom.xml
@@ -71,6 +71,13 @@
 
       <dependency>
          <groupId>org.infinispan</groupId>
+         <artifactId>infinispan-query-dsl</artifactId>
+         <version>${version.infinispan}</version>
+         <optional>true</optional>
+      </dependency>
+
+      <dependency>
+         <groupId>org.infinispan</groupId>
          <artifactId>infinispan-cachestore-jdbc</artifactId>
          <version>${version.infinispan}</version>
          <optional>true</optional>
@@ -106,6 +113,19 @@
  
 
    </dependencies>
+
+   <build>
+      <plugins>
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+               <source>1.8</source>
+               <target>1.8</target>
+            </configuration>
+         </plugin>
+      </plugins>
+   </build>
 
    <profiles>
       <profile>

--- a/plugins/infinispan80/src/main/java/org/radargun/service/Infinispan80EmbeddedQueryable.java
+++ b/plugins/infinispan80/src/main/java/org/radargun/service/Infinispan80EmbeddedQueryable.java
@@ -1,0 +1,94 @@
+package org.radargun.service;
+
+import org.infinispan.query.Search;
+import org.infinispan.query.dsl.Expression;
+import org.infinispan.query.dsl.FilterConditionEndContext;
+import org.infinispan.query.dsl.QueryFactory;
+
+/**
+ * Adds support for aggregations.
+ *
+ * @author Jakub Markos &lt;jmarkos@redhat.com&gt;
+ */
+public class Infinispan80EmbeddedQueryable extends Infinispan70EmbeddedQueryable {
+   public Infinispan80EmbeddedQueryable(Infinispan80EmbeddedService service) {
+      super(service);
+   }
+
+   @Override
+   public QueryBuilder getBuilder(String cacheName, Class<?> clazz) {
+      return new QueryBuilder80Impl(Search.getQueryFactory(service.getCache(cacheName)), clazz);
+   }
+
+   protected static class QueryBuilder80Impl extends QueryBuilderImpl {
+      public QueryBuilder80Impl(QueryFactory factory, Class<?> clazz) {
+         super(factory, clazz);
+      }
+
+      protected QueryBuilder80Impl(QueryFactory factory) {
+         super(factory);
+      }
+
+      protected Expression attributeToExpression(SelectExpression selectExpression) {
+         switch (selectExpression.function) {
+            case NONE:
+               return Expression.property(selectExpression.attribute);
+            case COUNT:
+               return Expression.count(selectExpression.attribute);
+            case AVG:
+               return Expression.avg(selectExpression.attribute);
+            case SUM:
+               return Expression.sum(selectExpression.attribute);
+            case MIN:
+               return Expression.min(selectExpression.attribute);
+            case MAX:
+               return Expression.max(selectExpression.attribute);
+            default:
+               throw new RuntimeException("Unknown aggregation function: " + selectExpression.function);
+         }
+      }
+
+      @Override
+      protected FilterConditionEndContext getEndContext(SelectExpression selectExpression) {
+         FilterConditionEndContext endContext;
+         if (context != null) {
+            endContext = context.and().having(attributeToExpression(selectExpression));
+         } else if (builder != null) {
+            endContext = builder.having(attributeToExpression(selectExpression));
+         } else {
+            endContext = factory.having(attributeToExpression(selectExpression));
+         }
+         return endContext;
+      }
+
+      @Override
+      public QueryBuilder projection(SelectExpression... selectExpressions) {
+         if (builder == null)
+            throw new IllegalArgumentException("You have to call projection() on root query builder!");
+         Expression[] projections = new Expression[selectExpressions.length];
+         for (int i = 0; i < selectExpressions.length; i++) {
+            projections[i] = attributeToExpression(selectExpressions[i]);
+         }
+         builder.select(projections);
+         return this;
+      }
+
+      @Override
+      public QueryBuilder groupBy(String... attributes) {
+         if (builder == null)
+            throw new IllegalArgumentException("You have to call groupBy() on root query builder!");
+         builder.groupBy(attributes);
+         context = null; // all further 'having' conditions will start a new .having() context
+         return this;
+      }
+
+      @Override
+      public QueryBuilder orderBy(SelectExpression selectExpression, SortOrder order) {
+         if (builder == null) throw new IllegalArgumentException("You have to call orderBy() on root query builder!");
+         builder.orderBy(attributeToExpression(selectExpression), order == SortOrder.ASCENDING ?
+               org.infinispan.query.dsl.SortOrder.ASC : org.infinispan.query.dsl.SortOrder.DESC);
+         return this;
+      }
+   }
+
+}

--- a/plugins/infinispan80/src/main/java/org/radargun/service/Infinispan80EmbeddedQueryable.java
+++ b/plugins/infinispan80/src/main/java/org/radargun/service/Infinispan80EmbeddedQueryable.java
@@ -83,9 +83,9 @@ public class Infinispan80EmbeddedQueryable extends Infinispan70EmbeddedQueryable
       }
 
       @Override
-      public QueryBuilder orderBy(SelectExpression selectExpression, SortOrder order) {
+      public QueryBuilder orderBy(SelectExpression selectExpression) {
          if (builder == null) throw new IllegalArgumentException("You have to call orderBy() on root query builder!");
-         builder.orderBy(attributeToExpression(selectExpression), order == SortOrder.ASCENDING ?
+         builder.orderBy(attributeToExpression(selectExpression), selectExpression.asc ?
                org.infinispan.query.dsl.SortOrder.ASC : org.infinispan.query.dsl.SortOrder.DESC);
          return this;
       }

--- a/plugins/infinispan80/src/main/java/org/radargun/service/Infinispan80EmbeddedService.java
+++ b/plugins/infinispan80/src/main/java/org/radargun/service/Infinispan80EmbeddedService.java
@@ -18,6 +18,12 @@ public class Infinispan80EmbeddedService extends Infinispan70EmbeddedService {
       return new InfinispanEmbeddedContinuousQuery(this);
    }
 
+   @Override
+   @ProvidesTrait
+   public InfinispanEmbeddedQueryable createQueryable() {
+      return new Infinispan80EmbeddedQueryable(this);
+   }
+
    @Destroy
    public void destroy() {
       Utils.shutdownAndWait(scheduledExecutor);

--- a/plugins/infinispan80/src/main/resources/query-aggregations.xml
+++ b/plugins/infinispan80/src/main/resources/query-aggregations.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this library; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA
+  -->
+
+<infinispan
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="urn:infinispan:config:8.0 http://www.infinispan.org/schemas/infinispan-config-8.0.xsd"
+        xmlns="urn:infinispan:config:8.0">
+
+    <cache-container name="default" default-cache="default">
+        <transport lock-timeout="60000" cluster="default"/>
+        <jmx duplicate-domains="true">
+            <property name="enabled">true</property>
+        </jmx>
+        <local-cache  name="default"/>
+
+        <distributed-cache name="dist_indexless" owners="2">
+            <transaction mode="NON_XA"/>
+        </distributed-cache>
+    </cache-container>
+
+</infinispan>

--- a/plugins/infinispan80/src/main/resources/query-aggregations.xml
+++ b/plugins/infinispan80/src/main/resources/query-aggregations.xml
@@ -1,22 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  ~ Copyright 2013 Red Hat, Inc. and/or its affiliates.
-  ~
-  ~ This is free software; you can redistribute it and/or modify it
-  ~ under the terms of the GNU Lesser General Public License as
-  ~ published by the Free Software Foundation; either version 2.1 of
-  ~ the License, or (at your option) any later version.
-  ~
-  ~ This software is distributed in the hope that it will be useful,
-  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
-  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-  ~ Lesser General Public License for more details.
-  ~
-  ~ You should have received a copy of the GNU Lesser General Public
-  ~ License along with this library; if not, write to the Free Software
-  ~ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
-  ~ 02110-1301 USA
-  -->
 
 <infinispan
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/plugins/jdg66/pom.xml
+++ b/plugins/jdg66/pom.xml
@@ -65,7 +65,7 @@
 
        <dependency>
            <groupId>org.radargun</groupId>
-           <artifactId>plugin-infinispan80</artifactId>
+           <artifactId>plugin-infinispan72</artifactId>
            <version>${project.version}</version>
        </dependency>
 

--- a/plugins/jdg66/src/main/java/org/radargun/service/JDG66EmbeddedQueryable.java
+++ b/plugins/jdg66/src/main/java/org/radargun/service/JDG66EmbeddedQueryable.java
@@ -1,0 +1,94 @@
+package org.radargun.service;
+
+import org.infinispan.query.Search;
+import org.infinispan.query.dsl.Expression;
+import org.infinispan.query.dsl.FilterConditionEndContext;
+import org.infinispan.query.dsl.QueryFactory;
+
+/**
+ * Adds support for aggregations.
+ *
+ * @author Jakub Markos &lt;jmarkos@redhat.com&gt;
+ */
+public class JDG66EmbeddedQueryable extends Infinispan70EmbeddedQueryable {
+   public JDG66EmbeddedQueryable(JDG66EmbeddedService service) {
+      super(service);
+   }
+
+   @Override
+   public QueryBuilder getBuilder(String cacheName, Class<?> clazz) {
+      return new QueryBuilder80Impl(Search.getQueryFactory(service.getCache(cacheName)), clazz);
+   }
+
+   protected static class QueryBuilder80Impl extends QueryBuilderImpl {
+      public QueryBuilder80Impl(QueryFactory factory, Class<?> clazz) {
+         super(factory, clazz);
+      }
+
+      protected QueryBuilder80Impl(QueryFactory factory) {
+         super(factory);
+      }
+
+      protected Expression selectExpressionToExpression(SelectExpression selectExpression) {
+         switch (selectExpression.function) {
+            case NONE:
+               return Expression.property(selectExpression.attribute);
+            case COUNT:
+               return Expression.count(selectExpression.attribute);
+            case AVG:
+               return Expression.avg(selectExpression.attribute);
+            case SUM:
+               return Expression.sum(selectExpression.attribute);
+            case MIN:
+               return Expression.min(selectExpression.attribute);
+            case MAX:
+               return Expression.max(selectExpression.attribute);
+            default:
+               throw new RuntimeException("Unknown aggregation function: " + selectExpression.function);
+         }
+      }
+
+      @Override
+      protected FilterConditionEndContext getEndContext(SelectExpression selectExpression) {
+         FilterConditionEndContext endContext;
+         if (context != null) {
+            endContext = context.and().having(selectExpressionToExpression(selectExpression));
+         } else if (builder != null) {
+            endContext = builder.having(selectExpressionToExpression(selectExpression));
+         } else {
+            endContext = factory.having(selectExpressionToExpression(selectExpression));
+         }
+         return endContext;
+      }
+
+      @Override
+      public QueryBuilder projection(SelectExpression... selectExpressions) {
+         if (builder == null)
+            throw new IllegalArgumentException("You have to call projection() on root query builder!");
+         Expression[] projections = new Expression[selectExpressions.length];
+         for (int i = 0; i < selectExpressions.length; i++) {
+            projections[i] = selectExpressionToExpression(selectExpressions[i]);
+         }
+         builder.select(projections);
+         return this;
+      }
+
+      @Override
+      public QueryBuilder groupBy(String... attributes) {
+         if (builder == null)
+            throw new IllegalArgumentException("You have to call groupBy() on root query builder!");
+         builder.groupBy(attributes);
+         context = null; // all further 'having' conditions will start a new .having() context
+         return this;
+      }
+
+      @Override
+      public QueryBuilder orderBy(SelectExpression selectExpression, SortOrder order) {
+         if (builder == null) throw new IllegalArgumentException("You have to call orderBy() on root query builder!");
+         builder.orderBy(selectExpressionToExpression(selectExpression), order == SortOrder.ASCENDING ?
+               org.infinispan.query.dsl.SortOrder.ASC : org.infinispan.query.dsl.SortOrder.DESC);
+         return this;
+      }
+   }
+
+}

--- a/plugins/jdg66/src/main/java/org/radargun/service/JDG66EmbeddedQueryable.java
+++ b/plugins/jdg66/src/main/java/org/radargun/service/JDG66EmbeddedQueryable.java
@@ -83,9 +83,9 @@ public class JDG66EmbeddedQueryable extends Infinispan70EmbeddedQueryable {
       }
 
       @Override
-      public QueryBuilder orderBy(SelectExpression selectExpression, SortOrder order) {
+      public QueryBuilder orderBy(SelectExpression selectExpression) {
          if (builder == null) throw new IllegalArgumentException("You have to call orderBy() on root query builder!");
-         builder.orderBy(selectExpressionToExpression(selectExpression), order == SortOrder.ASCENDING ?
+         builder.orderBy(selectExpressionToExpression(selectExpression), selectExpression.asc ?
                org.infinispan.query.dsl.SortOrder.ASC : org.infinispan.query.dsl.SortOrder.DESC);
          return this;
       }

--- a/plugins/jdg66/src/main/java/org/radargun/service/JDG66EmbeddedService.java
+++ b/plugins/jdg66/src/main/java/org/radargun/service/JDG66EmbeddedService.java
@@ -1,0 +1,20 @@
+package org.radargun.service;
+
+import org.radargun.Service;
+import org.radargun.traits.ProvidesTrait;
+
+/**
+ *
+ * @author vjuranek
+ *
+ */
+@Service(doc = JDG64EmbeddedService.SERVICE_DESCRIPTION)
+public class JDG66EmbeddedService extends JDG64EmbeddedService  {
+   protected static final String SERVICE_DESCRIPTION = "Service hosting JDG in embedded (library) mode.";
+
+   @ProvidesTrait
+   public InfinispanEmbeddedQueryable createQueryable() {
+      return new JDG66EmbeddedQueryable(this);
+   }
+
+}

--- a/plugins/jdg66/src/main/resources/plugin.properties
+++ b/plugins/jdg66/src/main/resources/plugin.properties
@@ -1,6 +1,6 @@
 service.default org.radargun.service.JDG66EmbeddedService
 service.embedded org.radargun.service.JDG66EmbeddedService
 service.server org.radargun.service.Infinispan60ServerService
-service.hotrod org.radargun.service.Infinispan80HotrodService
+service.hotrod org.radargun.service.Infinispan71HotrodService
 service.jcache org.radargun.service.JCacheService
 jmx.clustervalidator org.radargun.jmx.InfinispanJMXClusterValidator

--- a/plugins/jdg66/src/main/resources/plugin.properties
+++ b/plugins/jdg66/src/main/resources/plugin.properties
@@ -1,5 +1,5 @@
-service.default org.radargun.service.JDG64EmbeddedService
-service.embedded org.radargun.service.JDG64EmbeddedService
+service.default org.radargun.service.JDG66EmbeddedService
+service.embedded org.radargun.service.JDG66EmbeddedService
 service.server org.radargun.service.Infinispan60ServerService
 service.hotrod org.radargun.service.Infinispan80HotrodService
 service.jcache org.radargun.service.JCacheService


### PR DESCRIPTION
Aggregations in Infinispan 8 use Java8 features, so I moved the whole support only to JDG plugin for 2.x branch.

Not using structured expressions leads to this structure:
```html
<having>
    <gt value="50000">
        <aggregated-path>
            <sum path="integerValue"/>
        </aggregated-path>
    </gt>
</having>
```

Hazelcast requires a class (implementing PropertyExtractor) which extracts the aggregated property from cache entries. We use reflection for this in ReflexivePropertyExtractor. According to my local tests, it wasn't slower than using a special PropertyExtractor (like NumberObjectPropertyExtractor) which would know about the entries used in the test.