### PR TITLE
Include git information in the distribution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -736,6 +736,26 @@
                </dependency>
             </dependencies>
          </plugin>
+          <plugin>
+              <groupId>pl.project13.maven</groupId>
+              <artifactId>git-commit-id-plugin</artifactId>
+              <version>2.2.1</version>
+              <executions>
+                  <execution>
+                      <id>get-the-git-infos</id>
+                      <goals>
+                          <goal>revision</goal>
+                      </goals>
+                      <phase>install</phase>
+                  </execution>
+              </executions>
+              <configuration>
+                  <generateGitPropertiesFile>true</generateGitPropertiesFile>
+                  <generateGitPropertiesFilename>${distribution.artifact}/bin/git.properties</generateGitPropertiesFilename>
+                  <skipPoms>false</skipPoms>
+                  <failOnUnableToExtractRepoInfo>false</failOnUnableToExtractRepoInfo>
+              </configuration>
+          </plugin>
       </plugins>
    </build>
 </project>


### PR DESCRIPTION
I sometimes run into a situation where I don't know how I built a particular RG distro (what version? what branch?). This adds a git.properties file in the distribution/bin folder, containing such information.