### PR TITLE
Fix KeyExpirationTestStage with transactions

### DIFF
--- a/core/src/main/java/org/radargun/stages/test/legacy/LegacyStressor.java
+++ b/core/src/main/java/org/radargun/stages/test/legacy/LegacyStressor.java
@@ -221,8 +221,8 @@ public class LegacyStressor extends Thread {
    }
 
    private void clearTransaction() {
-      ongoingTx = null;
       logic.transactionEnded();
+      ongoingTx = null;
    }
 
    public int getThreadIndex() {

--- a/extensions/cache/src/main/java/org/radargun/stages/cache/test/legacy/KeyExpirationTestStage.java
+++ b/extensions/cache/src/main/java/org/radargun/stages/cache/test/legacy/KeyExpirationTestStage.java
@@ -103,7 +103,7 @@ public class KeyExpirationTestStage extends CacheTestStage {
          String cacheName = cacheSelector.getCacheName(stressor.getGlobalThreadIndex());
          nonTxCache = basicOperations.getCache(cacheName);
          if (useTransactions(cacheName)) {
-            cache = new Delegates.BasicOperationsCache();
+            cache = new Delegates.BasicOperationsCache<>();
          } else {
             cache = nonTxCache;
          }
@@ -117,7 +117,7 @@ public class KeyExpirationTestStage extends CacheTestStage {
 
       @Override
       public void transactionEnded() {
-         ((Delegates.BasicOperationsCache) cache).setDelegate(stressor.wrap(null));
+         ((Delegates.BasicOperationsCache) cache).setDelegate(null);
       }
 
       @Override


### PR DESCRIPTION
This fix makes transactionEnded() the same as in
BasicOperationsTestStage. Previous to this change, the stage would not
run on a transactional cache.