### PR TITLE
Fix issue 314

### DIFF
--- a/core/src/main/resources/includes.sh
+++ b/core/src/main/resources/includes.sh
@@ -106,8 +106,8 @@ tail_log() {
 
    tail -f ${1} | while true
    do
-      # Read from stdin with a 10 min timeout
-      IFS= read -r -t 600 -u 0
+      # Read output from pipe with a 10 min timeout
+      IFS= read -r -t 600
       if (($? == 0))
       then
          echo "${REPLY}"
@@ -116,15 +116,12 @@ tail_log() {
              kill -9 `pgrep -P $$ tail`
              break
          fi
-
-      fi
-      # Timeout occurred
-      if (($? > 128))
-      then
+      else
          # Kill tail if no java process spawned from the shell script is found
          if ! pgrep -P $$ java
          then
             kill -9 `pgrep -P $$ tail`
+            break
          fi
       fi
    done

--- a/core/src/main/resources/master.sh
+++ b/core/src/main/resources/master.sh
@@ -185,7 +185,7 @@ echo $RADARGUN_MASTER_PID > master.pid
 if [ $TAILF == "true" ]
 then
   touch ${OUT_FILE}
-  tail_log ${OUT_FILE} "Master process is being shutdown"
+  tail_log ${OUT_FILE} "Master process is being shutdown|All reporters have been executed, exiting|Master process: unexpected shutdown\!"
 fi
 
 if [ $WAIT == "true" ]


### PR DESCRIPTION
Bash read timeouts did not return an exit code greater than 127 on a
timeout. Also added some additional exit strings to master.sh.

https://github.com/radargun/radargun/issues/314