### PR TITLE
CacheManager needs to be started after the service has a reference to it

### DIFF
--- a/plugins/infinispan4/src/main/java/org/radargun/service/InfinispanEmbeddedService.java
+++ b/plugins/infinispan4/src/main/java/org/radargun/service/InfinispanEmbeddedService.java
@@ -111,6 +111,7 @@ public class InfinispanEmbeddedService {
       log.tracef("TxControl: %s", TxControl.isEnabled() ? "enabled" : "disabled");
 
       cacheManager = createCacheManager(configFile);
+      cacheManager.start();
       try {
          String cacheNames = cacheManager.getDefinedCacheNames();
          if (!cacheNames.contains(cacheName))
@@ -179,7 +180,6 @@ public class InfinispanEmbeddedService {
    protected DefaultCacheManager createCacheManager(String configFile) throws IOException {
       DefaultCacheManager cm = new DefaultCacheManager(configFile, false);
       beforeCacheManagerStart(cm);
-      cm.start();
       return cm;
    }
 

--- a/plugins/infinispan51/src/main/java/org/radargun/service/Infinispan51EmbeddedService.java
+++ b/plugins/infinispan51/src/main/java/org/radargun/service/Infinispan51EmbeddedService.java
@@ -139,7 +139,6 @@ public class Infinispan51EmbeddedService extends InfinispanEmbeddedService {
       cbh.getGlobalConfigurationBuilder().transport().transport(partitionable.createTransport());
       DefaultCacheManager cm = new DefaultCacheManager(cbh, false);
       beforeCacheManagerStart(cm);
-      cm.start();
       return cm;
    }
 


### PR DESCRIPTION
With the newest infinispan, the listener for the view changes (InfinispanClustered) is called during the cachemanager.start() in Infinispan51EmbeddedService, but fails, because the reference to cacheManager in InfinispanEmbeddedService at line 113 is still null at the time the listener is called.