### PR TITLE
Issue #405 Do not fail the build if .git is not present

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -753,6 +753,7 @@
                   <generateGitPropertiesFile>true</generateGitPropertiesFile>
                   <generateGitPropertiesFilename>${distribution.artifact}/bin/git.properties</generateGitPropertiesFilename>
                   <skipPoms>false</skipPoms>
+                  <failOnNoGitDirectory>false</failOnNoGitDirectory>
                   <failOnUnableToExtractRepoInfo>false</failOnUnableToExtractRepoInfo>
               </configuration>
           </plugin>


### PR DESCRIPTION
Fixes https://github.com/radargun/radargun/issues/405