### PR TITLE
Add JBoss client to avoid JMX connection failures

### DIFF
--- a/plugins/infinispan60/pom.xml
+++ b/plugins/infinispan60/pom.xml
@@ -15,6 +15,7 @@
    <properties>
       <version.infinispan>6.0.1.Final</version.infinispan>
       <version.jbossts>4.16.3.Final</version.jbossts>
+      <version.wildfly.cli>2.0.0.Final</version.wildfly.cli>
       <maven.test.skip>false</maven.test.skip>
    </properties>
 
@@ -95,6 +96,19 @@
          <artifactId>infinispan-cachestore-leveldb</artifactId>
          <version>${version.infinispan}</version>
          <optional>true</optional>
+      </dependency>
+
+      <dependency>
+         <groupId>org.wildfly.core</groupId>
+         <artifactId>wildfly-cli</artifactId>
+         <classifier>client</classifier>
+         <version>${version.wildfly.cli}</version>
+         <exclusions>
+            <exclusion>
+               <artifactId>*</artifactId>
+               <groupId>*</groupId>
+            </exclusion>
+         </exclusions>
       </dependency>
 
    </dependencies>


### PR DESCRIPTION
Otherwise query over HR client in CS mode fails with
```
15:01:40,315 ERROR [org.radargun.service.InfinispanHotrodQueryable] (sc-main) Failed to connect to service:jmx:remoting-jmx://127.0.0.1:9999
java.net.MalformedURLException: Unsupported protocol: remoting-jmx
        at javax.management.remote.JMXConnectorFactory.newJMXConnector(JMXConnectorFactory.java:359)
        at org.radargun.service.InfinispanHotrodQueryable.registerProtofilesRemote(InfinispanHotrodQueryable.java:73)
        at org.radargun.service.Infinispan60HotrodService.start(Infinispan60HotrodService.java:133)
        at org.radargun.stages.lifecycle.LifecycleHelper.start(LifecycleHelper.java:59)
        at org.radargun.stages.lifecycle.ServiceStartStage.executeOnSlave(ServiceStartStage.java:83)
        at org.radargun.SlaveBase.scenarioLoop(SlaveBase.java:87)
        at org.radargun.SlaveBase$ScenarioRunner.run(SlaveBase.java:151)
```