### PR TITLE
issue #327 Remove partial throughput charts for different operation types from report, 2.x

### DIFF
--- a/core/src/main/java/org/radargun/Operation.java
+++ b/core/src/main/java/org/radargun/Operation.java
@@ -1,5 +1,6 @@
 package org.radargun;
 
+import java.io.Serializable;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -8,7 +9,8 @@ import java.util.concurrent.ConcurrentHashMap;
  *
  * @author Radim Vansa &lt;rvansa@redhat.com&gt;
  */
-public final class Operation {
+// TODO split into Operation + operations repository
+public final class Operation implements Serializable {
    private static int nextId = 1;
    private static ConcurrentHashMap<Integer, Operation> byId = new ConcurrentHashMap<Integer, Operation>();
    private static ConcurrentHashMap<String, Operation> byName = new ConcurrentHashMap<String, Operation>();
@@ -88,10 +90,22 @@ public final class Operation {
       return operation;
    }
 
+   /**
+    * Remove all registered operations. WARNING: Should only be used when no clients access Operations class any longer (e.g. testing purposes)
+    */
+   public static synchronized void clear() {
+      nextId = 1;
+      byId.clear();
+      byName.clear();
+   }
+
    @Override
    public boolean equals(Object o) {
-      // there should be only one instance of each operation
-      return this == o;
+      if (o instanceof Operation) {
+         Operation op = (Operation) o;
+         return this.id == op.id;
+      }
+      return false;
    }
 
    @Override

--- a/core/src/main/java/org/radargun/reporting/Report.java
+++ b/core/src/main/java/org/radargun/reporting/Report.java
@@ -6,6 +6,7 @@ import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.util.*;
 
+import org.radargun.Operation;
 import org.radargun.config.Cluster;
 import org.radargun.config.Configuration;
 import org.radargun.config.Definition;
@@ -130,10 +131,19 @@ public class Report implements Comparable<Report>, Serializable {
       public final String name;
       public final String iterationsName;
       private ArrayList<TestIteration> iterations = new ArrayList<TestIteration>();
+      private Map<String, Set<Operation>> groupOperationsMap;
 
       private Test(String name, String iterationsName) {
          this.name = name;
          this.iterationsName = iterationsName;
+      }
+
+      public void setGroupOperationsMap(Map<String, Set<Operation>> groupOperationsMap) {
+         this.groupOperationsMap = groupOperationsMap;
+      }
+
+      public Map<String, Set<Operation>> getGroupOperationsMap() {
+         return groupOperationsMap;
       }
 
       /**

--- a/core/src/main/java/org/radargun/stages/cache/test/BasicOperationsTestStage.java
+++ b/core/src/main/java/org/radargun/stages/cache/test/BasicOperationsTestStage.java
@@ -1,5 +1,7 @@
 package org.radargun.stages.cache.test;
 
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Random;
 
 import org.radargun.Operation;
@@ -50,6 +52,25 @@ public class BasicOperationsTestStage extends CacheOperationsTestStage {
             .add(BasicOperations.REMOVE, removeRatio)
             .add(BasicOperations.GET_AND_REMOVE, getAndRemoveRatio)
             .build();
+      statisticsPrototype.registerOperationsGroup(BasicOperations.class.getSimpleName() + ".Total",
+                                                  new HashSet<>(Arrays.asList(
+                                                        BasicOperations.GET,
+                                                        Invocations.Get.GET_NULL,
+                                                        BasicOperations.CONTAINS_KEY,
+                                                        BasicOperations.PUT,
+                                                        BasicOperations.GET_AND_PUT,
+                                                        BasicOperations.REMOVE,
+                                                        BasicOperations.GET_AND_REMOVE)));
+      statisticsPrototype.registerOperationsGroup(BasicOperations.class.getSimpleName() + ".Total.TX",
+                                                  new HashSet<>(Arrays.asList(
+                                                        Invocations.Get.GET_TX,
+                                                        Invocations.Get.GET_NULL_TX,
+                                                        Invocations.ContainsKey.TX,
+                                                        Invocations.Put.TX,
+                                                        Invocations.GetAndPut.TX,
+                                                        Invocations.Remove.TX,
+                                                        Invocations.GetAndRemove.TX
+                                                  )));
    }
 
    @Override

--- a/core/src/main/java/org/radargun/stages/cache/test/BulkOperationsTestStage.java
+++ b/core/src/main/java/org/radargun/stages/cache/test/BulkOperationsTestStage.java
@@ -1,5 +1,6 @@
 package org.radargun.stages.cache.test;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -13,6 +14,7 @@ import org.radargun.config.Stage;
 import org.radargun.stages.test.Invocation;
 import org.radargun.stages.test.OperationLogic;
 import org.radargun.stages.test.Stressor;
+import org.radargun.traits.BasicOperations;
 import org.radargun.traits.BulkOperations;
 import org.radargun.traits.InjectTrait;
 
@@ -58,6 +60,20 @@ public class BulkOperationsTestStage extends CacheOperationsTestStage {
             .add(BulkOperations.REMOVE_ALL_NATIVE, removeAllNativeRatio)
             .add(BulkOperations.REMOVE_ALL_ASYNC, removeAllAsyncRatio)
             .build();
+      statisticsPrototype.registerOperationsGroup(BulkOperations.class.getSimpleName() + ".Total",
+                                                  new HashSet<>(Arrays.asList(
+                                                        BulkOperations.GET_ALL_NATIVE,
+                                                        BulkOperations.GET_ALL_ASYNC,
+                                                        BulkOperations.PUT_ALL_NATIVE,
+                                                        BulkOperations.PUT_ALL_ASYNC,
+                                                        BulkOperations.REMOVE_ALL_NATIVE,
+                                                        BulkOperations.REMOVE_ALL_ASYNC)));
+      statisticsPrototype.registerOperationsGroup(BulkOperations.class.getSimpleName() + ".Total.TX",
+                                                  new HashSet<>(Arrays.asList(
+                                                        Invocations.GetAll.NATIVE_TX,
+                                                        Invocations.PutAll.NATIVE_TX,
+                                                        Invocations.RemoveAll.NATIVE_TX
+                                                  )));
    }
 
    @Override

--- a/core/src/main/java/org/radargun/stages/cache/test/ConditionalOperationsTestStage.java
+++ b/core/src/main/java/org/radargun/stages/cache/test/ConditionalOperationsTestStage.java
@@ -1,5 +1,7 @@
 package org.radargun.stages.cache.test;
 
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Random;
 
 import org.radargun.Operation;
@@ -50,6 +52,20 @@ public class ConditionalOperationsTestStage extends CacheOperationsTestStage {
             .add(ConditionalOperations.REPLACE_ANY, replaceAnyRatio)
             .add(ConditionalOperations.GET_AND_REPLACE, getAndReplaceRatio)
             .build();
+      statisticsPrototype.registerOperationsGroup(ConditionalOperations.class.getSimpleName() + ".Total",
+                                                  new HashSet<>(Arrays.asList(
+                                                        ConditionalOperations.REMOVE,
+                                                        ConditionalOperations.REPLACE,
+                                                        ConditionalOperations.REPLACE_ANY,
+                                                        ConditionalOperations.GET_AND_REPLACE
+                                                  )));
+      statisticsPrototype.registerOperationsGroup(ConditionalOperations.class.getSimpleName() + ".Total.TX",
+                                                  new HashSet<>(Arrays.asList(
+                                                        Invocations.Remove.TX,
+                                                        Invocations.Replace.TX,
+                                                        Invocations.ReplaceAny.TX,
+                                                        Invocations.GetAndReplace.TX
+                                                  )));
    }
 
    @Override

--- a/core/src/main/java/org/radargun/stages/cache/test/Invocations.java
+++ b/core/src/main/java/org/radargun/stages/cache/test/Invocations.java
@@ -20,9 +20,9 @@ import org.radargun.traits.Queryable;
  */
 public class Invocations {
    public static final class Get implements Invocation {
-      private final static Operation GET_NULL = BasicOperations.GET.derive("Null");
-      private final static Operation GET_TX = BasicOperations.GET.derive("TX");
-      private final static Operation GET_NULL_TX = BasicOperations.GET.derive("TX");
+      public final static Operation GET_NULL = BasicOperations.GET.derive("Null");
+      public final static Operation GET_TX = BasicOperations.GET.derive("TX");
+      public final static Operation GET_NULL_TX = BasicOperations.GET.derive("TX");
       private final BasicOperations.Cache cache;
       private final Object key;
       private Object value;
@@ -49,7 +49,7 @@ public class Invocations {
    }
 
    public static final class Put implements Invocation {
-      private final static Operation TX = BasicOperations.PUT.derive("TX");
+      public final static Operation TX = BasicOperations.PUT.derive("TX");
       private final BasicOperations.Cache cache;
       private final Object key;
       private final Object value;
@@ -78,7 +78,7 @@ public class Invocations {
    }
 
    public static final class PutWithLifespan implements Invocation {
-      private final static Operation TX = TemporalOperations.PUT_WITH_LIFESPAN.derive("TX");
+      public final static Operation TX = TemporalOperations.PUT_WITH_LIFESPAN.derive("TX");
       private final TemporalOperations.Cache cache;
       private final Object key;
       private final Object value;
@@ -109,7 +109,7 @@ public class Invocations {
    }
 
    public static final class PutWithLifespanAndMaxIdle implements Invocation {
-      private final static Operation TX = TemporalOperations.PUT_WITH_LIFESPAN_AND_MAXIDLE.derive("TX");
+      public final static Operation TX = TemporalOperations.PUT_WITH_LIFESPAN_AND_MAXIDLE.derive("TX");
       private final TemporalOperations.Cache cache;
       private final Object key;
       private final Object value;
@@ -142,7 +142,7 @@ public class Invocations {
    }
 
    public static final class Remove implements Invocation {
-      private final static Operation TX = BasicOperations.REMOVE.derive("TX");
+      public final static Operation TX = BasicOperations.REMOVE.derive("TX");
       private final BasicOperations.Cache cache;
       private final Object key;
 
@@ -168,7 +168,7 @@ public class Invocations {
    }
 
    public static final class ContainsKey implements Invocation {
-      private final static Operation TX = BasicOperations.CONTAINS_KEY.derive("TX");
+      public final static Operation TX = BasicOperations.CONTAINS_KEY.derive("TX");
       private final BasicOperations.Cache cache;
       private final Object key;
 
@@ -194,7 +194,7 @@ public class Invocations {
    }
 
    public static final class GetAndPut implements Invocation {
-      private final static Operation TX = BasicOperations.GET_AND_PUT.derive("TX");
+      public final static Operation TX = BasicOperations.GET_AND_PUT.derive("TX");
       private final BasicOperations.Cache cache;
       private final Object key;
       private final Object value;
@@ -222,7 +222,7 @@ public class Invocations {
    }
 
    public static final class GetAndPutWithLifespan implements Invocation {
-      private final static Operation TX = TemporalOperations.GET_AND_PUT_WITH_LIFESPAN.derive("TX");
+      public final static Operation TX = TemporalOperations.GET_AND_PUT_WITH_LIFESPAN.derive("TX");
       private final TemporalOperations.Cache cache;
       private final Object key;
       private final Object value;
@@ -250,7 +250,7 @@ public class Invocations {
    }
 
    public static final class GetAndPutWithLifespanAndMaxIdle implements Invocation {
-      private final static Operation TX = TemporalOperations.GET_AND_PUT_WITH_LIFESPAN_AND_MAXIDLE.derive("TX");
+      public final static Operation TX = TemporalOperations.GET_AND_PUT_WITH_LIFESPAN_AND_MAXIDLE.derive("TX");
       private final TemporalOperations.Cache cache;
       private final Object key;
       private final Object value;
@@ -280,7 +280,7 @@ public class Invocations {
    }
 
    public static final class GetAndRemove implements Invocation {
-      private final static Operation TX = BasicOperations.GET_AND_REMOVE.derive("TX");
+      public final static Operation TX = BasicOperations.GET_AND_REMOVE.derive("TX");
       private final BasicOperations.Cache cache;
       private final Object key;
 
@@ -306,7 +306,7 @@ public class Invocations {
    }
 
    public static final class PutIfAbsent implements Invocation {
-      private final static Operation TX = ConditionalOperations.PUT_IF_ABSENT.derive("TX");
+      public final static Operation TX = ConditionalOperations.PUT_IF_ABSENT.derive("TX");
       private final ConditionalOperations.Cache cache;
       private final Object key;
       private final Object value;
@@ -334,7 +334,7 @@ public class Invocations {
    }
 
    public static final class PutIfAbsentWithLifespan implements Invocation {
-      private final static Operation TX = TemporalOperations.PUT_IF_ABSENT_WITH_LIFESPAN.derive("TX");
+      public final static Operation TX = TemporalOperations.PUT_IF_ABSENT_WITH_LIFESPAN.derive("TX");
       private final TemporalOperations.Cache cache;
       private final Object key;
       private final Object value;
@@ -364,7 +364,7 @@ public class Invocations {
    }
 
    public static final class PutIfAbsentWithLifespanAndMaxIdle implements Invocation {
-      private final static Operation TX = TemporalOperations.PUT_IF_ABSENT_WITH_LIFESPAN_AND_MAXIDLE.derive("TX");
+      public final static Operation TX = TemporalOperations.PUT_IF_ABSENT_WITH_LIFESPAN_AND_MAXIDLE.derive("TX");
       private final TemporalOperations.Cache cache;
       private final Object key;
       private final Object value;
@@ -396,7 +396,7 @@ public class Invocations {
    }
 
    public static final class RemoveConditionally implements Invocation {
-      private final static Operation TX = ConditionalOperations.REMOVE.derive("TX");
+      public final static Operation TX = ConditionalOperations.REMOVE.derive("TX");
       private final ConditionalOperations.Cache cache;
       private final Object key;
       private final Object value;
@@ -424,7 +424,7 @@ public class Invocations {
    }
 
    public static final class Replace implements Invocation {
-      private final static Operation TX = ConditionalOperations.REPLACE.derive("TX");
+      public final static Operation TX = ConditionalOperations.REPLACE.derive("TX");
       private final ConditionalOperations.Cache cache;
       private final Object key;
       private final Object oldValue;
@@ -454,7 +454,7 @@ public class Invocations {
    }
 
    public static final class ReplaceAny implements Invocation {
-      private final static Operation TX = ConditionalOperations.REPLACE_ANY.derive("TX");
+      public final static Operation TX = ConditionalOperations.REPLACE_ANY.derive("TX");
       private final ConditionalOperations.Cache cache;
       private final Object key;
       private final Object newValue;
@@ -482,7 +482,7 @@ public class Invocations {
    }
 
    public static final class GetAndReplace implements Invocation {
-      private final static Operation TX = ConditionalOperations.GET_AND_REPLACE.derive("TX");
+      public final static Operation TX = ConditionalOperations.GET_AND_REPLACE.derive("TX");
       private final ConditionalOperations.Cache cache;
       private final Object key;
       private final Object newValue;
@@ -510,7 +510,7 @@ public class Invocations {
    }
 
    public static final class GetAll implements Invocation {
-      private final static Operation NATIVE_TX = BulkOperations.GET_ALL_NATIVE.derive("TX");
+      public final static Operation NATIVE_TX = BulkOperations.GET_ALL_NATIVE.derive("TX");
       private final static Operation ASYNC_TX = BulkOperations.GET_ALL_ASYNC.derive("TX");
       private final BulkOperations.Cache cache;
       private final Set keys;
@@ -539,7 +539,7 @@ public class Invocations {
    }
 
    public static final class PutAll implements Invocation {
-      private final static Operation NATIVE_TX = BulkOperations.PUT_ALL_NATIVE.derive("TX");
+      public final static Operation NATIVE_TX = BulkOperations.PUT_ALL_NATIVE.derive("TX");
       private final static Operation ASYNC_TX = BulkOperations.PUT_ALL_ASYNC.derive("TX");
       private final BulkOperations.Cache cache;
       private final Map entries;
@@ -569,7 +569,7 @@ public class Invocations {
    }
 
    public static final class RemoveAll implements Invocation {
-      private final static Operation NATIVE_TX = BulkOperations.REMOVE_ALL_NATIVE.derive("TX");
+      public final static Operation NATIVE_TX = BulkOperations.REMOVE_ALL_NATIVE.derive("TX");
       private final static Operation ASYNC_TX = BulkOperations.REMOVE_ALL_ASYNC.derive("TX");
       private final BulkOperations.Cache cache;
       private final Set keys;
@@ -599,7 +599,7 @@ public class Invocations {
    }
 
    public static final class Query implements Invocation {
-      protected static final Operation TX = Queryable.QUERY.derive("TX");
+      public static final Operation TX = Queryable.QUERY.derive("TX");
       private final org.radargun.traits.Query query;
 
       public Query(org.radargun.traits.Query query) {

--- a/core/src/main/java/org/radargun/stages/cache/test/KeyExpirationTestStage.java
+++ b/core/src/main/java/org/radargun/stages/cache/test/KeyExpirationTestStage.java
@@ -1,6 +1,8 @@
 package org.radargun.stages.cache.test;
 
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Random;
 import java.util.TreeSet;
@@ -42,7 +44,7 @@ public class KeyExpirationTestStage extends CacheTestStage {
    protected int putRatio = 1;
 
    @InjectTrait
-   BasicOperations basicOperations;
+   protected BasicOperations basicOperations;
 
    protected OperationSelector operationSelector;
 
@@ -52,6 +54,18 @@ public class KeyExpirationTestStage extends CacheTestStage {
             .add(BasicOperations.PUT, putRatio)
             .add(BasicOperations.GET, getRatio)
             .build();
+      statisticsPrototype.registerOperationsGroup(BasicOperations.class.getSimpleName() + ".Total",
+                                                  new HashSet<>(Arrays.asList(
+                                                        BasicOperations.GET,
+                                                        Invocations.Get.GET_NULL,
+                                                        BasicOperations.PUT
+                                                  )));
+      statisticsPrototype.registerOperationsGroup(BasicOperations.class.getSimpleName() + ".Total.TX",
+                                                  new HashSet<>(Arrays.asList(
+                                                        Invocations.Get.GET_TX,
+                                                        Invocations.Get.GET_NULL_TX,
+                                                        Invocations.Put.TX
+                                                  )));
    }
 
 

--- a/core/src/main/java/org/radargun/stages/cache/test/QueryStage.java
+++ b/core/src/main/java/org/radargun/stages/cache/test/QueryStage.java
@@ -1,32 +1,21 @@
 package org.radargun.stages.cache.test;
 
-import java.lang.reflect.Type;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import org.radargun.DistStageAck;
 import org.radargun.StageResult;
-import org.radargun.config.Converter;
-import org.radargun.config.DefinitionElement;
 import org.radargun.config.Property;
-import org.radargun.config.PropertyHelper;
 import org.radargun.config.Stage;
 import org.radargun.reporting.Report;
 import org.radargun.stages.test.OperationLogic;
 import org.radargun.stages.test.Stressor;
-import org.radargun.stages.test.TestStage;
 import org.radargun.state.SlaveState;
 import org.radargun.stats.Statistics;
-import org.radargun.traits.InjectTrait;
 import org.radargun.traits.Query;
 import org.radargun.traits.Queryable;
-import org.radargun.utils.NumberConverter;
-import org.radargun.utils.ObjectConverter;
 import org.radargun.utils.Projections;
-import org.radargun.utils.ReflexiveConverters;
 
 /**
  * Executes Queries using Infinispan-Query API against the cache.
@@ -83,7 +72,7 @@ public class QueryStage extends AbstractQueryStage {
       public final int queryResultSize;
 
       public QueryAck(SlaveState slaveState, List<List<Statistics>> iterations, int queryResultSize) {
-         super(slaveState, iterations);
+         super(slaveState, iterations, null);
          this.queryResultSize = queryResultSize;
       }
    }

--- a/core/src/main/java/org/radargun/stages/cache/test/TemporalOperationsTestStage.java
+++ b/core/src/main/java/org/radargun/stages/cache/test/TemporalOperationsTestStage.java
@@ -11,6 +11,8 @@ import org.radargun.traits.BasicOperations;
 import org.radargun.traits.InjectTrait;
 import org.radargun.traits.TemporalOperations;
 
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Random;
 
 /**
@@ -68,6 +70,27 @@ public class TemporalOperationsTestStage extends CacheOperationsTestStage {
             .add(TemporalOperations.PUT_IF_ABSENT_WITH_LIFESPAN, putIfAbsentWithLifespanRatio)
             .add(TemporalOperations.PUT_IF_ABSENT_WITH_LIFESPAN_AND_MAXIDLE, putIfAbsentWithLifespanAndMaxIdleRatio)
             .build();
+      statisticsPrototype.registerOperationsGroup(TemporalOperations.class.getSimpleName() + ".Total",
+                                                  new HashSet<>(Arrays.asList(
+                                                        BasicOperations.GET,
+                                                        Invocations.Get.GET_NULL,
+                                                        TemporalOperations.PUT_WITH_LIFESPAN,
+                                                        TemporalOperations.GET_AND_PUT_WITH_LIFESPAN,
+                                                        TemporalOperations.PUT_WITH_LIFESPAN_AND_MAXIDLE,
+                                                        TemporalOperations.GET_AND_PUT_WITH_LIFESPAN_AND_MAXIDLE,
+                                                        TemporalOperations.PUT_IF_ABSENT_WITH_LIFESPAN,
+                                                        TemporalOperations.PUT_IF_ABSENT_WITH_LIFESPAN_AND_MAXIDLE)));
+      statisticsPrototype.registerOperationsGroup(TemporalOperations.class.getSimpleName() + ".Total.TX",
+                                                  new HashSet<>(Arrays.asList(
+                                                        Invocations.Get.GET_TX,
+                                                        Invocations.Get.GET_NULL_TX,
+                                                        Invocations.PutWithLifespan.TX,
+                                                        Invocations.GetAndPutWithLifespan.TX,
+                                                        Invocations.PutWithLifespanAndMaxIdle.TX,
+                                                        Invocations.GetAndPutWithLifespanAndMaxIdle.TX,
+                                                        Invocations.PutIfAbsentWithLifespan.TX,
+                                                        Invocations.PutIfAbsentWithLifespanAndMaxIdle.TX
+                                                  )));
    }
 
    @Override

--- a/core/src/main/java/org/radargun/stages/test/TestStage.java
+++ b/core/src/main/java/org/radargun/stages/test/TestStage.java
@@ -3,10 +3,12 @@ package org.radargun.stages.test;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import org.radargun.DistStageAck;
+import org.radargun.Operation;
 import org.radargun.StageResult;
 import org.radargun.config.Init;
 import org.radargun.config.Path;
@@ -150,6 +152,9 @@ public abstract class TestStage extends AbstractDistStage {
                      test.setIterationValue(i, iterationValue);
                   }
                   test.addStatistics(i++, ack.getSlaveIndex(), threadStats);
+                  if (test.getGroupOperationsMap() == null) {
+                     test.setGroupOperationsMap(ack.getGroupOperationsMap());
+                  }
                }
                threads = Math.max(threads, threadStats.size());
                for (Statistics s : threadStats) {
@@ -253,7 +258,7 @@ public abstract class TestStage extends AbstractDistStage {
 
    protected DistStageAck newStatisticsAck(List<Stressor> stressors) {
       List<List<Statistics>> results = gatherResults(stressors, new StatisticsResultRetriever());
-      return new StatisticsAck(slaveState, results);
+      return new StatisticsAck(slaveState, results, statisticsPrototype.getGroupOperationsMap());
    }
 
    protected <T> List<List<T>> gatherResults(List<Stressor> stressors, ResultRetriever<T> retriever) {
@@ -388,10 +393,16 @@ public abstract class TestStage extends AbstractDistStage {
 
    protected static class StatisticsAck extends DistStageAck {
       private final List<List<Statistics>> iterations;
+      private final Map<String, Set<Operation>> groupOperationsMap;
 
-      protected StatisticsAck(SlaveState slaveState, List<List<Statistics>> iterations) {
+      protected StatisticsAck(SlaveState slaveState, List<List<Statistics>> iterations, Map<String, Set<Operation>> groupOperationsMap) {
          super(slaveState);
          this.iterations = iterations;
+         this.groupOperationsMap = groupOperationsMap;
+      }
+
+      public Map<String, Set<Operation>> getGroupOperationsMap() {
+         return groupOperationsMap;
       }
    }
 

--- a/core/src/main/java/org/radargun/stats/DefaultStatistics.java
+++ b/core/src/main/java/org/radargun/stats/DefaultStatistics.java
@@ -1,13 +1,9 @@
 package org.radargun.stats;
 
 import java.lang.reflect.Array;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -30,6 +26,11 @@ public class DefaultStatistics extends IntervalStatistics {
 
    @Property(name = "operationStats", doc = "Operation statistics prototype.", complexConverter = OperationStats.Converter.class)
    protected OperationStats prototype = new DefaultOperationStats();
+
+   @Override
+   public Map<String, Set<Operation>> getGroupOperationsMap() {
+      return groupOperationsMap;
+   }
 
    public static Statistics merge(Collection<Statistics> set) {
       if (set.size() == 0) {
@@ -146,20 +147,6 @@ public class DefaultStatistics extends IntervalStatistics {
          for (int i = 0; i < stats.operationStats.length; ++i) {
             operationStats[i].merge(stats.operationStats[i]);
          }
-      }
-      for (Map.Entry<String, Set<Operation>> entryOtherStats : ((DefaultStatistics) otherStats).groupOperationsMap.entrySet()) {
-         if (!groupOperationsMap.containsKey(entryOtherStats.getKey())) {
-            groupOperationsMap.put(entryOtherStats.getKey(), new HashSet<Operation>());
-         }
-         groupOperationsMap.get(entryOtherStats.getKey()).addAll(entryOtherStats.getValue());
-      }
-      for (Map.Entry<Operation, String> entryOtherStats : ((DefaultStatistics) otherStats).operationGroupMap.entrySet()) {
-         String groupThisStats = operationGroupMap.get(entryOtherStats.getKey());
-         if (groupThisStats != null && !groupThisStats.equals(entryOtherStats.getValue())) {
-            throw new IllegalStateException(String.format("Operation %s was already registered with different group %s, expected %s",
-                                                          entryOtherStats.getKey(), entryOtherStats.getValue(), groupThisStats));
-         }
-         operationGroupMap.put(entryOtherStats.getKey(), entryOtherStats.getValue());
       }
    }
 

--- a/core/src/main/java/org/radargun/stats/PeriodicStatistics.java
+++ b/core/src/main/java/org/radargun/stats/PeriodicStatistics.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.radargun.Operation;
 import org.radargun.config.DefinitionElement;
@@ -105,12 +106,27 @@ public class PeriodicStatistics extends IntervalStatistics implements IterationD
    }
 
    @Override
+   public void registerOperationsGroup(String name, Set<Operation> operations) {
+      prototype.registerOperationsGroup(name, operations);
+   }
+
+   @Override
    public void merge(Statistics otherStats) {
       throw new UnsupportedOperationException();
    }
 
    @Override
    public Map<String, OperationStats> getOperationsStats() {
+      return prototype.getOperationsStats();
+   }
+
+   @Override
+   public String getOperationsGroup(Operation operation) {
+      return prototype.getOperationsGroup(operation);
+   }
+
+   @Override
+   public Map<String, OperationStats> getOperationStatsForGroups() {
       throw new UnsupportedOperationException();
    }
 

--- a/core/src/main/java/org/radargun/stats/PeriodicStatistics.java
+++ b/core/src/main/java/org/radargun/stats/PeriodicStatistics.java
@@ -126,6 +126,11 @@ public class PeriodicStatistics extends IntervalStatistics implements IterationD
    }
 
    @Override
+   public Map<String, Set<Operation>> getGroupOperationsMap() {
+      return prototype.getGroupOperationsMap();
+   }
+
+   @Override
    public Map<String, OperationStats> getOperationStatsForGroups() {
       throw new UnsupportedOperationException();
    }

--- a/core/src/main/java/org/radargun/stats/Statistics.java
+++ b/core/src/main/java/org/radargun/stats/Statistics.java
@@ -2,6 +2,7 @@ package org.radargun.stats;
 
 import java.io.Serializable;
 import java.util.Map;
+import java.util.Set;
 
 import org.radargun.Operation;
 import org.radargun.utils.ReflexiveConverters;
@@ -54,6 +55,19 @@ public interface Statistics extends Serializable {
    Statistics copy();
 
    /**
+    * Creates a logical group of operations identified by given group name. Should be used on per-stage basis.
+    *
+    * @param name Name of the group
+    * @param operations Operations to include in logical group
+    */
+   void registerOperationsGroup(String name, Set<Operation> operations);
+
+   /**
+    * @return Group name for supplied operation. Returns null if group with given operation is not registered.
+    */
+   String getOperationsGroup(Operation operation);
+
+   /**
     * Add the measurements collected into another instance to this instance.
     * @param otherStats Must be of the same class as this instance.
     */
@@ -74,6 +88,11 @@ public interface Statistics extends Serializable {
     * @return Map of operations stats keyed by operations names.
     */
    Map<String, OperationStats> getOperationsStats();
+
+   /**
+    * @return Merged operation stats for registered groups. Calculation should be based on operations registered with this group.
+    */
+   Map<String, OperationStats> getOperationStatsForGroups();
 
    /* Util method, execute only on the same node */
 

--- a/core/src/main/java/org/radargun/stats/Statistics.java
+++ b/core/src/main/java/org/radargun/stats/Statistics.java
@@ -68,6 +68,11 @@ public interface Statistics extends Serializable {
    String getOperationsGroup(Operation operation);
 
    /**
+    * @return Map all registered groups and their corresponding operations
+    */
+   Map<String, Set<Operation>> getGroupOperationsMap();
+
+   /**
     * Add the measurements collected into another instance to this instance.
     * @param otherStats Must be of the same class as this instance.
     */

--- a/core/src/main/java/org/radargun/utils/Utils.java
+++ b/core/src/main/java/org/radargun/utils/Utils.java
@@ -309,6 +309,17 @@ public class Utils {
       }
    }
 
+   public static void deleteDirectory(File file) {
+      if (file.isDirectory()) {
+         for (File f : file.listFiles()) {
+            deleteDirectory(f);
+         }
+      }
+      if (file.exists()) {
+         file.delete();
+      }
+   }
+
    public static String prettyPrintTime(long time, TimeUnit unit) {
       NumberFormat nf = NumberFormat.getNumberInstance();
       nf.setMaximumFractionDigits(2);

--- a/core/src/main/resources/benchmark-dist.xml
+++ b/core/src/main/resources/benchmark-dist.xml
@@ -16,7 +16,7 @@
    <!-- List of configurations of the services -->
    <configurations>
       <config name="Infinispan 5.2 - distributed">
-         <!-- All slaves use the same configuration -->
+      <!-- All slaves use the same configuration -->
          <setup plugin="infinispan52">
             <embedded xmlns="urn:radargun:plugins:infinispan52:2.2" file="dist-sync.xml"/>
          </setup>

--- a/core/src/test/java/org/radargun/stats/DefaultStatisticsTest.java
+++ b/core/src/test/java/org/radargun/stats/DefaultStatisticsTest.java
@@ -89,40 +89,4 @@ public class DefaultStatisticsTest {
       Assert.assertTrue(operationStatsForGroups.containsKey("testGroup2"));
    }
 
-   public void testMergeStats() {
-      DefaultStatistics statistics1 = new DefaultStatistics(new DefaultOperationStats());
-      Operation operation1 = Operation.register("testOp1");
-
-      statistics1.registerOperationsGroup("testGroup1", new HashSet<>(Arrays.asList(operation1)));
-      statistics1.registerRequest(1, operation1);
-
-      DefaultStatistics statistics2 = new DefaultStatistics(new DefaultOperationStats());
-      Operation operation2 = Operation.register("testOp2");
-
-      statistics2.registerOperationsGroup("testGroup2", new HashSet<>(Arrays.asList(operation2)));
-      statistics2.registerRequest(2, operation2);
-
-      Map<String, OperationStats> operationStatsForGroups1 = statistics1.getOperationStatsForGroups();
-      Assert.assertNotNull(operationStatsForGroups1);
-      Assert.assertEquals(operationStatsForGroups1.size(), 1);
-
-      statistics1.merge(statistics2);
-
-      operationStatsForGroups1 = statistics1.getOperationStatsForGroups();
-      Assert.assertNotNull(operationStatsForGroups1);
-      Assert.assertEquals(operationStatsForGroups1.size(), 2);
-
-      DefaultStatistics statistics3 = new DefaultStatistics(new DefaultOperationStats());
-      Operation operation3 = Operation.register("testOp3");
-
-      // the same group with different op
-      statistics3.registerOperationsGroup("testGroup2", new HashSet<>(Arrays.asList(operation3)));
-      statistics3.registerRequest(3, operation3);
-
-      statistics1.merge(statistics3);
-
-      operationStatsForGroups1 = statistics1.getOperationStatsForGroups();
-      Assert.assertNotNull(operationStatsForGroups1);
-      Assert.assertEquals(operationStatsForGroups1.size(), 2);
-   }
 }

--- a/core/src/test/java/org/radargun/stats/DefaultStatisticsTest.java
+++ b/core/src/test/java/org/radargun/stats/DefaultStatisticsTest.java
@@ -1,0 +1,128 @@
+package org.radargun.stats;
+
+import org.radargun.Operation;
+import org.testng.Assert;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+
+/**
+ * @author Matej Cimbora
+ */
+@Test(sequential = true)
+public class DefaultStatisticsTest {
+
+   @AfterTest
+   public void cleanup() {
+      Operation.clear();
+   }
+
+   public void testRegisterOperationsGroup() {
+      DefaultStatistics statistics = new DefaultStatistics(new DefaultOperationStats());
+      Operation operation1 = Operation.register("testOp1");
+      Operation operation2 = Operation.register("testOp2");
+      Assert.assertNull(statistics.getOperationsGroup(operation1));
+      Assert.assertNull(statistics.getOperationsGroup(operation2));
+
+      statistics.registerOperationsGroup("testGroup1", new HashSet<>(Arrays.asList(operation1)));
+      statistics.registerRequest(1, operation1);
+      statistics.registerRequest(2, operation2);
+
+      String operationsGroup1 = statistics.getOperationsGroup(operation1);
+      Assert.assertEquals("testGroup1", operationsGroup1);
+      Assert.assertNull(statistics.getOperationsGroup(operation2));
+
+      statistics.registerOperationsGroup("testGroup2", new HashSet<>(Arrays.asList(operation2)));
+
+      operationsGroup1 = statistics.getOperationsGroup(operation1);
+      String operationsGroup2 = statistics.getOperationsGroup(operation2);
+      Assert.assertEquals("testGroup1", operationsGroup1);
+      Assert.assertEquals("testGroup2", operationsGroup2);
+   }
+
+   @Test(expectedExceptions = IllegalArgumentException.class)
+   public void testRegisterDuplicateOperationsGroup() {
+      DefaultStatistics statistics = new DefaultStatistics(new DefaultOperationStats());
+      Operation operation1 = Operation.register("testOp1");
+      Operation operation2 = Operation.register("testOp2");
+
+      statistics.registerOperationsGroup("testGroup1", new HashSet<>(Arrays.asList(operation1)));
+      statistics.registerOperationsGroup("testGroup1", new HashSet<>(Arrays.asList(operation2)));
+   }
+
+   @Test(expectedExceptions = IllegalArgumentException.class)
+   public void testRegisterDuplicateOperation() {
+      DefaultStatistics statistics = new DefaultStatistics(new DefaultOperationStats());
+      Operation operation1 = Operation.register("testOp1");
+
+      statistics.registerOperationsGroup("testGroup1", new HashSet<>(Arrays.asList(operation1)));
+      statistics.registerOperationsGroup("testGroup2", new HashSet<>(Arrays.asList(operation1)));
+   }
+
+   public void testGetOperationStatsForGroups() {
+      DefaultStatistics statistics = new DefaultStatistics(new DefaultOperationStats());
+      Operation operation1 = Operation.register("testOp1");
+      Operation operation2 = Operation.register("testOp2");
+
+      Map<String, OperationStats> operationStatsForGroups = statistics.getOperationStatsForGroups();
+      Assert.assertNotNull(operationStatsForGroups);
+      Assert.assertEquals(operationStatsForGroups.size(), 0);
+
+      statistics.registerOperationsGroup("testGroup1", new HashSet<>(Arrays.asList(operation1)));
+      statistics.registerRequest(1l, operation1);
+      statistics.registerRequest(2l, operation2);
+
+      operationStatsForGroups = statistics.getOperationStatsForGroups();
+      Assert.assertNotNull(operationStatsForGroups);
+      Assert.assertEquals(operationStatsForGroups.size(), 1);
+      Assert.assertTrue(operationStatsForGroups.containsKey("testGroup1"));
+
+      statistics.registerOperationsGroup("testGroup2", new HashSet<>(Arrays.asList(operation2)));
+
+      operationStatsForGroups = statistics.getOperationStatsForGroups();
+      Assert.assertNotNull(operationStatsForGroups);
+      Assert.assertEquals(operationStatsForGroups.size(), 2);
+      Assert.assertTrue(operationStatsForGroups.containsKey("testGroup1"));
+      Assert.assertTrue(operationStatsForGroups.containsKey("testGroup2"));
+   }
+
+   public void testMergeStats() {
+      DefaultStatistics statistics1 = new DefaultStatistics(new DefaultOperationStats());
+      Operation operation1 = Operation.register("testOp1");
+
+      statistics1.registerOperationsGroup("testGroup1", new HashSet<>(Arrays.asList(operation1)));
+      statistics1.registerRequest(1, operation1);
+
+      DefaultStatistics statistics2 = new DefaultStatistics(new DefaultOperationStats());
+      Operation operation2 = Operation.register("testOp2");
+
+      statistics2.registerOperationsGroup("testGroup2", new HashSet<>(Arrays.asList(operation2)));
+      statistics2.registerRequest(2, operation2);
+
+      Map<String, OperationStats> operationStatsForGroups1 = statistics1.getOperationStatsForGroups();
+      Assert.assertNotNull(operationStatsForGroups1);
+      Assert.assertEquals(operationStatsForGroups1.size(), 1);
+
+      statistics1.merge(statistics2);
+
+      operationStatsForGroups1 = statistics1.getOperationStatsForGroups();
+      Assert.assertNotNull(operationStatsForGroups1);
+      Assert.assertEquals(operationStatsForGroups1.size(), 2);
+
+      DefaultStatistics statistics3 = new DefaultStatistics(new DefaultOperationStats());
+      Operation operation3 = Operation.register("testOp3");
+
+      // the same group with different op
+      statistics3.registerOperationsGroup("testGroup2", new HashSet<>(Arrays.asList(operation3)));
+      statistics3.registerRequest(3, operation3);
+
+      statistics1.merge(statistics3);
+
+      operationStatsForGroups1 = statistics1.getOperationStatsForGroups();
+      Assert.assertNotNull(operationStatsForGroups1);
+      Assert.assertEquals(operationStatsForGroups1.size(), 2);
+   }
+}

--- a/reporters/reporter-default/pom.xml
+++ b/reporters/reporter-default/pom.xml
@@ -17,5 +17,10 @@
          <artifactId>jfreechart</artifactId>
          <version>1.0.18</version>
       </dependency>
+      <dependency>
+         <groupId>org.freemarker</groupId>
+         <artifactId>freemarker</artifactId>
+         <version>2.3.23</version>
+      </dependency>
    </dependencies>
 </project>

--- a/reporters/reporter-default/src/main/java/org/radargun/reporting/commons/TestAggregations.java
+++ b/reporters/reporter-default/src/main/java/org/radargun/reporting/commons/TestAggregations.java
@@ -33,6 +33,7 @@ public class TestAggregations {
 
    private int maxIterations = 0;
    private Set<String> operations = new TreeSet<>();
+   private Set<String> operationGroups = new TreeSet<>();
    private Set<Cluster> clusters = new TreeSet<>();
 
    public TestAggregations(String testName, List<Report.Test> tests){
@@ -112,18 +113,19 @@ public class TestAggregations {
          for (Map.Entry<String, OperationStats> op : totalStats.getOperationsStats().entrySet()) {
             if (!op.getValue().isEmpty()) operations.add(op.getKey());
          }
+         operationGroups.addAll(totalStats.getOperationStatsForGroups().keySet());
       }
 
       if (it != null && it.getResults() != null) {
          for (Map.Entry<String, Report.TestResult> entry : it.getResults().entrySet()) {
             Map<Report, List<Report.TestResult>> resultsByType = results.get(entry.getKey());
             if (resultsByType == null) {
-               resultsByType = new TreeMap<Report, List<Report.TestResult>>();
+               resultsByType = new TreeMap<>();
                results.put(entry.getKey(), resultsByType);
             }
             List<Report.TestResult> resultsList = resultsByType.get(test.getReport());
             if (resultsList == null) {
-               resultsList = new ArrayList<Report.TestResult>();
+               resultsList = new ArrayList<>();
                resultsByType.put(test.getReport(), resultsList);
             }
             resultsList.add(entry.getValue());
@@ -145,6 +147,10 @@ public class TestAggregations {
 
    public Set<String> getAllOperations() {
       return Collections.unmodifiableSet(operations);
+   }
+
+   public Set<String> getOperationGroups() {
+      return Collections.unmodifiableSet(operationGroups);
    }
 
    public Set<Cluster> getAllClusters() {

--- a/reporters/reporter-default/src/main/java/org/radargun/reporting/commons/TestAggregations.java
+++ b/reporters/reporter-default/src/main/java/org/radargun/reporting/commons/TestAggregations.java
@@ -8,6 +8,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 
+import org.radargun.Operation;
 import org.radargun.config.Cluster;
 import org.radargun.logging.Log;
 import org.radargun.logging.LogFactory;
@@ -109,6 +110,11 @@ public class TestAggregations {
       if (totalStats == null) {
          log.warn("There are no stats for this iteration");
       } else {
+         if (test.getGroupOperationsMap() != null) {
+            for (Map.Entry<String, Set<Operation>> op : test.getGroupOperationsMap().entrySet()) {
+               totalStats.registerOperationsGroup(op.getKey(), op.getValue());
+            }
+         }
          iterations.add(new Aggregation(nodeStats, nodeThreads, totalStats, totalThreads, it));
          for (Map.Entry<String, OperationStats> op : totalStats.getOperationsStats().entrySet()) {
             if (!op.getValue().isEmpty()) operations.add(op.getKey());

--- a/reporters/reporter-default/src/main/java/org/radargun/reporting/html/HtmlDocument.java
+++ b/reporters/reporter-default/src/main/java/org/radargun/reporting/html/HtmlDocument.java
@@ -10,7 +10,6 @@ import java.io.PrintWriter;
  * @author Radim Vansa &lt;rvansa@redhat.com&gt;
  */
 public abstract class HtmlDocument {
-   protected PrintWriter writer;
    protected final String directory;
    private final String title;
    private final String fileName;
@@ -29,61 +28,24 @@ public abstract class HtmlDocument {
       this.title = title;
    }
 
-   /**
-    * Open the document file and write common headers.
-    * @throws IOException
-    */
-   public void open() throws IOException {
+   public String getFileName() {
+      return fileName;
+   }
+
+   public String getDirectory() {
+      return directory;
+   }
+
+   public void createReportDirectory() {
       File dir = new File(directory);
-      if (dir.exists() && !dir.isDirectory()) {
-         throw new IllegalArgumentException(dir.getAbsolutePath() + " is not a directory");
-      } else if (!dir.exists()) {
-         dir.mkdirs();
-      }
-      writer = new PrintWriter(directory + File.separator + fileName);
-      write("<HTML><HEAD><TITLE>");
-      write(title);
-      write("</TITLE><STYLE>\n");
-      writeStyle();
-      write("</STYLE>\n<SCRIPT>\n");
-      writeScripts();
-      write("</SCRIPT></HEAD>\n<BODY>");
+      dir.mkdirs();
    }
-
    /**
-    * Write CSS styles.
+    * The following methods are used in Freemarker templates
+    * e.g. method getPercentiles() can be used as getPercentiles() or percentiles in template
     */
-   protected void writeStyle() {
-   }
 
-   /**
-    * Write JavaScript scripts used in the document.
-    */
-   protected void writeScripts() {
-   }
-
-   /**
-    * Write footer and close the file.
-    */
-   public void close() {
-      writer.println("</BODY></HTML>");
-      writer.close();
-   }
-
-   /**
-    * Write open tag, content and closing tag
-    * @param tag
-    * @param content
-    */
-   protected void writeTag(String tag, String content) {
-      writer.write(String.format("<%s>%s</%s>", tag, content, tag));
-   }
-
-   /**
-    * Write arbitrary text.
-    * @param text
-    */
-   public void write(String text) {
-      writer.write(text);
+   public String getTitle() {
+      return title;
    }
 }

--- a/reporters/reporter-default/src/main/java/org/radargun/reporting/html/HtmlReporter.java
+++ b/reporters/reporter-default/src/main/java/org/radargun/reporting/html/HtmlReporter.java
@@ -2,10 +2,16 @@ package org.radargun.reporting.html;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintWriter;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.util.*;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import freemarker.cache.ClassTemplateLoader;
+import freemarker.template.*;
 import org.radargun.config.Configuration;
 import org.radargun.config.Property;
 import org.radargun.config.PropertyDelegate;
@@ -37,8 +43,12 @@ public class HtmlReporter implements Reporter {
    @PropertyDelegate(prefix = "timeline.")
    private TimelineDocument.Configuration timelineConfig = new TimelineDocument.Configuration();
 
+   private Set<String> allTests = new LinkedHashSet<>();
+   private Collection<Report> reports;
+
    @Override
    public void run(Collection<Report> reports) {
+      this.reports = reports;
       Set<String> allTests = new LinkedHashSet<>();
       Set<String> combinedTests = new LinkedHashSet<>();
       Map<String, List<Report.Test>> testsByName = new HashMap<String, List<Report.Test>>();
@@ -46,11 +56,14 @@ public class HtmlReporter implements Reporter {
       resolveCombinedTests(allTests, combinedTests);
       resolveTestsByName(reports, allTests, combinedTests, testsByName);
 
-      writeIndexDocument(reports, allTests);
+      this.allTests = allTests;
+
+      writeIndexDocument(reports);
       writeTimelineDocuments(reports);
       writeTestReportDocuments(combinedTests, testsByName);
       writeCombinedReportDocuments(testsByName);
       writeNormalizedConfigDocuments(reports);
+
    }
 
    private void resolveCombinedTests(Set<String> allTests, Set<String> combinedTests) {
@@ -67,7 +80,7 @@ public class HtmlReporter implements Reporter {
 
    private void resolveTestsByName(Collection<Report> reports, Set<String> allTests, Set<String> combinedTests, Map<String, List<Report.Test>> testsByName) {
       for (Report report : reports) {
-         for(Report.Test test : report.getTests()) {
+         for (Report.Test test : report.getTests()) {
             List<Report.Test> list = testsByName.get(test.name);
             if (list == null) {
                list = new ArrayList<>();
@@ -93,15 +106,14 @@ public class HtmlReporter implements Reporter {
             }
             for (String config : normalized) {
                NormalizedConfigDocument document = new NormalizedConfigDocument(
-                     targetDir, report.getConfiguration().name, setup.group, report.getCluster(), config, report.getNormalizedServiceConfigs(), slaves);
-               try {
-                  document.open();
-                  document.writeProperties();
-               } catch (IOException e) {
-                  log.error("Failed to write normalized configuration", e);
-               } finally {
-                  document.close();
-               }
+                       targetDir, report.getConfiguration().name, setup.group, report.getCluster(), config, report.getNormalizedServiceConfigs(), slaves);
+
+               document.createReportDirectory();
+
+               Map root = new HashMap();
+               root.put("normalized", document);
+
+               processTemplate(root, targetDir, document.getFileName(), "normalizedReport.ftl");
             }
          }
       }
@@ -127,15 +139,17 @@ public class HtmlReporter implements Reporter {
             return;
          }
          CombinedReportDocument testReport = new CombinedReportDocument(testAggregations, sb.toString(), combined, targetDir, testReportConfig);
-         try {
-            testReport.open();
-            testReport.writeTest();
-         } catch (IOException e) {
-            log.error("Failed to create test report combined", e);
-         }
-         finally {
-            testReport.close();
-         }
+
+         testReport.createReportDirectory();
+         testReport.calculateClusterSizes();
+         testReport.createTestCharts();
+
+         Map root = new HashMap();
+         root.put("testReport", testReport);
+         root.put("enums", DefaultObjectWrapper.getDefaultInstance().getEnumModels());
+
+         processTemplate(root, targetDir, "test_" + testReport.testName + ".html", "testReport.ftl");
+
       }
    }
 
@@ -147,47 +161,140 @@ public class HtmlReporter implements Reporter {
          }
          TestAggregations ta = new TestAggregations(entry.getKey(), entry.getValue());
          TestReportDocument testReport = new TestReportDocument(ta, targetDir, testReportConfig);
-         try {
-            testReport.open();
-            testReport.writeTest();
-         } catch (IOException e) {
-            log.error("Failed to create test report " + entry.getKey(), e);
-         } finally {
-            testReport.close();
-         }
+
+         testReport.createReportDirectory();
+         testReport.createTestCharts();
+
+         Map root = new HashMap();
+         root.put("testReport", testReport);
+         root.put("enums", DefaultObjectWrapper.getDefaultInstance().getEnumModels());
+
+         processTemplate(root, targetDir, "test_" + testReport.testName + ".html", "testReport.ftl");
       }
    }
 
    private void writeTimelineDocuments(Collection<Report> reports) {
       for (Report report : reports) {
          String configName = report.getConfiguration().name;
-
          TimelineDocument timelineDocument = new TimelineDocument(timelineConfig, targetDir,
-               configName + "_" + report.getCluster().getClusterIndex(), configName + " on " + report.getCluster(), report.getTimelines(), report.getCluster());
-         try {
-            timelineDocument.open();
-            timelineDocument.writeTimelines();
-         } catch (IOException e) {
-            log.error("Failed to create timeline report " + configName, e);
-         } finally {
-            timelineDocument.close();
-         }
+                 configName + "_" + report.getCluster().getClusterIndex(), configName + " on " + report.getCluster(), report.getTimelines(), report.getCluster());
+
+         timelineDocument.createReportDirectory();
+         timelineDocument.createTestCharts();
+
+         Map root = new HashMap();
+         root.put("timelineDocument", timelineDocument);
+
+         exposeStaticMethods(root, "java.lang.String", "String");
+         processTemplate(root, targetDir, timelineDocument.getFileName(), "timelineReport.ftl");
       }
    }
 
-   private void writeIndexDocument(Collection<Report> reports, Set<String> allTests) {
+   private void writeIndexDocument(Collection<Report> reports) {
       IndexDocument index = new IndexDocument(targetDir);
+      index.createReportDirectory();
+      index.prepareServiceConfigs(reports);
+
       try {
-         index.open();
-         index.writeTests(allTests);
-         index.writeConfigurations(reports);
-         index.writeScenario(reports);
-         index.writeTimelines(reports);
-         index.writeFooter();
+         copyResources("style.css");
+         copyResources("script.js");
       } catch (IOException e) {
-         log.error("Failed to write HTML report.", e);
-      } finally {
-         index.close();
+         log.error("Failed to copy resources", e);
       }
+
+      Map root = new HashMap();
+      root.put("reporter", this);
+      root.put("indexDocument", index);
+
+      processTemplate(root, targetDir, "index.html", "index.ftl");
+   }
+
+   /**
+    * Allows to use static methods in the template
+    *
+    * @param root        map to which String will be added
+    * @param className   full name of class which is to be exposed to the template e.g. java.lang.String
+    * @param exposedName name by which the class will be accessed in the template e.g. String
+    */
+   private void exposeStaticMethods(Map root, String className, String exposedName) {
+      DefaultObjectWrapperBuilder builder = new DefaultObjectWrapperBuilder(freemarker.template.Configuration.VERSION_2_3_23);
+      try {
+         root.put(exposedName, builder.build().getStaticModels().get(className));
+      } catch (TemplateModelException e) {
+         log.error("Error while getting static class", e);
+      }
+   }
+
+   /**
+    * Creates html file from template
+    *
+    * @param root         Map of objects that are exposed to the template
+    * @param targetDir    target directory for the html file
+    * @param fileName     name of html file e.g. index.html
+    * @param templateName name of template file e.g. index.ftl
+    */
+   public static void processTemplate(Map root, String targetDir, String fileName, String templateName) {
+      freemarker.template.Configuration cfg = initConfig();
+      try (PrintWriter printWriter = new PrintWriter(targetDir + File.separator + fileName)) {
+         Template reportTemplate = cfg.getTemplate(templateName);
+         reportTemplate.process(root, printWriter);
+      } catch (Exception e) {
+         log.error("Templating exception", e);
+      }
+   }
+
+   /**
+    * Copies files from resources to targetDir destination
+    * This is used to copy css and js files to target dir
+    *
+    * @param file to be copied
+    * @throws IOException if file can not be copied
+    */
+   private void copyResources(String file) throws IOException {
+      ClassLoader classLoader = getClass().getClassLoader();
+      try (InputStream source = classLoader.getResourceAsStream("html/templates/" + file)) {
+         File destination = new File(targetDir + File.separator + file);
+         Files.copy(source, destination.toPath(), StandardCopyOption.REPLACE_EXISTING);
+      } catch (Exception e) {
+         log.error("Exception while copying resources", e);
+      }
+   }
+
+   /**
+    * Initializes Freemarker configuration
+    *
+    * @return created configuration
+    */
+   public static freemarker.template.Configuration initConfig() {
+      freemarker.template.Configuration cfg = new freemarker.template.Configuration(freemarker.template.Configuration.VERSION_2_3_23);
+      cfg.setTemplateLoader(new ClassTemplateLoader(HtmlReporter.class, "/html/templates"));
+
+      DefaultObjectWrapperBuilder builder = new DefaultObjectWrapperBuilder(freemarker.template.Configuration.VERSION_2_3_23);
+      // grants access to public fields
+      builder.setExposeFields(true);
+      DefaultObjectWrapper bw = builder.build();
+      // allows to use ?api construct in templates
+      cfg.setAPIBuiltinEnabled(true);
+      // setting how booleans are displayed, default results in error
+      cfg.setBooleanFormat("True, False");
+      cfg.setObjectWrapper(bw);
+      return cfg;
+   }
+
+   /**
+    * The following methods are used in Freemarker templates
+    * e.g. method getPercentiles() can be used as getPercentiles() or percentiles in template
+    */
+
+   public String getSystemProperty(String property) {
+      return System.getProperty(property);
+   }
+
+   public Set<String> getAllTests() {
+      return allTests;
+   }
+
+   public Collection<Report> getReports() {
+      return reports;
    }
 }

--- a/reporters/reporter-default/src/main/java/org/radargun/reporting/html/IndexDocument.java
+++ b/reporters/reporter-default/src/main/java/org/radargun/reporting/html/IndexDocument.java
@@ -7,18 +7,14 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
-import org.radargun.Service;
 import org.radargun.config.Cluster;
-import org.radargun.config.ComplexDefinition;
 import org.radargun.config.Configuration;
-import org.radargun.config.Definition;
-import org.radargun.config.SimpleDefinition;
 import org.radargun.logging.Log;
 import org.radargun.logging.LogFactory;
 import org.radargun.reporting.Report;
@@ -31,168 +27,23 @@ import org.radargun.reporting.Report;
  */
 public class IndexDocument extends HtmlDocument {
    private static final Log log = LogFactory.getLog(IndexDocument.class);
-
-   private int elementCounter = 0;
+   private Map<Report, Set<OriginalConfig>> configs = new HashMap<>();
+   private Set<String> normalized = new HashSet<>();
 
    public IndexDocument(String directory) {
       super(directory, "index.html", "RadarGun benchmark");
    }
 
-   @Override
-   public void open() throws IOException {
-      super.open();
-      writeTag("h1", "RadarGun benchmark report");
-   }
-
-   @Override
-   protected void writeScripts() {
-      write("function switch_visibility (id) {\n");
-      write("    var element = document.getElementById(id);\n");
-      write("    if (element == null) return;\n");
-      write("    if (element.style.visibility == 'collapse') {\n");
-      write("        element.style.visibility = 'visible';\n");
-      write("    } else {\n");
-      write("         element.style.visibility = 'collapse';\n");
-      write("    }\n}\n");
-      write("function switch_li_display (id) {\n");
-      write("    var element = document.getElementById(id);\n");
-      write("    if (element == null) return;\n");
-      write("    if (element.style.display == 'none') {\n");
-      write("        element.style.display = 'list-item';\n");
-      write("    } else {\n");
-      write("         element.style.display = 'none';\n");
-      write("    }\n}\n");
-   }
-
-   public void writeConfigurations(Collection<Report> reports) {
-      writeTag("h2", "Configurations");
-      write("The benchmark was executed on following configurations and cluster sizes:<br>\n");
-      for (Report report : reports) {
-         writeTag("strong", report.getConfiguration().name);
-         write(" on cluster with " + report.getCluster().getSize() + " slaves: " + report.getCluster());
-         write("\n<br>Setups:<br><ul>\n");
-         for (Configuration.Setup setup : report.getConfiguration().getSetups()) {
-            write(String.format("<li>Group %s:<ul>\n<li>Plugin: %s</li>\n<li>Service: %s</li>\n", setup.group, setup.plugin, setup.service));
-            writeConfigurationFiles(report, setup);
-            if (!setup.getProperties().isEmpty()) {
-               write("<li>Properties: <ul>\n");
-               for (Map.Entry<String, Definition> property : setup.getProperties().entrySet()) {
-                  writeProperty(property.getKey(), property.getValue());
-               }
-               write("</ul></li>\n");
-            }
-            write("</ul></li>\n");
-         }
-         write("</ul><br>\n");
-      }
-
-   }
-
-   private void writeProperty(String name, Definition definition) {
-      if (definition instanceof SimpleDefinition) {
-         write(String.format("<li>%s: %s</li>\n", name, definition));
-      } else if (definition instanceof ComplexDefinition) {
-         write("<li>" + name + ":<ul>\n");
-         for (ComplexDefinition.Entry property : ((ComplexDefinition) definition).getAttributes()) {
-            writeProperty(property.name, property.definition);
-         }
-         write("</ul></li>\n");
-      }
-   }
-
-   private static class OriginalConfig {
-      private Set<Integer> slaves = new HashSet<>();
-      private String filename;
-      private byte[] content;
-
-      public OriginalConfig(int slave, String filename, byte[] content) {
-         slaves.add(slave);
-         this.filename = filename;
-         this.content = content;
-      }
-   }
-
-   private void writeConfigurationFiles(Report report, Configuration.Setup setup) {
-      Set<Integer> slaves = report.getCluster().getSlaves(setup.group);
-      Set<OriginalConfig> configs = new HashSet<>();
-      for (Map.Entry<Integer, Map<String, byte[]>> entry : report.getOriginalServiceConfig().entrySet()) {
-         if (slaves.contains(entry.getKey()) && entry.getValue() != null) {
-            for (Map.Entry<String, byte[]> file : entry.getValue().entrySet()) {
-               addToConfigs(configs, entry.getKey(), file.getKey(), file.getValue());
-            }
-         }
-      }
-      String file = String.valueOf(setup.getProperties().get(Service.FILE));
-      if (configs.size() == 0) {
-         write("<li>Configuration file: " + file + "</li>\n");
-      } else if (configs.size() == 1) {
-         write("<li>Configuration file: ");
-         writeConfig(report.getCluster(), setup, configs.iterator().next(), false);
-         write("</li>\n");
-      } else {
-         write("<li>Configuration files: <ul>\n");
-         for (OriginalConfig config : configs) {
-            if (config.filename.equals(file)) {
-               write("<li>");
-               writeConfig(report.getCluster(), setup, config, config.slaves.size() != slaves.size());
-               write("</li>\n");
-            }
-         }
-         for (OriginalConfig config : configs) {
-            if (!config.filename.equals(file)) {
-               write("<li>");
-               writeConfig(report.getCluster(), setup, config, config.slaves.size() != slaves.size());
-               write("</li>\n");
-            }
-         }
-         write("</ul>");
-      }
-      Set<String> normalized = new HashSet<>();
-      for (Map.Entry<Integer, Map<String, Properties>> entry : report.getNormalizedServiceConfigs().entrySet()) {
-         if (slaves.contains(entry.getKey()) && entry.getValue() != null) {
-            normalized.addAll(entry.getValue().keySet());
-         }
-      }
-      write("<li>Normalized configurations: <ul>\n");
-      for (String config : normalized) {
-         write(String.format("<li><a href=\"%s\">%s</a></li>",
-               NormalizedConfigDocument.getFilename(
-                     report.getConfiguration().name, setup.group, report.getCluster(), config), config));
-      }
-      write("</ul></li>");
-   }
-
-   private void writeConfig(Cluster cluster, Configuration.Setup setup, OriginalConfig config, boolean writeSlaves) {
+   private void writeConfig(Cluster cluster, Configuration.Setup setup, OriginalConfig config) {
       String configFile = String.format("original_%s_%s_%d_%s",
-            setup.getConfiguration().name, setup.group, cluster.getClusterIndex(), config.filename).replace(File.separator, "_");
-      boolean written = true;
+                                        setup.getConfiguration().name, setup.group, cluster.getClusterIndex(), config.filename).replace(File.separator, "_");
       try (FileOutputStream contentWriter = new FileOutputStream(directory + File.separator + configFile)) {
          contentWriter.write(config.content);
       } catch (FileNotFoundException e) {
-         written = false;
          log.error("Failed to open " + configFile, e);
       } catch (IOException e) {
-         written = false;
          log.error("Failed to write " + configFile, e);
       }
-      if (written) {
-         write(String.format("<a href=\"%s\">%s</a>", configFile, config.filename));
-      } else {
-         write(config.filename);
-      }
-      if (writeSlaves) {
-         write("(slaves ");
-         boolean first = true;
-         for (int slave : config.slaves) {
-            write(String.valueOf(slave));
-            if (!first) {
-               write(", ");
-            }
-            first = false;
-         }
-         write(")");
-      }
-
    }
 
    private void addToConfigs(Set<OriginalConfig> configs, int slave, String filename, byte[] content) {
@@ -209,71 +60,87 @@ public class IndexDocument extends HtmlDocument {
       }
    }
 
-   public void writeScenario(Collection<Report> reports) {
-      if (reports.isEmpty()) return;
-      // all reports should share the same stages
-      List<Report.Stage> stages = reports.iterator().next().getStages();
-      writeTag("h2", "Scenario");
-      write("Note that some properties may have not been resolved correctly as these depend on local properties<br>");
-      write("\nThese stages have been used for the benchmark:<br><ul>\n");
-      for (Report.Stage stage : stages) {
-         writeStage(stage);
-      }
-      write("</ul>\n");
-   }
+   /**
+    * Prepares configuration files for report
+    *
+    * @param reports to be parsed
+    */
+   public void prepareServiceConfigs(Collection<Report> reports) {
+      for (Report report : reports) {
+         for (Configuration.Setup setup : report.getConfiguration().getSetups()) {
+            Set<Integer> slaves = report.getCluster().getSlaves(setup.group);
 
-   private void writeStage(Report.Stage stage) {
-      writer.write("<li><span style=\"cursor: pointer\" onClick=\"");
-      List<Report.Property> properties = stage.getProperties();
-      for (int i = 0; i < properties.size(); ++i) {
-         writer.write("switch_li_display('e" + (elementCounter + i) + "');");
-      }
-      writer.write(String.format("\">%s</span><ul>\n", stage.getName()));
-      for (Report.Property property : properties) {
-         int propertyCounter = elementCounter++;
-         if (property.getDefinition() != null) {
-            writer.write(String.format("<li><strong>%s = %s</strong>&nbsp;" +
-                  "<small style=\"cursor: pointer\"  id=\"showdef%d\" onClick=\"switch_visibility('showdef%d'); switch_visibility('def%d');\">show definition</small>" +
-                  "<span id=\"def%d\" style=\"visibility: collapse\"><small style=\"cursor: pointer\" onClick=\"switch_visibility('showdef%d'); switch_visibility('def%d');\">hide definition:</small>" +
-                  "&nbsp;%s</span></li>\n", property.getName(), escape(String.valueOf(property.getValue())),
-                  propertyCounter, propertyCounter, propertyCounter, propertyCounter, propertyCounter, propertyCounter,
-                  escape(String.valueOf(property.getDefinition()))));
-         } else {
-            writer.write(String.format("<li id=\"e%d\" style=\"display: none\"><small>%s = %s</small></li>\n",
-                     propertyCounter, property.getName(), property.getValue()));
+            for (Map.Entry<Integer, Map<String, Properties>> entry : report.getNormalizedServiceConfigs().entrySet()) {
+               if (slaves.contains(entry.getKey()) && entry.getValue() != null) {
+                  normalized.addAll(entry.getValue().keySet());
+               }
+            }
+
+            Set<OriginalConfig> configs = new HashSet<>();
+            for (Map.Entry<Integer, Map<String, byte[]>> entry : report.getOriginalServiceConfig().entrySet()) {
+               if (slaves.contains(entry.getKey()) && entry.getValue() != null) {
+                  for (Map.Entry<String, byte[]> file : entry.getValue().entrySet()) {
+                     addToConfigs(configs, entry.getKey(), file.getKey(), file.getValue());
+                  }
+               }
+            }
+            this.configs.put(report, configs);
+
+            for (OriginalConfig config : configs) {
+               writeConfig(report.getCluster(), setup, config);
+            }
          }
       }
-      writer.write("</ul></li>\n");
    }
 
-   private String escape(String str) {
-      return str.replaceAll("<", "&lt;").replace(">", "&gt;");
+   /**
+    * The following methods are used in Freemarker templates
+    * e.g. method getPercentiles() can be used as getPercentiles() or percentiles in template
+    */
+
+   public Set<OriginalConfig> getConfigs(Report report) {
+      return configs.get(report);
    }
 
-   protected void writeTimelines(Collection<Report> reports) {
-      writeTag("h2", "Timelines");
-      write("<ul>\n");
-      for (Report report : reports) {
-         write(String.format("<li><a href=\"timeline_%s_%d.html\">%s on %s</a></li>",
-            report.getConfiguration().name, report.getCluster().getClusterIndex(), report.getConfiguration().name, report.getCluster()));
+   public String getFilename(String configName, String groupName, Cluster cluster, String config) {
+      return String.format("normalized_%s_%s_%d_%s.html",
+              configName, groupName, cluster.getClusterIndex(), config);
+   }
+
+   public Set<String> getNormalized() {
+      return normalized;
+   }
+
+   public String removeFileSeparator(String string) {
+      return string.replace(File.separator, "_");
+   }
+
+   public static class OriginalConfig {
+      private Set<Integer> slaves = new HashSet<>();
+      private String filename;
+      private byte[] content;
+
+      public OriginalConfig(int slave, String filename, byte[] content) {
+         slaves.add(slave);
+         this.filename = filename;
+         this.content = content;
       }
-      write("\n</ul>");
-   }
 
-   protected void writeTests(Collection<String> testNames) {
-      writeTag("h2", "Tests");
-      write("<ul>\n");
-      for (String test : testNames) {
-         write(String.format("<li><a href=\"test_%s.html\">%s</a></li>", test, test));
+      /**
+       * The following methods are used in Freemarker templates
+       * e.g. method getPercentiles() can be used as getPercentiles() or percentiles in template
+       */
+
+      public Set<Integer> getSlaves() {
+         return slaves;
       }
-      write("\n</ul>");
-   }
 
-   protected void writeFooter() {
-      writer.write("<hr>");
-      writer.write("Generated on " + new Date() + " by RadarGun\nJDK: " +
-            System.getProperty("java.vm.name") + " (" + System.getProperty("java.vm.version") + ", " +
-            System.getProperty("java.vm.vendor") + ") OS: " + System.getProperty("os.name") + " (" +
-            System.getProperty("os.version") + ", " + System.getProperty("os.arch") + ")");
+      public String getFilename() {
+         return filename;
+      }
+
+      public byte[] getContent() {
+         return content;
+      }
    }
 }

--- a/reporters/reporter-default/src/main/java/org/radargun/reporting/html/NormalizedConfigDocument.java
+++ b/reporters/reporter-default/src/main/java/org/radargun/reporting/html/NormalizedConfigDocument.java
@@ -1,10 +1,6 @@
 package org.radargun.reporting.html;
 
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
-import java.util.SortedMap;
-import java.util.TreeMap;
+import java.util.*;
 
 import org.radargun.config.Cluster;
 
@@ -39,53 +35,37 @@ public class NormalizedConfigDocument extends HtmlDocument {
 
    private static String getTitle(String configName, String groupName, Cluster cluster, String config) {
       return String.format("Normalized configuration %s for %s, group %s on %s",
-            config, configName, groupName, cluster);
+              config, configName, groupName, cluster);
    }
 
    public static String getFilename(String configName, String groupName, Cluster cluster, String config) {
       return String.format("normalized_%s_%s_%d_%s.html",
-            configName, groupName, cluster.getClusterIndex(), config);
+              configName, groupName, cluster.getClusterIndex(), config);
    }
 
-   @Override
-   protected void writeStyle() {
-      write("TABLE { border-spacing: 0; border-collapse: collapse; }\n");
-      write("TD { border: 1px solid gray; padding: 2px; }\n");
-      write("TH { border: 1px solid gray; padding: 2px; text-align: left; }\n");
-      write(".difference { background-color: #FFBBBB; }\n");
+   /**
+    * The following methods are used in Freemarker templates
+    * e.g. method getPercentiles() can be used as getPercentiles() or percentiles in template
+    */
+
+   public Map<String, SortedMap<Integer, String>> getProperties() {
+      return properties;
    }
 
-   public void writeProperties() {
-      write("<table><tr><th>&nbsp;</th>");
-      for (Integer slave : slaves) {
-         write("<th style=\"text-align: center\">Slave " + slave + "</th>");
+   public Set<Integer> getSlaves() {
+      return slaves;
+   }
+
+   public boolean checkForDifference(List<String> values) {
+      String firstValue = null;
+
+      for (String value : values) {
+         if (firstValue == null) {
+            firstValue = value;
+         } else if (!firstValue.equals(value)) {
+            return true;
+         }
       }
-      write("</tr>");
-      for (Map.Entry<String, SortedMap<Integer, String>> property : properties.entrySet()) {
-         String firstValue = null;
-         boolean difference = false;
-         for (String value : property.getValue().values()) {
-            if (firstValue == null) {
-               firstValue = value;
-            } else if (!firstValue.equals(value)) {
-               difference = true;
-            }
-         }
-         write("<tr>");
-         if (difference) {
-            write("<th class=\"difference\">" + property.getKey() + "</th>");
-         } else {
-            writeTag("th", property.getKey());
-         }
-         for (String value : property.getValue().values()) {
-            if (difference) {
-               write("<td class=\"difference\">" + value + "</td>");
-            } else {
-               writeTag("td", value);
-            }
-         }
-         write("</tr>\n");
-      }
-      write("</table>");
+      return false;
    }
 }

--- a/reporters/reporter-default/src/main/java/org/radargun/reporting/html/TestReportDocument.java
+++ b/reporters/reporter-default/src/main/java/org/radargun/reporting/html/TestReportDocument.java
@@ -45,25 +45,30 @@ public class TestReportDocument extends ReportDocument {
    }
 
    public void createTestCharts() {
-      for (String operation : testAggregations.getAllOperations()) {
+      createTestCharts(testAggregations.getOperationGroups());
+      createTestCharts(testAggregations.getAllOperations());
+      waitForChartsGeneration();
+   }
+
+   private void createTestCharts(Set<String> targets) {
+      for (String target : targets) {
          if (maxClusters > 1 && configuration.separateClusterCharts) {
             for (Integer clusterSize : testAggregations.byClusterSize().keySet()) {
                try {
-                  createCharts(operation, clusterSize);
+                  createCharts(target, clusterSize);
                } catch (IOException e) {
                   log.error("Exception while creating test charts", e);
                }
             }
          } else {
             try {
-               createCharts(operation, 0);
+               createCharts(target, 0);
             } catch (IOException e) {
                log.error("Exception while creating test charts", e);
             }
          }
-         createHistogramAndPercentileCharts(operation, testAggregations.byReports(), testName);
+         createHistogramAndPercentileCharts(target, testAggregations.byReports(), testName);
       }
-      waitForChartsGeneration();
    }
 
    /**
@@ -88,5 +93,9 @@ public class TestReportDocument extends ReportDocument {
 
    public Set<String> getOperations() {
       return testAggregations.getAllOperations();
+   }
+
+   public Set<String> getOperationGroups() {
+      return testAggregations.getOperationGroups();
    }
 }

--- a/reporters/reporter-default/src/main/java/org/radargun/reporting/html/TimelineChart.java
+++ b/reporters/reporter-default/src/main/java/org/radargun/reporting/html/TimelineChart.java
@@ -97,7 +97,7 @@ public class TimelineChart {
       for (Timeline.Event event : events) {
          if (event instanceof Timeline.Value) {
             Timeline.Value value = (Timeline.Value) event;
-            int bucket = (int) ((event.timestamp - startTimestamp) * MAX_EVENT_VALUES / (endTimestamp - startTimestamp));
+            int bucket = (int) ((event.timestamp - startTimestamp) * (MAX_EVENT_VALUES - 1) / (endTimestamp - startTimestamp));
             if (minValues[bucket] == null) {
                minValues[bucket] = value.value;
                maxValues[bucket] = value.value;

--- a/reporters/reporter-default/src/main/resources/html/templates/index.ftl
+++ b/reporters/reporter-default/src/main/resources/html/templates/index.ftl
@@ -1,0 +1,149 @@
+<html>
+<head>
+   <title>${indexDocument.getTitle()}</title>
+   <script src="script.js"></script>
+   <link rel="stylesheet" href="style.css">
+   <#import "lib/library.ftl" as library />
+</head>
+<body>
+   <h1>RadarGun benchmark report</h1>
+   <h2>Tests</h2>
+   <#assign elementCounter = 0 />
+   <ul>
+      <#list reporter.allTests as testName>
+         <li>
+            <a href="test_${testName}.html">${testName}</a>
+         </li>
+      </#list>
+   </ul>
+   <h2>Configurations</h2>
+      The benchmark was executed on following configurations and cluster sizes: <br/>
+   <ul>
+      <#list reporter.reports as report>
+         <li>
+            <b>${report.configuration.name}</b> on cluster with ${report.cluster.size} slaves: ${report.cluster}. <br/>
+               Setups: <br/>
+            <ul>
+               <#list report.configuration.setups as setup>
+                  <li>
+                     Group: ${setup.group}
+                     <ul>
+                        <li>Plugin: ${setup.plugin}</li>
+                        <li>Service: ${setup.service}</li>
+                        <#if (indexDocument.getConfigs(report))?size == 0>
+                           <#assign fileName = (setup.properties["file"])!" no file" />
+                              <li>Configuration file: ${fileName}</li>
+
+                        <#else>
+                           <li>
+                              Configuration files:
+                              <ul>
+                                 <#list (indexDocument.getConfigs(report)) as config>
+                                    <li>
+                                       <a href="${getConfigFileName(setup.configuration.name, setup.group, report.cluster.clusterIndex, config.filename)}"> ${config.filename}</a>
+                                    </li>
+                                 </#list>
+                              </ul>
+                           </li>
+                           <li>
+                              Normalized configurations:
+                               <ul>
+                                  <#list indexDocument.getNormalized() as config>
+                                    <li>
+                                       <a href="${indexDocument.getFilename(report.getConfiguration().name, setup.group, report.getCluster(), config)}">
+                                             ${config}
+                                       </a>
+                                    </li>
+                                  </#list>
+                               </ul>
+                           </li>
+                        </#if>
+                     </ul>
+                     <#if setup.properties??>
+                        <li>
+                           Properties:
+                            <ul>
+                               <#list setup.properties?keys as property>
+                                 <@writeProperty name=property definition=(setup.properties)[property] />
+                              </#list>
+                            </ul>
+                        </li>
+                     </#if>
+                  </li>
+               </#list>
+            </ul>
+         </li>
+      </#list>
+   </ul>
+   <h2>Scenario</h2>
+      Note that some properties may have not been resolved correctly as these depend on local properties. <br/>
+      These stages have been used for the benchmark: <br/>
+   <ul>
+      <#if reporter.reports?? && reporter.reports?has_content>
+         <#list reporter.reports[0].stages as stage>
+            <li>
+               <span class="onClick" onclick="${library.expandableRowsInList(stage.getProperties()?size, elementCounter)}">
+                     ${stage.name}
+               </span>
+               <ul>
+                  <#list stage.properties as property>
+                     <#assign propertyCounter = elementCounter />
+                     <#assign elementCounter = elementCounter + 1 />
+                     <#if property.definition??>
+                        <li>
+                           <b>${property.name} = ${property.value}</b>
+                           <small class="onClick" id="showdef${propertyCounter}"
+                                 onclick="switch_visibility('showdef${propertyCounter}'); switch_visibility('def${propertyCounter}');">show definition</small>
+
+                            <span id="def${propertyCounter}" class="collapse"><small class="onClick"
+                               onClick="switch_visibility('showdef${propertyCounter}'); switch_visibility('def${propertyCounter}');">hide definition:</small>
+                               ${property.getDefinition()}
+                            </span>
+                        </li>
+                     <#else>
+                        <li id="e${propertyCounter}" class="none">
+                              ${property.name} = ${property.value}
+                        </li>
+                     </#if>
+                  </#list>
+               </ul>
+            </li>
+         </#list>
+      </#if>
+   </ul>
+   <h2>Timelines</h2>
+   <ul>
+      <#list reporter.reports as report>
+         <li>
+            <a href="timeline_${report.configuration.name}_${report.cluster.clusterIndex}.html">${report.configuration.name} on ${report.cluster}</a>
+         </li>
+      </#list>
+   </ul>
+   <hr/>
+   Generated on ${.now} by RadarGun
+   JDK: ${reporter.getSystemProperty("java.vm.name")} ${reporter.getSystemProperty("java.vm.version")}, ${reporter.getSystemProperty("java.vm.vendor")}
+   OS: ${reporter.getSystemProperty("os.name")} ${reporter.getSystemProperty("os.version")}, ${reporter.getSystemProperty("os.arch")}
+</body>
+</html>
+
+<#macro writeProperty name definition>
+<#if definition.getClass().getSimpleName() == "SimpleDefinition">
+<li>
+   ${name} : ${definition}
+</li>
+<#elseif definition.getClass().getSimpleName() == "ComplexDefinition">
+<li>
+    <ul>
+       <#list definition.attributes?keys as attributeKey>
+            <@writeProperty name=attributeKey definition=(definition.attributes)[attributeKey]/>
+         </#list>
+    </ul>
+</li>
+</#if>
+</#macro>
+
+<#function getConfigFileName configurationName group clusterIndex filename>
+   <#local result = "original_" + configurationName + "_" + group + "_" + clusterIndex + "_" + filename />
+   <#local result = indexDocument.removeFileSeparator(result)/>
+   <#return result />
+</#function>

--- a/reporters/reporter-default/src/main/resources/html/templates/lib/library.ftl
+++ b/reporters/reporter-default/src/main/resources/html/templates/lib/library.ftl
@@ -1,0 +1,15 @@
+<#function expandableRowsInList rowCount elementCounter>
+   <#local result = "" />
+   <#list 0 .. (rowCount - 1) as count>
+      <#local result = result + "switch_li_display('e" + (elementCounter + count) + "'); " />
+   </#list>
+   <#return result />
+</#function>
+
+<#function expandableRows rowCount elementCounter>
+   <#local result = "" />
+   <#list 0 .. (rowCount - 1) as count>
+      <#local result = result + "switch_visibility('e" + (elementCounter + count) + "'); " />
+   </#list>
+   <#return result />
+</#function>

--- a/reporters/reporter-default/src/main/resources/html/templates/normalizedReport.ftl
+++ b/reporters/reporter-default/src/main/resources/html/templates/normalizedReport.ftl
@@ -1,0 +1,38 @@
+<html>
+<head>
+   <title>${normalized.getTitle()}</title>
+   <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+   <table>
+      <tr>
+         <th></th>
+         <#list normalized.getSlaves() as slave>
+            <th class="center">
+               Slave ${slave}
+            </th>
+         </#list>
+      </tr>
+
+      <#list normalized.getProperties()?keys as key>
+         <#assign difference = normalized.checkForDifference(normalized.getProperties()[key]?values) />
+         <tr>
+            <#if difference>
+               <th class="difference left"> ${key} </th>
+            <#else>
+               <th class="left"> ${key} </th>
+            </#if>
+            <#list normalized.getProperties()[key]?values as value>
+               <#if difference>
+                  <td class="difference"> ${value} </td>
+               <#else>
+                  <td>${value}</td>
+               </#if>
+            </#list>
+         </tr>
+      </#list>
+   </table>
+</body>
+</html>
+

--- a/reporters/reporter-default/src/main/resources/html/templates/script.js
+++ b/reporters/reporter-default/src/main/resources/html/templates/script.js
@@ -1,0 +1,36 @@
+function switch_visibility(id) {
+    var element = document.getElementById(id);
+    if (element == null) return;
+
+    if (element.classList.contains('collapse')) {
+        element.classList.remove('collapse');
+        element.classList.add('visible');
+    } else {
+        element.classList.remove('visible');
+        element.classList.add('collapse');
+    }
+}
+function switch_li_display(id) {
+    var element = document.getElementById(id);
+    if (element == null) return;
+    if (element.classList.contains('list-item')) {
+        element.classList.remove('list-item');
+        element.classList.add('none');
+    } else {
+        element.classList.remove('none');
+        element.classList.add('list-item');
+    }
+}
+function is_checked(id, checked) {
+    var element = document.getElementById(id);
+    return element == null ? false : element.checked
+}
+function reset_display(id, checked, display) {
+    var element = document.getElementById(id);
+    if (element == null) return;
+    if (checked) {
+        element.style.display = display;
+    } else {
+        element.style.display = 'none';
+    }
+}

--- a/reporters/reporter-default/src/main/resources/html/templates/style.css
+++ b/reporters/reporter-default/src/main/resources/html/templates/style.css
@@ -1,0 +1,87 @@
+.highlight {
+    background-color: #FFBBBB;
+}
+
+.gray {
+    background-color: #F0F0F0;
+}
+
+.firstCellStyle {
+    border-left-color: black;
+    border-left-width: 2px;
+    text-align: right;
+}
+
+.rowStyle {
+    text-align: right;
+}
+
+.collapse {
+    visibility: collapse;
+}
+
+.visible {
+    visibility: visible;
+}
+
+.none {
+    display: none;
+}
+
+.listItem {
+    display: list-item;
+}
+
+.graphTable, .graphTable th, .graphTable td {
+    border: none;
+}
+
+.onClick {
+    cursor: pointer;
+}
+
+.center {
+    text-align: center;
+}
+
+.left {
+    text-align: left;
+}
+
+.difference {
+    background-color: #FFBBBB;
+}
+
+.topLeft {
+    position: absolute;
+    left: 0;
+    top: 0;
+}
+
+.graphDiv {
+    position: relative;
+}
+
+.floatLeft {
+    float: left;
+}
+
+table {
+    border-spacing: 0;
+    border-collapse: collapse;
+    border: 1px solid gray;
+}
+
+td {
+    border: 1px solid gray;
+    padding: 2px;
+}
+
+th {
+    border: 1px solid gray;
+    padding: 2px;
+
+    border-left-color: black;
+    border-left-width: 2px;
+    text-align: center;
+}

--- a/reporters/reporter-default/src/main/resources/html/templates/testReport.ftl
+++ b/reporters/reporter-default/src/main/resources/html/templates/testReport.ftl
@@ -1,0 +1,368 @@
+<html xmlns="http://www.w3.org/1999/html">
+<head>
+    <title>${testReport.getTitle()}</title>
+    <script></script>
+    <link rel="stylesheet" href="style.css">
+    <script src="script.js"></script>
+    <#import "lib/library.ftl" as library />
+</head>
+<body>
+   <h1>Test ${testReport.getTestName()}</h1>
+   <#assign StatisticType=enums["org.radargun.reporting.html.ReportDocument$StatisticType"] />
+
+   <#assign aggregationsList = testReport.getTestAggregations()>
+   <#list  aggregationsList as aggregations>
+      <#list aggregations.results()?keys as aggregationKey>
+         <h2> ${aggregationKey} </h2>
+         <table>
+            <#assign results = aggregations.results()[aggregationKey]/>
+            <#if (testReport.maxIterations > 1)>
+                <tr>
+                   <th colspan="2">&nbsp</th>
+                   <#assign entry = (results?api.entrySet()?first)! />
+                   <#list 0..(testReport.maxIterations -1) as iteration>
+                      <#if entry?has_content>
+                         <#assign testResult = entry.getValue()[iteration]/>
+                         <#assign iterationName = (testResult.getIteration().test.iterationsName)!/>
+                         <#if iterationName?has_content && testResult?has_content>
+                            <#assign iterationValue = (iterationName + "=" + testResult.getIteration().getValue() )/>
+                         <#else>
+                            <#assign iterationValue = ("iteration " + iteration)/>
+                         </#if>
+                      <#else>
+                         <#assign iterationValue = ("iteration " + iteration)/>
+                      </#if>
+                      <th>${iterationValue}</th>
+                   </#list>
+                </tr>
+            </#if>
+            <tr>
+               <th colspan="2">Configuration</th>
+               <#list 0..(testReport.maxIterations - 1) as iteration>
+                  <th>Value</th>
+               </#list>
+            </tr>
+
+            <#list results?keys as report>
+               <#if results?api.get(report)?size == 0>
+                  <#assign nodeCount = 0 />
+               <#else>
+                  <#assign nodeCount = results?api.get(report)?first.slaveResults?size />
+               </#if>
+               <tr>
+                  <th class="onClick" onclick="${library.expandableRows(nodeCount, testReport.elementCounter)}">
+                     ${report.getConfiguration().name}
+                  </th>
+                  <th>
+                     ${report.getCluster()}
+                  </th>
+                  <#list results?api.get(report) as result>
+                     <#assign rowClass = testReport.rowClass(result.suspicious) />
+                     <td class="${rowClass}">
+                        ${result.aggregatedValue}
+                     </td>
+                  </#list>
+               </tr>
+               <#if testReport.configuration.generateNodeStats>
+                  <#list 0 .. (nodeCount - 1) as node>
+                     <tr id="e${testReport.getElementCounter()}" class="collapse">
+                        <th colspan="2"> node${node}</th>
+                        ${testReport.incElementCounter()}
+                        <#list results?api.get(report) as result>
+                           <#assign slaveResult = (result.slaveResults?api.get(node))! />
+                           <#if slaveResult?? && slaveResult.value??>
+                              <#assign rowClass = testReport.rowClass(result.suspicious) />
+                              <td class="${rowClass}">
+                                 ${slaveResult.value}
+                              </td>
+                           <#else >
+                              <td></td>
+                           </#if>
+                        </#list>
+                     </tr>
+                  </#list>
+               </#if>
+            </#list>
+         </table>
+      </#list>
+   </#list>
+
+   <#list testReport.getOperations() as operation>
+   <h2>${operation}</h2>
+      <#if (testReport.getMaxClusters() > 1 && testReport.separateClusterCharts())>
+         <#list testReport.getClusterSizes() as clusterSize>
+            <#if (clusterSize > 0)>
+               <#assign suffix = "_" + clusterSize />
+            <#else>
+               <#assign suffix = "" />
+            </#if>
+         <@graphs operation=operation suffix=suffix/>
+         </#list>
+      <#else>
+         <#assign suffix = "" />
+         <@graphs operation=operation suffix=suffix/>
+      </#if>
+
+      <#assign aggregationsList = testReport.getTestAggregations()>
+      <#assign i = 0 />
+      <#list  aggregationsList as aggregations>
+      <table>
+         <#assign operationData = testReport.getOperationData(operation, aggregations.byReports())>
+         <#assign numberOfColumns = testReport.numberOfColumns(operationData.getPresentedStatistics()) />
+
+         <#if (testReport.getMaxIterations() > 1)>
+            <tr>
+               <th colspan="2">&nbsp</th>
+               <#list operationData.getIterationValues() as iterationValue>
+                  <th colspan=${numberOfColumns}> ${iterationValue}</th>
+               </#list>
+            </tr>
+         </#if>
+
+         <tr>
+            <th colspan="2"> Configuration ${testReport.getSingleTestName(i)}</th>
+            <#assign i = i + 1 />
+            <#list 0 .. (testReport.getMaxIterations() - 1) as i >
+               <th>requests</th>
+               <th>errors</th>
+               <th>mean</th>
+               <th>std.dev</th>
+
+               <#if operationData.getPresentedStatistics()?seq_contains(StatisticType.OPERATION_THROUGHPUT) >
+                  <th>gross operation throughput</th>
+                  <th>net operation throughput</th>
+               </#if>
+               <#if operationData.getPresentedStatistics()?seq_contains(StatisticType.DATA_THROUGHPUT) >
+                  <th colspan="4">data throughput</th>
+               </#if>
+
+               <#if operationData.getPresentedStatistics()?seq_contains(StatisticType.PERCENTILES) >
+                  <#list testReport.configuration.percentiles as percentile>
+                     <th>RTM at ${percentile} %</th>
+                  </#list>
+               </#if>
+
+               <#if operationData.getPresentedStatistics()?seq_contains(StatisticType.HISTOGRAM) >
+                  <th>histograms</th>
+               </#if>
+
+            </#list>
+         </tr>
+
+         <#assign reportAggregationMap = aggregations.byReports() />
+         <#list reportAggregationMap?keys as report>
+
+            <#assign aggregs = reportAggregationMap?api.get(report) />
+            <#assign nodeCount = aggregs?first.nodeStats?size!0 />
+            <#assign expandableRowsCount = testReport.calculateExpandableRows(aggregs, nodeCount) />
+
+            <tr>
+               <th onClick="${library.expandableRows(expandableRowsCount, testReport.elementCounter)}" class="onClick">
+                  ${report.getConfiguration().name}
+               </th>
+               <th>
+                  ${report.getCluster()}
+               </th>
+               <#list aggregs as aggregation>
+                  <@writeRepresentations statistics=aggregation.totalStats report=report aggregation=aggregation
+                  node="total" operation=operation/>
+               </#list>
+            </tr
+
+            <#if testReport.configuration.generateNodeStats>
+               </tr>
+               <#list 0..(nodeCount -1) as node>
+                  <tr id="e${testReport.getElementCounter()}" class="collapse">
+                     <th colspan="2">node${node}</th>
+                     ${testReport.incElementCounter()}
+                     <#list aggregs as aggregation>
+                        <#assign statistics = testReport.getStatistics(aggregation, node)! />
+                        <@writeRepresentations statistics=statistics report=report aggregation=aggregation
+                        node= "node${node}" operation=operation/>
+                     </#list>
+                  </tr>
+                  <#if testReport.configuration.generateThreadStats>
+                     <#assign maxThreads = testReport.getMaxThreads(aggregs, node) />
+                     <#list 0..(maxThreads -1) as thread>
+                        <tr id="e${testReport.getElementCounter()}" class="collapse">
+                           <th colspan="2">thread ${node}_${thread}</th>
+                           ${testReport.incElementCounter()}
+                           <#list aggregs as aggregation >
+                              <#assign threadStats = (testReport.getThreadStatistics(aggregation, node, thread))! />
+                              <@writeRepresentations statistics=threadStats report=report aggregation=aggregation
+                              node="thread${node}_${thread}" operation=operation/>
+                           </#list>
+                        </tr>
+                     </#list>
+                  </#if>
+               </#list>
+            </#if>
+         </#list>
+         </tr>
+      </table>
+      </#list>
+   </#list>
+</body>
+</html>
+
+<#macro graphs operation suffix>
+
+   <table class="graphTable">
+      <#if testReport.getGeneratedCharts()?seq_contains("mean_dev")>
+         <#local img_mean = testReport.generateImageName(operation, suffix, "mean_dev.png")/>
+         <th>
+            Response time mean <br/>
+            <img src="${img_mean}" alt="${operation}">
+         </th>
+      </#if>
+
+      <#if testReport.getGeneratedCharts()?seq_contains("throughput_gross")>
+         <#local img_throughput = testReport.generateImageName(operation, suffix, "throughput_gross.png")/>
+         <th>
+            Gross operation throughput <br/>
+            <img src="${img_throughput}" alt="${operation}">
+         </th>
+      </#if>
+
+      <#if testReport.getGeneratedCharts()?seq_contains("throughput_net")>
+         <#local img_throughput = testReport.generateImageName(operation, suffix, "throughput_net.png")/>
+         <th>
+            Net operation throughput <br/>
+            <img src="${img_throughput}" alt="${operation}">
+         </th>
+      </#if>
+
+      <#if testReport.getGeneratedCharts()?seq_contains("data_throughput")>
+         <#local img_data_throughput = testReport.generateImageName(operation, suffix, "data_throughput.png")/>
+         <th>
+            Data throughput mean <br/>
+            <img src="${img_data_throughput}" alt="${operation}">
+         </th>
+      </#if>
+   </table>
+
+</#macro>
+
+<#macro writeRepresentations statistics report aggregation node operation>
+
+   <#if statistics?has_content>
+      <#local period = testReport.period(statistics)!0 />
+      <#local operationStats = testReport.operationStats(statistics,operation)! />
+   </#if>
+
+   <#if operationStats?has_content>
+      <#local defaultOutcome = operationStats.getRepresentation(testReport.defaultOutcomeClass())! />
+      <#local meanAndDev = operationStats.getRepresentation(testReport.meanAndDevClass())! />
+   </#if>
+
+   <#local rowClass = testReport.rowClass(aggregation.anySuspect(operation)) />
+   <#if defaultOutcome?? && defaultOutcome?has_content>
+      <td class="${rowClass} firstCellStyle">
+         ${defaultOutcome.requests}
+      </td>
+      <td class="${rowClass} rowStyle">
+         ${defaultOutcome.errors}
+      </td>
+   <#else >
+      <td class="${rowClass} firstCellStyle"/>
+      <td class="${rowClass} rowStyle"/>
+   </#if>
+
+   <#if operationData.getPresentedStatistics()?seq_contains(StatisticType.MEAN_AND_DEV)>
+      <#if meanAndDev?has_content>
+         <td class="${rowClass} rowStyle">
+            ${testReport.formatTime(meanAndDev.mean)}
+         </td>
+         <td class="${rowClass} rowStyle">
+            ${testReport.formatTime(meanAndDev.dev)}
+         </td>
+      <#else >
+         <td class="${rowClass} rowStyle"/>
+         <td class="${rowClass} rowStyle"/>
+      </#if>
+   </#if>
+   <#if operationData.getPresentedStatistics()?seq_contains(StatisticType.OPERATION_THROUGHPUT)>
+
+      <#if operationStats?has_content>
+         <#local operationThroughput = operationStats.getRepresentation(testReport.operationThroughputClass(), period)! />
+      </#if>
+
+      <#if operationThroughput?has_content>
+         <td class="${rowClass} rowStyle">
+            ${testReport.formatOperationThroughput(operationThroughput.gross)}
+         </td>
+         <td class="${rowClass} rowStyle">
+            ${testReport.formatOperationThroughput(operationThroughput.net)}
+         </td>
+      <#else >
+         <td class="${rowClass} rowStyle"/>
+         <td class="${rowClass} rowStyle"/>
+      </#if>
+   </#if>
+
+   <#if operationData.getPresentedStatistics()?seq_contains(StatisticType.DATA_THROUGHPUT)>
+      <#if operationStats?has_content>
+         <#local dataThroughput = operationStats.getRepresentation(testReport.dataThroughputClass())! />
+      </#if>
+      <#if dataThroughput?has_content>
+         <td class="${rowClass} rowStyle">
+            ${testReport.formatDataThroughput(dataThroughput.minThroughput)} - min
+         </td>
+         <td class="${rowClass} rowStyle">
+            ${testReport.formatDataThroughput(dataThroughput.maxThroughput)} - max
+         </td>
+         <td class="${rowClass} rowStyle">
+            ${testReport.formatDataThroughput(dataThroughput.meanThroughput)} - mean
+         </td>
+         <td class="${rowClass} rowStyle">
+            ${testReport.formatDataThroughput(dataThroughput.deviation)} - std. dev
+         </td>
+      <#else >
+         <td class="${rowClass} rowStyle"/>
+         <td class="${rowClass} rowStyle"/>
+         <td class="${rowClass} rowStyle"/>
+         <td class="${rowClass} rowStyle"/>
+      </#if>
+   </#if>
+
+   <#if operationData.getPresentedStatistics()?seq_contains(StatisticType.PERCENTILES)>
+      <#list testReport.configuration.percentiles as percentile >
+         <#if operationStats?has_content>
+            <#local p = (operationStats.getRepresentation(testReport.percentileClass(), percentile?double))! />
+         </#if>
+
+         <#if p?has_content>
+            <td class="${rowClass} rowStyle">
+               ${testReport.formatTime(p.responseTimeMax)}
+            </td>
+         <#else >
+            <td class="${rowClass} rowStyle"/>
+         </#if>
+      </#list>
+   </#if>
+
+   <#if operationData.getPresentedStatistics()?seq_contains(StatisticType.HISTOGRAM)>
+      <#if operationStats?has_content>
+         <#local histogram = testReport.getHistogramName(operationStats, operation, report.getConfiguration().name,
+         report.getCluster().getClusterIndex(), aggregation.iteration.id, node, operationData.getPresentedStatistics()) />
+
+         <#local percentileGraph = testReport.getPercentileChartName(operationStats, operation, report.getConfiguration().name,
+         report.getCluster().getClusterIndex(), aggregation.iteration.id, node, operationData.getPresentedStatistics()) />
+
+         <#if histogram?has_content && percentileGraph?has_content>
+            <td class="${rowClass} rowStyle">
+               <a href="${histogram}">histogram</a> <br>
+               <a href="${percentileGraph}">percentiles</a>
+            </td>
+         <#else >
+            <td class="${rowClass} rowStyle">
+               none
+            </td>
+         </#if>
+      <#else>
+         <td class="rowStyle"">
+            none
+         </td>
+      </#if>
+   </#if>
+</#macro>

--- a/reporters/reporter-default/src/main/resources/html/templates/timelineReport.ftl
+++ b/reporters/reporter-default/src/main/resources/html/templates/timelineReport.ftl
@@ -1,0 +1,136 @@
+<html>
+<head>
+    <title>${timelineDocument.getTitle()}</title>
+    <link rel="stylesheet" href="style.css">
+    <script src="script.js"></script>
+</head>
+
+<body>
+   <h1> ${timelineDocument.title} Timeline</h1>
+   <table class="graphTable floatLeft">
+      <#list timelineDocument.getValueCategories()?keys as key>
+         <#assign valueCategory = key />
+         <#assign valueCategoryId = timelineDocument.getValueCategories()[key] />
+
+         <#assign relativeDomainFile = "domain_${timelineDocument.getConfigName()}_relative.png" />
+         <#assign absoluteDomainFile = "domain_${timelineDocument.getConfigName()}_absolute.png" />
+
+         <tr>
+            <th colspan="2"> ${valueCategory} </th>
+         </tr>
+         <#assign rangeFile = timelineDocument.range(valueCategory, valueCategoryId) />
+         <tr>
+            <td>
+               <img src="${rangeFile}">
+            </td>
+            <td>
+               <div class="graphDiv"
+                    style="width: ${timelineDocument.getConfiguration().width}; height: ${timelineDocument.getConfiguration().height}; ">
+                  <#list timelineDocument.getTimelines() as timeline>
+                     <#assign valueChartFile = timelineDocument.getValueChartFile(valueCategoryId, timeline.slaveIndex) />
+                     <img class="topLeft" id="layer_${valueCategoryId}_${timeline.slaveIndex}" src="${valueChartFile}">
+
+                     <#list timeline.getEventCategories() as eventCategory>
+                        <#assign events = timeline.getEvents(eventCategory)!false />
+                        <#if !events?is_boolean>
+                           <#assign eventCategoryId = timelineDocument.getEventCategories()[eventCategory] />
+                           <#assign eventChartFile = timelineDocument.generateEventChartFile(eventCategoryId, timeline.slaveIndex) />
+                           <img class="topLeft"
+                                id="layer_${valueCategoryId}_${timelineDocument.eventCategories[eventCategory]}_${timeline.slaveIndex}"
+                                src="${eventChartFile}">
+                        </#if>
+                     </#list>
+                  </#list>
+               </div>
+            </td>
+          </tr>
+         <tr>
+            <td></td>
+            <td>
+               <img src="${relativeDomainFile}">
+            </td>
+         </tr>
+         <tr>
+            <td> </td>
+            <td>
+               <img src="${absoluteDomainFile}">
+            </td>
+         </tr>
+      </#list>
+   </table>
+
+   <#-- Checkboxes -->
+   <div class="floatLeft">
+      <#list timelineDocument.getEventCategories()?keys as key>
+         <#assign value = timelineDocument.getEventCategories()[key] />
+          <input id="cat_${value}" type="checkbox" checked="checked"
+                 onclick="${resetDisplay(value)}">
+          <strong>${key}</strong>
+          <br/>
+      </#list>
+      <br/><br/>
+      <#assign groups = timelineDocument.getCluster().getGroups() />
+      <#list timelineDocument.getTimelines() as timeline>
+         <span style="background-color: ${timelineDocument.getCheckboxColor(timeline)}">&nbsp</span>
+         <input type="checkbox" checked="checked" id="slave_${timeline.slaveIndex}"
+                onclick="${resetDisplayTimeline(timeline)}">
+         <#if (timeline.slaveIndex >= 0)>
+            <strong>
+               Slave
+               <#if (groups?size > 1)>
+                  ${timeline.slaveIndex} ${timelineDocument.getCluster().getGroup(timeline.slaveIndex).name}
+               <#else>
+                  ${timeline.slaveIndex}
+               </#if>
+            </strong> <br/>
+         <#else>
+            <strong>Master</strong><br>
+         </#if>
+      </#list>
+      <#if (groups?size > 1) >
+         <#list 0..groups as groupID>
+            <span>&nbsp;</span>
+            <input type="checkbox" checked="checked" id="group_${groupID}"
+               onclick="${resetDisplayGroup(groupID, groups)}">
+             <strong>Group ${groups.get(groupId).name} </strong><br>
+         </#list>
+      </#if>
+   </div>
+</body>
+</html>
+
+<#function resetDisplay value >
+   <#local result = "" />
+   <#list timelineDocument.timelines as timeline>
+      <#list timelineDocument.valueCategories?values as valuesId>
+      <#local result = result + (String.format("reset_display('layer_%d_%d_%d', this.checked && is_checked('slave_%d'), 'block');",
+         valuesId, value, timeline.slaveIndex, timeline.slaveIndex)) />
+      </#list>
+   </#list>
+   <#return result/>
+</#function>
+
+<#function resetDisplayTimeline timeline>
+   <#local result = "" />
+   <#list timelineDocument.valueCategories?values as valuesId>
+      <#local result = result + (String.format("reset_display('layer_%d_%d', this.checked, 'block');",
+         valuesId, timeline.slaveIndex)) />
+      <#list timelineDocument.eventCategories?values as eventsId>
+         <#local result = result + (String.format("reset_display('layer_%d_%d_%d', this.checked && is_checked('cat_%d'), 'block');",
+            valuesId, eventsId, timeline.slaveIndex, eventsId)) />
+      </#list>
+   </#list>
+   <#return result/>
+</#function>
+
+<#function resetDisplayGroup groups groupId>
+   <#local result = "" />
+   <#list timelineDocument.cluster.getSlaves(groups?api.get(groupId).name) as slaveIndex>
+      <#list timelineDocument.valueCategories?values as valuesId>
+         <#local result = result + (String.format("document.getElementById('slave_%d').checked = this.checked;", slaveIndex)) />
+         <#local result = result + String.format("reset_display('layer_%d_%d', this.checked, 'block');",
+            valuesId, slaveIndex) />
+      </#list>
+   </#list>
+   <#return result/>
+</#function>

--- a/reporters/reporter-default/src/test/java/HtmlReporterTest.java
+++ b/reporters/reporter-default/src/test/java/HtmlReporterTest.java
@@ -1,0 +1,139 @@
+import org.radargun.Operation;
+import org.radargun.config.Cluster;
+import org.radargun.config.Configuration;
+import org.radargun.reporting.Report;
+import org.radargun.reporting.Timeline;
+import org.radargun.reporting.html.HtmlReporter;
+import org.radargun.stats.DefaultOperationStats;
+import org.radargun.stats.DefaultStatistics;
+import org.radargun.stats.Statistics;
+import org.radargun.utils.Utils;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author Matej Cimbora
+ */
+public class HtmlReporterTest {
+
+   /**
+    * Just a basic test with random values, useful for debugging purposes. Make sure to comment out
+    * 'Utils.deleteDirectory(...)' line when in a need to verify the output manually. By default the content
+    * of temporary directory is cleared after each test run.
+    */
+   @Test
+   public void testHtmlReporter() throws IOException {
+      Path tempDirectory = null;
+      try {
+         HtmlReporter htmlReporter = new HtmlReporter();
+         tempDirectory = Files.createTempDirectory("HtmlReporterTest_testHtmlReporter");
+         Utils.setField(HtmlReporter.class, "targetDir", htmlReporter, tempDirectory.toString());
+
+         Configuration configuration1 = new Configuration("test1");
+         Configuration configuration2 = new Configuration("test2");
+
+         Cluster cluster1 = new Cluster();
+         cluster1.setSize(2);
+
+         Cluster cluster2 = new Cluster();
+         cluster2.setSize(3);
+
+         Timeline timeline1 = new Timeline(0);
+         timeline1.addValue("event1", new Timeline.Value(0, 1));
+         timeline1.addValue("event1", new Timeline.Value(1000, 2));
+         timeline1.addValue("event2", new Timeline.Value(0, 1));
+         timeline1.addValue("event2", new Timeline.Value(1000, 2));
+         Timeline timeline2 = new Timeline(1);
+         timeline2.addValue("event1", new Timeline.Value(0, 1));
+         timeline2.addValue("event1", new Timeline.Value(1000, 2));
+         timeline2.addValue("event2", new Timeline.Value(0, 1));
+         timeline2.addValue("event2", new Timeline.Value(1000, 2));
+         Timeline timeline3 = new Timeline(2);
+         timeline3.addValue("event1", new Timeline.Value(0, 1));
+         timeline3.addValue("event1", new Timeline.Value(1000, 2));
+         timeline3.addValue("event2", new Timeline.Value(0, 1));
+         timeline3.addValue("event2", new Timeline.Value(1000, 2));
+
+
+         Operation operation1 = Operation.register("op1");
+         Operation operation2 = Operation.register("op2");
+         Operation operation3 = Operation.register("op3");
+
+         DefaultStatistics defaultStatistics1 = new DefaultStatistics(new DefaultOperationStats());
+         defaultStatistics1.setBegin(0);
+         defaultStatistics1.registerRequest(10, operation1);
+         defaultStatistics1.registerRequest(20, operation1);
+         defaultStatistics1.registerRequest(30, operation1);
+         defaultStatistics1.registerRequest(100, operation2);
+         defaultStatistics1.registerRequest(200, operation2);
+         defaultStatistics1.registerRequest(300, operation3);
+         defaultStatistics1.registerError(300, operation3);
+         defaultStatistics1.setEnd(1001);
+
+         Report report1 = new Report(configuration1, cluster1);
+         report1.addStage("stage1");
+         report1.addStage("stage2");
+         Report.Test test1 = report1.createTest("test1", "it1", true);
+         Map<Integer, Report.SlaveResult> slaveResults = new HashMap<>();
+         slaveResults.put(0, new Report.SlaveResult("10", false));
+         slaveResults.put(1, new Report.SlaveResult("20", false));
+         test1.addResult(0, new Report.TestResult("test1", slaveResults, "30", false));
+         test1.addStatistics(0, 0, Arrays.asList((Statistics) defaultStatistics1));
+         test1.addStatistics(0, 1, Arrays.asList((Statistics) defaultStatistics1));
+         report1.addTimelines(Arrays.asList(timeline1, timeline2));
+
+         Report report2 = new Report(configuration1, cluster2);
+         report2.addStage("stage1");
+         report2.addStage("stage2");
+         Report.Test test2 = report2.createTest("test1", "it1", true);
+         slaveResults = new HashMap<>();
+         slaveResults.put(0, new Report.SlaveResult("10", false));
+         slaveResults.put(1, new Report.SlaveResult("20", false));
+         slaveResults.put(2, new Report.SlaveResult("30", false));
+         test2.addResult(0, new Report.TestResult("test1", slaveResults, "60", false));
+         test2.addStatistics(0, 0, Arrays.asList((Statistics) defaultStatistics1));
+         test2.addStatistics(0, 1, Arrays.asList((Statistics) defaultStatistics1));
+         test2.addStatistics(0, 2, Arrays.asList((Statistics) defaultStatistics1));
+         report2.addTimelines(Arrays.asList(timeline1, timeline2, timeline3));
+
+         Report report3 = new Report(configuration2, cluster1);
+         report3.addStage("stage1");
+         report3.addStage("stage2");
+         Report.Test test3 = report3.createTest("test1", "it1", true);
+         slaveResults = new HashMap<>();
+         slaveResults.put(0, new Report.SlaveResult("10", false));
+         slaveResults.put(1, new Report.SlaveResult("20", false));
+         test3.addResult(0, new Report.TestResult("test1", slaveResults, "30", false));
+         test3.addStatistics(0, 0, Arrays.asList((Statistics) defaultStatistics1));
+         test3.addStatistics(0, 1, Arrays.asList((Statistics) defaultStatistics1));
+         report3.addTimelines(Arrays.asList(timeline1, timeline2));
+
+         Report report4 = new Report(configuration2, cluster2);
+         report4.addStage("stage1");
+         report4.addStage("stage2");
+         Report.Test test4 = report4.createTest("test1", "it1", true);
+         slaveResults = new HashMap<>();
+         slaveResults.put(0, new Report.SlaveResult("10", false));
+         slaveResults.put(1, new Report.SlaveResult("20", false));
+         slaveResults.put(2, new Report.SlaveResult("30", false));
+         test4.addResult(0, new Report.TestResult("test1", slaveResults, "60", false));
+         test4.addStatistics(0, 0, Arrays.asList((Statistics) defaultStatistics1));
+         test4.addStatistics(0, 1, Arrays.asList((Statistics) defaultStatistics1));
+         test4.addStatistics(0, 2, Arrays.asList((Statistics) defaultStatistics1));
+         report4.addTimelines(Arrays.asList(timeline1, timeline2, timeline3));
+
+         htmlReporter.run(Arrays.asList(report1, report2, report3, report4));
+      } finally {
+         // comment out when debugging
+         Utils.deleteDirectory(tempDirectory.toFile());
+      }
+   }
+
+
+}

--- a/reporters/reporter-default/src/test/java/LineChartTest.java
+++ b/reporters/reporter-default/src/test/java/LineChartTest.java
@@ -1,7 +1,11 @@
+import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Random;
 
 import org.radargun.reporting.html.LineChart;
+import org.radargun.utils.Utils;
 import org.testng.annotations.Test;
 
 /**
@@ -9,7 +13,7 @@ import org.testng.annotations.Test;
  */
 public class LineChartTest {
    @Test
-   public void test() {
+   public void testChartGeneration() {
       LineChart chart = new LineChart("foos", "bars");
       Random random = new Random();
       for (int category = 0; category < 3; category++) {
@@ -20,10 +24,16 @@ public class LineChartTest {
             chart.addValue(lastValue, lastDev, "Serie" + category, i, String.valueOf(Math.pow(2, i)));
          }
       }
+      Path tempDirectory = null;
       try {
-         chart.setHeight(500).setWidth(600).save("/tmp/foobar.png");
+         tempDirectory = Files.createTempDirectory("LineChartTest_testChartGeneration");
+         chart.setHeight(500).setWidth(600).save(new File(tempDirectory.toFile(), "foobar.png").toString());
       } catch (IOException e) {
          e.printStackTrace();
+      } finally {
+         if (tempDirectory != null) {
+            Utils.deleteDirectory(tempDirectory.toFile());
+         }
       }
    }
 

--- a/reporters/reporter-default/src/test/java/TimelineChartsTest.java
+++ b/reporters/reporter-default/src/test/java/TimelineChartsTest.java
@@ -1,8 +1,10 @@
-import java.io.IOException;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.radargun.config.Cluster;
 import org.radargun.reporting.Timeline;
+import org.radargun.reporting.html.HtmlReporter;
 import org.radargun.reporting.html.TimelineDocument;
 import org.radargun.utils.TimeService;
 import org.testng.annotations.Test;
@@ -47,13 +49,14 @@ public class TimelineChartsTest {
 
       Cluster cluster = new Cluster();
       cluster.addGroup("default", 2);
-      TimelineDocument doc = new TimelineDocument(new TimelineDocument.Configuration(), "test", "testconfig", "Test Config", Arrays.asList(t0, t1), cluster);
-      try {
-         doc.open();
-         doc.writeTimelines();
-         doc.close();
-      } catch (IOException e) {
-         e.printStackTrace();
-      }
+      TimelineDocument timelineDocument = new TimelineDocument(new TimelineDocument.Configuration(), "test", "testconfig", "Test Config", Arrays.asList(t0, t1), cluster);
+
+      timelineDocument.createReportDirectory();
+      timelineDocument.createTestCharts();
+
+      Map root = new HashMap();
+      root.put("timelineDocument", timelineDocument);
+
+      HtmlReporter.processTemplate(root, timelineDocument.getDirectory(), timelineDocument.getFileName(), "timelineReport.ftl");
    }
 }


### PR DESCRIPTION
- Backported templating PR for HTML reporter 
- Introduced logical operation groups
-- Defined on stage level
-- Specifies which operations should be treated as a single group (especially in reporting) - ATM only throughput chart will be generated for the group, while avoiding generation of Response time mean charts for partial operations, to avoid problems specified in https://github.com/radargun/radargun/wiki/Understanding-stress-test-results-in-RadarGun-2 - this applies to operations which define ratio of executed operations
- Added simple debugging test for HTMLReporter