### PR TITLE
Add operation count based functionality to benchmarks

### DIFF
--- a/core/src/main/java/org/radargun/stages/test/BaseTestStage.java
+++ b/core/src/main/java/org/radargun/stages/test/BaseTestStage.java
@@ -25,8 +25,11 @@ public abstract class BaseTestStage extends AbstractDistStage {
       "results are amended to existing test (as iterations). Default is false.")
    public boolean amendTest = false;
 
-   @Property(converter = TimeConverter.class, doc = "Benchmark duration.", optional = false)
-   public long duration;
+   @Property(converter = TimeConverter.class, doc = "Benchmark duration. You have to set either this or 'totalNumOperations'.")
+   public long duration = 0;
+
+   @Property(doc = "The total number of operations to perform during the test. You have to set either this or 'duration'.")
+   public long numOperations = 0;
 
    @Property(name = "statistics", doc = "Type of gathered statistics. Default are the 'default' statistics " +
       "(fixed size memory footprint for each operation).", complexConverter = Statistics.Converter.class)
@@ -46,8 +49,14 @@ public abstract class BaseTestStage extends AbstractDistStage {
 
    @Init
    public void check() {
-      if (duration <= 0) {
+      if ((duration > 0 && numOperations > 0) || (duration == 0 && numOperations == 0)) {
+         throw new IllegalArgumentException("Set either the test duration or totalNumOperations.");
+      }
+      if (duration < 0) {
          throw new IllegalArgumentException("Test duration must be positive.");
+      }
+      if (numOperations < 0) {
+         throw new IllegalArgumentException("Test totalNumOperations must be positive. " + numOperations);
       }
    }
 

--- a/core/src/main/java/org/radargun/stages/test/legacy/AbstractCompletion.java
+++ b/core/src/main/java/org/radargun/stages/test/legacy/AbstractCompletion.java
@@ -8,7 +8,6 @@ import org.radargun.utils.TimeService;
  * @author Radim Vansa &lt;rvansa@redhat.com&gt;
  */
 public abstract class AbstractCompletion implements Completion {
-   protected static final String PROGRESS_STRING = "Number of operations executed by this thread: %d. Elapsed time: %s. Remaining: %s. Total: %s.";
    protected static final Log log = LogFactory.getLog(Completion.class);
 
    protected boolean started, completed;

--- a/core/src/main/java/org/radargun/stages/test/legacy/CountStressorCompletion.java
+++ b/core/src/main/java/org/radargun/stages/test/legacy/CountStressorCompletion.java
@@ -1,0 +1,50 @@
+package org.radargun.stages.test.legacy;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.radargun.utils.TimeService;
+import org.radargun.utils.Utils;
+
+/**
+ * Operation count-based limitation of the stress test.
+ *
+ * @author Alan Field &lt;afield@redhat.com&gt;
+ */
+public class CountStressorCompletion extends AbstractCompletion {
+
+   protected static final String PROGRESS_STRING = "Number of operations executed by this thread: %d. Elapsed time: %s. Operations Remaining: %s. Total Operations: %s.";
+   private volatile long lastPrint = -1;
+   private final long operationsPerNode;
+   private final long logFrequency = TimeUnit.SECONDS.toNanos(20);
+   private final AtomicLong operationCount = new AtomicLong(0);
+
+   public CountStressorCompletion(long opCount) {
+      this.operationsPerNode = opCount;
+   }
+
+   @Override
+   public boolean moreToRun() {
+      boolean moreToRun = operationCount.incrementAndGet() <= operationsPerNode;
+      if (!moreToRun) {
+         runCompletionHandler();
+      }
+      return moreToRun;
+   }
+
+   @Override
+   public void logProgress(int executedOps) {
+      long now = TimeService.nanoTime();
+      //make sure this info is not printed more frequently than 20 secs
+      if (lastPrint < 0 || (now - lastPrint) < logFrequency) {
+         return;
+      }
+      synchronized (this) {
+         if (now - lastPrint < logFrequency)
+            return;
+         lastPrint = now;
+         log.infof(PROGRESS_STRING, executedOps, Utils.getNanosDurationString(now - startTime),
+               operationCount.toString(), operationsPerNode);
+      }
+   }
+}

--- a/core/src/main/java/org/radargun/stages/test/legacy/LegacyTestStage.java
+++ b/core/src/main/java/org/radargun/stages/test/legacy/LegacyTestStage.java
@@ -151,7 +151,10 @@ public abstract class LegacyTestStage extends BaseTestStage {
       completion.setCompletionHandler(new Runnable() {
          @Override
          public void run() {
-            finished = true;
+            //Stop collecting statistics for duration-based tests
+            if (duration > 0) {
+               finished = true;
+            }
             finishCountDown.countDown();
          }
       });
@@ -201,6 +204,14 @@ public abstract class LegacyTestStage extends BaseTestStage {
 
    protected Completion createCompletion() {
       Completion completion = new TimeStressorCompletion(duration);
+      if (numOperations > 0) {
+         long countPerNode = numOperations / getExecutingSlaves().size();
+         long modCountPerNode = numOperations % getExecutingSlaves().size();
+         if (this.getExecutingSlaveIndex() + 1 <= modCountPerNode) {
+            countPerNode++;
+         }
+         completion = new CountStressorCompletion(countPerNode);
+      }
       return completion;
    }
 

--- a/core/src/main/java/org/radargun/stages/test/legacy/TimeStressorCompletion.java
+++ b/core/src/main/java/org/radargun/stages/test/legacy/TimeStressorCompletion.java
@@ -12,6 +12,7 @@ import org.radargun.utils.Utils;
  */
 public class TimeStressorCompletion extends AbstractCompletion {
 
+   protected static final String PROGRESS_STRING = "Number of operations executed by this thread: %d. Elapsed time: %s. Remaining: %s. Total: %s.";
    private volatile long lastPrint = -1;
    private final long duration;
    private final long logFrequency = TimeUnit.SECONDS.toNanos(20);


### PR DESCRIPTION
This PR adds the ability to execute a specific number of operations
during a benchmark.
