### PR TITLE
Avoid division by zero

### DIFF
--- a/extensions/cache/src/main/java/org/radargun/stages/cache/test/legacy/ConcurrentKeysSelector.java
+++ b/extensions/cache/src/main/java/org/radargun/stages/cache/test/legacy/ConcurrentKeysSelector.java
@@ -50,6 +50,9 @@ public class ConcurrentKeysSelector implements KeySelector {
          if (numEntriesPerThread > 0) {
             return new ConcurrentKeysSelector(random, numEntriesPerThread * globalThreadId, numEntriesPerThread);
          } else if (totalEntries > 0) {
+            if (totalEntries < totalThreads) {
+               throw new IllegalStateException("Number of total threads cannot be greater than number of total entries.");
+            }
             long offset = totalEntries * globalThreadId / totalThreads;
             long end = totalEntries * (globalThreadId + 1) / totalThreads;
             return new ConcurrentKeysSelector(random, offset, end - offset);


### PR DESCRIPTION
if number of entries is lower than number of threads, it fails with
```
java.lang.ArithmeticException: / by zero
	at org.radargun.stages.cache.test.legacy.ConcurrentKeysSelector.next(ConcurrentKeysSelector.java:27) ~[radargun-cache-3.0.0-SNAPSHOT.jar:?]
	at org.radargun.stages.cache.test.legacy.BasicOperationsTestStage$Logic.run(BasicOperationsTestStage.java:94) ~[radargun-cache-3.0.0-SNAPSHOT.jar:?]
```