### PR TITLE
Fix LegacyStressor statistics recording at the end of the test

### DIFF
--- a/core/src/main/java/org/radargun/stages/test/legacy/LegacyStressor.java
+++ b/core/src/main/java/org/radargun/stages/test/legacy/LegacyStressor.java
@@ -213,7 +213,7 @@ public class LegacyStressor extends Thread {
             log.error("Failed to end transaction", e);
          }
       } finally {
-         if (requests != null) {
+         if (requests != null && commitRequest != null) {
             requests.add(commitRequest);
             if (recording()) {
                requests.finished(commitRequest.isSuccessful(), Transactional.DURATION);

--- a/core/src/main/java/org/radargun/stats/Request.java
+++ b/core/src/main/java/org/radargun/stats/Request.java
@@ -20,6 +20,7 @@ public final class Request {
 //   private long responseStartedTime;
    private long responseCompleteTime = Long.MIN_VALUE;
    private boolean successful = true;
+   private boolean discarded = false;
 
    public Request(Statistics statistics) {
       this.statistics = statistics;
@@ -84,6 +85,7 @@ public final class Request {
    }
 
    public void discard() {
+      this.discarded = true;
       statistics.discard(this);
    }
 
@@ -92,7 +94,7 @@ public final class Request {
    }
 
    public boolean isFinished() {
-      return responseCompleteTime > Long.MIN_VALUE;
+      return discarded || responseCompleteTime > Long.MIN_VALUE;
    }
 
    public long getRequestStartTime() {


### PR DESCRIPTION
RequestSet can throw this exception
```07:32:25,296 ERROR [org.radargun.stages.test.legacy.LegacyStressor] (Stressor-19) Unexpected error in stressor!
    java.lang.IllegalArgumentException
    at org.radargun.stats.RequestSet.add(RequestSet.java:21) ~[radargun-core-3.0.0-SNAPSHOT.jar:?]```
during the end of the test, when a Request is discarded (because the test already ended) and thus not finished, but still passed to RequestSet which excepts only finished Requests.
I don't really like the fix, but a nicer one would probably require some refactoring in LegacyStressor, which I'm not eager to do.