### PR TITLE
Testsuite fix

### DIFF
--- a/core/src/test/java/org/radargun/config/AbstractConfigurationTest.java
+++ b/core/src/test/java/org/radargun/config/AbstractConfigurationTest.java
@@ -31,16 +31,17 @@ import static org.testng.Assert.*;
  *
  * @author Roman Macor &lt;rmacor@redhat.com&gt;
  */
-@Test
 @PowerMockIgnore({"javax.management.*"})
 @PrepareForTest(Utils.class)
 @SuppressStaticInitializationFor({"org.radargun.Directories"})
-public abstract class AbstractConfigurationTest extends PowerMockTestCase {
+public class AbstractConfigurationTest extends PowerMockTestCase {
    protected static Log log = LogFactory.getLog(AbstractConfigurationTest.class);
    protected MasterConfig masterConfig;
    protected List<String> resources = new ArrayList<>();
 
-   protected abstract String getBenchmark();
+   protected String getBenchmark() {
+      return null;
+   }
 
    /**
     * Copies resources to the testing directory (such as benchmark file or scenario file)

--- a/core/src/test/java/org/radargun/config/ConfigurationWithImportedScenarioFromAnotherBenchmarkTest.java
+++ b/core/src/test/java/org/radargun/config/ConfigurationWithImportedScenarioFromAnotherBenchmarkTest.java
@@ -1,10 +1,13 @@
 package org.radargun.config;
 
+import org.testng.annotations.Test;
+
 /**
  * Variation of AbstractConfigurationTest when scenario is imported from another benchmark file
  *
  * @author Roman Macor &lt;rmacor@redhat.com&gt;
  */
+@Test
 public class ConfigurationWithImportedScenarioFromAnotherBenchmarkTest extends AbstractConfigurationTest {
    public ConfigurationWithImportedScenarioFromAnotherBenchmarkTest() {
       resources.add("benchmark-test.xml");
@@ -13,5 +16,35 @@ public class ConfigurationWithImportedScenarioFromAnotherBenchmarkTest extends A
    @Override
    protected String getBenchmark() {
       return "benchmark-importedScenarioFromAnotherBenchmark.xml";
+   }
+   
+   @Override //TODO remove once #431 is done
+   public void testClusters() {
+      super.testClusters();
+   }
+   
+   @Override //TODO remove once #431 is done
+   public void testConfiguration() {
+      super.testConfiguration();
+   }
+   
+   @Override //TODO remove once #431 is done
+   public void testHost() {
+      super.testHost();
+   }
+   
+   @Override //TODO remove once #431 is done
+   public void testPlugins() {
+      super.testPlugins();
+   }
+   
+   @Override //TODO remove once #431 is done
+   public void testReport() {
+      super.testReport();
+   }
+   
+   @Override //TODO remove once #431 is done
+   public void testScenario() {
+      super.testScenario();
    }
 }

--- a/core/src/test/java/org/radargun/config/ConfigurationWithImportedScenarioFromDesignatedScenarioFileTest.java
+++ b/core/src/test/java/org/radargun/config/ConfigurationWithImportedScenarioFromDesignatedScenarioFileTest.java
@@ -15,4 +15,34 @@ public class ConfigurationWithImportedScenarioFromDesignatedScenarioFileTest ext
    protected String getBenchmark() {
       return "benchmark-importedScenarioFromDesignatedScenarioFile.xml";
    }
+   
+   @Override //TODO remove once #431 is done
+   public void testClusters() {
+      super.testClusters();
+   }
+   
+   @Override //TODO remove once #431 is done
+   public void testConfiguration() {
+      super.testConfiguration();
+   }
+   
+   @Override //TODO remove once #431 is done
+   public void testHost() {
+      super.testHost();
+   }
+   
+   @Override //TODO remove once #431 is done
+   public void testPlugins() {
+      super.testPlugins();
+   }
+   
+   @Override //TODO remove once #431 is done
+   public void testReport() {
+      super.testReport();
+   }
+   
+   @Override //TODO remove once #431 is done
+   public void testScenario() {
+      super.testScenario();
+   }
 }

--- a/core/src/test/java/org/radargun/config/ConfigurationWithScenarioInFileTest.java
+++ b/core/src/test/java/org/radargun/config/ConfigurationWithScenarioInFileTest.java
@@ -11,4 +11,34 @@ public class ConfigurationWithScenarioInFileTest extends AbstractConfigurationTe
    protected String getBenchmark() {
       return "benchmark-test.xml";
    }
+   
+   @Override //TODO remove once #431 is done
+   public void testClusters() {
+      super.testClusters();
+   }
+   
+   @Override //TODO remove once #431 is done
+   public void testConfiguration() {
+      super.testConfiguration();
+   }
+   
+   @Override //TODO remove once #431 is done
+   public void testHost() {
+      super.testHost();
+   }
+   
+   @Override //TODO remove once #431 is done
+   public void testPlugins() {
+      super.testPlugins();
+   }
+   
+   @Override //TODO remove once #431 is done
+   public void testReport() {
+      super.testReport();
+   }
+   
+   @Override //TODO remove once #431 is done
+   public void testScenario() {
+      super.testScenario();
+   }
 }

--- a/core/src/test/java/org/radargun/config/ConfigurationWithURLImportedScenarioTest.java
+++ b/core/src/test/java/org/radargun/config/ConfigurationWithURLImportedScenarioTest.java
@@ -11,4 +11,34 @@ public class ConfigurationWithURLImportedScenarioTest extends AbstractConfigurat
    protected String getBenchmark() {
       return "benchmark-importedScenarioFromURL.xml";
    }
+   
+   @Override //TODO remove once #431 is done
+   public void testClusters() {
+      super.testClusters();
+   }
+   
+   @Override //TODO remove once #431 is done
+   public void testConfiguration() {
+      super.testConfiguration();
+   }
+   
+   @Override //TODO remove once #431 is done
+   public void testHost() {
+      super.testHost();
+   }
+   
+   @Override //TODO remove once #431 is done
+   public void testPlugins() {
+      super.testPlugins();
+   }
+   
+   @Override //TODO remove once #431 is done
+   public void testReport() {
+      super.testReport();
+   }
+   
+   @Override //TODO remove once #431 is done
+   public void testScenario() {
+      super.testScenario();
+   }
 }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -101,6 +101,11 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <version>2.19.1</version>
+            <configuration>
+            	<parallel>tests</parallel>
+            	<forkCount>1</forkCount>
+            	<reuseForks>true</reuseForks>
+            </configuration>
          </plugin>
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
* runs tests sequentially as when run in parallel they clash
* PowerMock doesn't work with abstract classes - convert `AbstractConfigurationTest` to normal class, however without `@Test` annotation so that it's not run by TestNG. Nicer solution can be done once switched to jUnit, which doesn't require test class to inherit from `PowerMockTestCase`