### PR TITLE
Issue 394

### DIFF
--- a/reporters/reporter-default/src/main/java/org/radargun/reporting/html/ReportDocument.java
+++ b/reporters/reporter-default/src/main/java/org/radargun/reporting/html/ReportDocument.java
@@ -65,7 +65,7 @@ public abstract class ReportDocument extends HtmlDocument {
    public void createHistogramAndPercentileChart(Statistics statistics, final String operation, final String configurationName, int cluster, int iteration,
                                                    String node, Collection<StatisticType> presentedStatistics) {
 
-      if (!presentedStatistics.contains(StatisticType.HISTOGRAM)) {
+      if (statistics == null || !presentedStatistics.contains(StatisticType.HISTOGRAM)) {
          return;
       }
       final Histogram histogram = statistics.getRepresentation(operation, Histogram.class, configuration.histogramBuckets, configuration.histogramPercentile);

--- a/reporters/reporter-default/src/main/resources/html/templates/testReport.ftl
+++ b/reporters/reporter-default/src/main/resources/html/templates/testReport.ftl
@@ -328,6 +328,10 @@
 
 <#macro writeRepresentations statistics report aggregation node operation>
 
+   <#if !statistics?has_content>
+      <#return>
+   </#if>
+
    <#if statistics?has_content>
       <#local period = testReport.period(statistics)!0 />
    </#if>


### PR DESCRIPTION
Depends on https://github.com/radargun/radargun/pull/398 .
Fixes the 2nd exception mentioned in the issue.
The problem was that this commit https://github.com/radargun/radargun/commit/e7d330a95e5e6a92eca16f79b5c080d2c257e17b removed the null check on statistics in ReportDocument - it is needed for tests where some nodes don't produce any statistics, like client/server.