### PR TITLE
Issue 425 - Check that group is configured when stage doesn't execute

### DIFF
--- a/core/src/main/java/org/radargun/config/Cluster.java
+++ b/core/src/main/java/org/radargun/config/Cluster.java
@@ -77,6 +77,17 @@ public class Cluster implements Serializable, Comparable<Cluster> {
       }
       throw new IllegalStateException("Slave index is " + slaveIndex + ", cluster is " + toString());
    }
+   
+   public boolean groupExists(String groupName) {
+      boolean result = false;
+      for (Group group : groups) {
+         if (group.name.equals(groupName)) {
+            result = true;
+            break;
+         }
+      }
+      return result;
+   }
 
    public int getClusterIndex() {
       return index;

--- a/core/src/main/java/org/radargun/stages/AbstractDistStage.java
+++ b/core/src/main/java/org/radargun/stages/AbstractDistStage.java
@@ -67,6 +67,19 @@ public abstract class AbstractDistStage extends AbstractStage implements DistSta
       boolean execBySlave = slaves == null || slaves.contains(slaveState.getSlaveIndex());
       boolean execByGroup = groups == null || groups.contains(slaveState.getGroupName());
       boolean execByRole = roles == null || RoleHelper.hasAnyRole(slaveState, roles);
+      //Issue 425
+      if (groups != null) {
+         StateBase state = masterState != null ? masterState : slaveState;
+         if (state.getCluster() == null) {
+            throw new IllegalStateException(String.format("Cluster has not been set in %s yet.", state));
+         }
+         for (String groupName : groups) {
+            if (!state.getCluster().groupExists(groupName)) {
+               throw new IllegalStateException(
+                     String.format("Group '%s' does not exist in benchmark configuration.", groupName));
+            }
+         }
+      }
       return execBySlave && execByGroup && execByRole;
    }
 


### PR DESCRIPTION
Check that the group(s) configured on the stage have been configured in
the benchmark. If not, then fail the stage with an error.