### PR TITLE
Fix issue 314

### DIFF
--- a/core/src/main/resources/includes.sh
+++ b/core/src/main/resources/includes.sh
@@ -102,12 +102,13 @@ tail_log() {
    # Bash log tailer
    # Param 1 - log file
    # Param 2 - String in the log file. When it is found, the tail process is killed
+   # Param 3 - The string in 'ps -ef' to search for. If it doesn't exist, then exit.
    #
 
    tail -f ${1} | while true
    do
       # Read from stdin with a 10 min timeout
-      IFS= read -r -t 600 -u 0
+      IFS= read -r -u 0 -t 600
       if (($? == 0))
       then
          echo "${REPLY}"
@@ -116,15 +117,12 @@ tail_log() {
              kill -9 `pgrep -P $$ tail`
              break
          fi
-
-      fi
-      # Timeout occurred
-      if (($? > 128))
-      then
+      else
          # Kill tail if no java process spawned from the shell script is found
-         if ! pgrep -P $$ java
+         if ! (ps -ef | grep "${3}" &>/dev/null)
          then
             kill -9 `pgrep -P $$ tail`
+            break
          fi
       fi
    done

--- a/core/src/main/resources/master.sh
+++ b/core/src/main/resources/master.sh
@@ -185,7 +185,7 @@ echo $RADARGUN_MASTER_PID > master.pid
 if [ $TAILF == "true" ]
 then
   touch ${OUT_FILE}
-  tail_log ${OUT_FILE} "Master process is being shutdown"
+  tail_log ${OUT_FILE} "Master process is being shutdown|All reporters have been executed, exiting|Master process: unexpected shutdown\!" org.radargun.LaunchMaster
 fi
 
 if [ $WAIT == "true" ]

--- a/core/src/main/resources/slave.sh
+++ b/core/src/main/resources/slave.sh
@@ -176,7 +176,7 @@ echo ""
 if [ $TAILF == "true" ]
 then
   touch ${OUT_FILE}
-  tail_log ${OUT_FILE} "Master shutdown\!|Slave process: unexpected shutdown\!|Communication with master failed"
+  tail_log ${OUT_FILE} "Master shutdown\!|Slave process: unexpected shutdown\!|Communication with master failed" ${LOG4J_PREFIX}
 fi
 
 if [ $WAIT == "true" ]


### PR DESCRIPTION
The previous strategy of checking for processes based on the shell
process was not working, because the new java processes do not have the
expected parent PID. Instead tail_log takes a new argument that is a
search string for the 'ps -ef' command. If the read times out and the
process doesn't exist, then the shell process exits. Also added some
additional exit strings to master.sh.

https://github.com/radargun/radargun/issues/314