### PR TITLE
Issue 373: Investigate new classpath scanner

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -26,7 +26,7 @@
       <dependency>
          <groupId>io.github.lukehutch</groupId>
          <artifactId>fast-classpath-scanner</artifactId>
-         <version>1.91.6</version>
+         <version>1.93.1</version>
       </dependency>
       <dependency>
          <groupId>log4j</groupId>

--- a/core/src/main/java/org/radargun/config/ClasspathScanner.java
+++ b/core/src/main/java/org/radargun/config/ClasspathScanner.java
@@ -4,8 +4,10 @@ import java.lang.annotation.Annotation;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 import io.github.lukehutch.fastclasspathscanner.FastClasspathScanner;
+import io.github.lukehutch.fastclasspathscanner.scanner.ClassInfo;
 import io.github.lukehutch.fastclasspathscanner.scanner.ScanResult;
 
 import org.radargun.logging.Log;
@@ -27,43 +29,50 @@ public final class ClasspathScanner {
     * 
     * Scan the classpath for classes with the specified annotations
     * 
-    * @param superClass restrict the search to annotations that are subclasses of this class, or <code>null</code> to search all classes
-    * @param annotationClass the annotation to find
-    * @param requirePackage restrict the search for the annotation to this package, or <code>null</code> to search all packages
-    * @param consumer a Consumer to process the matching annotion classes
+    * @param superClass
+    *           restrict the search to annotations that are subclasses of this class, or
+    *           <code>null</code> to search all classes
+    * @param annotationClass
+    *           the annotation to find. Required.
+    * @param requirePackage
+    *           restrict the search for the annotation to this package, or <code>null</code> to
+    *           search all packages
+    * @param consumer
+    *           a Consumer to process the matching annotion classes
     */
    public static <TClass, TAnnotation extends Annotation> void scanClasspath(Class<TClass> superClass,
                                                                              Class<TAnnotation> annotationClass,
                                                                              String requirePackage,
                                                                              Consumer<Class<? extends TClass>> consumer) {
 
+      if (annotationClass == null) {
+         throw new IllegalArgumentException("An annotation class must be specified");
+      }
       FastClasspathScanner fcs;
       if (requirePackage != null) {
-         fcs = new FastClasspathScanner(requirePackage);
+         fcs = new FastClasspathScanner("!", requirePackage);
       } else {
-         fcs = new FastClasspathScanner();
+         fcs = new FastClasspathScanner("!");
       }
 
       ScanResult scanResults = fcs.scan();
 
-      List<String> assignableFrom = Collections.EMPTY_LIST;
+      List<String> matches = Collections.EMPTY_LIST;
       if (superClass != null) {
-         if (superClass.isInterface()) {
-            assignableFrom = scanResults.getNamesOfClassesImplementing(superClass.getName());
-         } else {
-            assignableFrom = scanResults.getNamesOfSubclassesOf(superClass.getName());
-         }
-      }
-
-      List<String> matches = scanResults.getNamesOfClassesWithAnnotation(annotationClass.getName());
-      if (superClass != null) {
-         matches.retainAll(assignableFrom);
+         matches = scanResults.getClassNameToClassInfo().values().stream()
+               .filter(ci -> ci.hasSuperclass(superClass.getName()) || ci.implementsInterface(superClass.getName()))
+               .filter(ci -> ci.hasAnnotation(annotationClass.getName())).map(ClassInfo::getClassName)
+               .collect(Collectors.toList());
          log.debug("Found " + matches.size() + " classes with annotation '" + annotationClass.getName()
                + "' and super class '" + superClass.getName() + "'");
       } else {
+         matches = scanResults.getClassNameToClassInfo().values().stream()
+               .filter(ci -> ci.hasAnnotation(annotationClass.getName())).map(ClassInfo::getClassName)
+               .collect(Collectors.toList());
          log.debug("Found " + matches.size() + " classes with annotation '" + annotationClass.getName() + "'");
       }
 
+      // Only load matched classes to avoid any spourious exceptions thrown from static blocks
       for (String className : matches) {
          Class<?> clazz;
          try {


### PR DESCRIPTION
Reimplement ClasspathScanner.scanClasspath using
https://github.com/lukehutch/fast-classpath-scanner

Add a debug log message to ClasspathScanner
Passing null as the superclass to ClasspathScanner.scanClasspath() means
to search for classes with the annotation without regard to the
superclass
Added JavaDoc and removed @author tag
Updated to newest FCS streaming API