### PR TITLE
Add REST stages that run in background

### DIFF
--- a/core/src/main/java/org/radargun/stages/test/BaseTestStage.java
+++ b/core/src/main/java/org/radargun/stages/test/BaseTestStage.java
@@ -61,6 +61,10 @@ public abstract class BaseTestStage extends AbstractDistStage {
    }
 
    protected Report.Test getTest(boolean allowExisting) {
+      return getTest(allowExisting, testName);
+   }
+
+   protected Report.Test getTest(boolean allowExisting, String testName) {
       if (testName == null || testName.isEmpty()) {
          log.warn("No test name - results are not recorded");
          return null;

--- a/core/src/main/java/org/radargun/stages/test/legacy/StressorsManager.java
+++ b/core/src/main/java/org/radargun/stages/test/legacy/StressorsManager.java
@@ -1,0 +1,36 @@
+package org.radargun.stages.test.legacy;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+
+/**
+ * A class that holds additional information about stressors and makes is possible to
+ * pass stressors together with this information between stages. An arbitrary stage can wait
+ * for the stressors to finish and track their execution time.
+ *
+ * @author Martin Gencur
+ */
+public class StressorsManager {
+
+   private CountDownLatch finishCountDown;
+   private long startTime;
+   private List<LegacyStressor> stressors;
+
+   public StressorsManager(List<LegacyStressor> stressors, long startTime, CountDownLatch finishCountDown) {
+      this.stressors = stressors;
+      this.startTime = startTime;
+      this.finishCountDown = finishCountDown;
+   }
+
+   public long getStartTime() {
+      return startTime;
+   }
+
+   public List<LegacyStressor> getStressors() {
+      return stressors;
+   }
+
+   public CountDownLatch getFinishCountDown() {
+      return finishCountDown;
+   }
+}

--- a/core/src/main/java/org/radargun/stages/test/legacy/TimeStressorCompletion.java
+++ b/core/src/main/java/org/radargun/stages/test/legacy/TimeStressorCompletion.java
@@ -18,7 +18,7 @@ public class TimeStressorCompletion extends AbstractCompletion {
    private final long logFrequency = TimeUnit.SECONDS.toNanos(20);
 
    /**
-    * @param duration Duration of the test in nanoseconds.
+    * @param duration Duration of the test in nanoseconds. When duration is 0 the test will run indefinitely.
     */
    public TimeStressorCompletion(long duration) {
       this.duration = TimeUnit.MILLISECONDS.toNanos(duration);
@@ -26,7 +26,7 @@ public class TimeStressorCompletion extends AbstractCompletion {
 
    @Override
    public boolean moreToRun() {
-      boolean moreToRun = TimeService.nanoTime() < startTime + duration;
+      boolean moreToRun = duration == 0 ? true : TimeService.nanoTime() < startTime + duration;
       if (!moreToRun) {
          runCompletionHandler();
       }

--- a/extensions/rest/src/main/java/org/radargun/stages/BackgroundRESTOperationsStartStage.java
+++ b/extensions/rest/src/main/java/org/radargun/stages/BackgroundRESTOperationsStartStage.java
@@ -1,0 +1,76 @@
+package org.radargun.stages;
+
+import java.util.List;
+import org.radargun.DistStageAck;
+import org.radargun.StageResult;
+import org.radargun.config.Namespace;
+import org.radargun.config.Stage;
+import org.radargun.stages.test.legacy.Completion;
+import org.radargun.stages.test.legacy.LegacyTestStage;
+import org.radargun.stages.test.legacy.TimeStressorCompletion;
+
+/**
+ * A stage for REST operations running in background.
+ *
+ * @author Martin Gencur
+ */
+@Namespace(LegacyTestStage.NAMESPACE)
+@Stage(doc = "Stage for starting REST operations in the background")
+public class BackgroundRESTOperationsStartStage extends RESTOperationsTestStage {
+
+   //Override Init method from BaseTestStage in order to handle duration specifically
+   @Override
+   public void check() {
+      if (duration > 0 || duration < 0) {
+         duration = 0;
+         log.warn("Parameter duration ignored in background stage. Stage will run indefinitely until " +
+            "it is manually stopped from " + BackgroundRESTOperationsStopStage.class.getSimpleName());
+      }
+      if (numOperations > 0) {
+         numOperations = 0;
+         log.warn("Parameter numOperations ignored in background stage.");
+      }
+      if (timeout > 0 || timeout < 0) {
+         timeout = 0;
+         log.warn("Parameter timeout ignored in background stage.");
+      }
+   }
+
+   @Override
+   protected Completion createCompletion() {
+      return new TimeStressorCompletion(duration);
+   }
+
+   @Override
+   public DistStageAck executeOnSlave() {
+      if (!isServiceRunning()) {
+         log.info("Not running test on this slave as service is not running.");
+         return successfulResponse();
+      }
+      try {
+         log.info("Starting test " + testName + " in the background.");
+         stressorsManager = setUpAndStartStressors();
+         slaveState.put(testName, this);
+         return successfulResponse();
+      } catch (Exception e) {
+         return errorResponse("Exception while initializing the test", e);
+      }
+   }
+
+   @Override
+   public StageResult processAckOnMaster(List<DistStageAck> acks) {
+      StageResult result = StageResult.SUCCESS;
+      logDurationInfo(acks);
+      for (DistStageAck ack : acks) {
+         if (ack.isError()) {
+            log.warn("Received error ack " + ack);
+            result = errorResult();
+         } else {
+            if (log.isTraceEnabled()) {
+               log.trace("Received success ack " + ack);
+            }
+         }
+      }
+      return result;
+   }
+}

--- a/extensions/rest/src/main/java/org/radargun/stages/BackgroundRESTOperationsStopStage.java
+++ b/extensions/rest/src/main/java/org/radargun/stages/BackgroundRESTOperationsStopStage.java
@@ -1,0 +1,73 @@
+package org.radargun.stages;
+
+import java.util.List;
+import org.radargun.DistStageAck;
+import org.radargun.StageResult;
+import org.radargun.config.Namespace;
+import org.radargun.config.Property;
+import org.radargun.config.Stage;
+import org.radargun.stages.test.legacy.LegacyTestStage;
+import org.radargun.utils.TimeService;
+import org.radargun.utils.Utils;
+
+/**
+ * A test stage for stopping REST operations background stage.
+ *
+ * @author Martin Gencur
+ */
+@Namespace(LegacyTestStage.NAMESPACE)
+@Stage(doc = "Stage for stopping REST operations running in the background")
+public class BackgroundRESTOperationsStopStage extends RESTOperationsTestStage {
+
+   @Property(doc = "Name of the background operations to be stopped. Default is 'Test'.")
+   protected String testNameToStop = "Test";
+
+   @Override
+   public void check() {
+      if (duration > 0 || duration < 0) {
+         duration = 0;
+         log.warn("Parameter duration ignored in background stage.");
+      }
+      if (numOperations > 0) {
+         numOperations = 0;
+         log.warn("Parameter numOperations ignored in background stage.");
+      }
+      if (timeout > 0 || timeout < 0) {
+         timeout = 0;
+         log.warn("Parameter timeout ignored in background stage.");
+      }
+   }
+
+   @Override
+   public void init() {
+      //do not check any parameters
+   }
+
+   @Override
+   public DistStageAck executeOnSlave() {
+      if (!isServiceRunning()) {
+         log.info("Not running test on this slave as service is not running.");
+         return successfulResponse();
+      }
+      try {
+         BackgroundRESTOperationsStartStage startedStage = (BackgroundRESTOperationsStartStage) slaveState.get(testNameToStop);
+         if (startedStage == null) {
+            throw new RuntimeException("Unable to find the test in slaveState: " + testNameToStop);
+         }
+         log.info("Stopping test " + startedStage.testName + " running in the background.");
+
+         startedStage.setTerminated();
+
+         waitForStressorsToFinish(startedStage.getStressorsManager());
+         log.info("Finished test. Test duration is: " + Utils.getMillisDurationString(TimeService.currentTimeMillis() - startedStage.getStressorsManager().getStartTime()));
+         return newStatisticsAck(startedStage.getStressorsManager().getStressors());
+      } catch (Exception e) {
+         return errorResponse("Exception while initializing the test", e);
+      }
+   }
+
+   @Override
+   public StageResult processAckOnMaster(List<DistStageAck> acks) {
+      return processAckOnMaster(acks, testNameToStop);
+   }
+}


### PR DESCRIPTION
* useful for resilience tests where we need to kill some servers from stages running in foreground

Example benchmark looks like this: https://gist.github.com/mgencur/45dcd4af4d0a9dc5046676fab092c000
