### PR TITLE
gh-371 RadarGun reports should include server configuration file 

### DIFF
--- a/core/src/main/java/org/radargun/utils/Utils.java
+++ b/core/src/main/java/org/radargun/utils/Utils.java
@@ -647,5 +647,22 @@ public class Utils {
       }
    }
 
+   public static void loadConfigFile(String filename, Map<String, byte[]> configs) {
+      if (filename != null) {
+         InputStream is = null;
+         try {
+            is = Utils.class.getClassLoader().getResourceAsStream(filename);
+            if (is == null) { //not attached as resource - assume the direct path on filesystem
+               is = new FileInputStream(new File(filename));
+            }
+            configs.put(filename, Utils.readAsBytes(is));
+         } catch (Exception e) {
+            log.error("Error while reading configuration file (" + filename + ")", e);
+         } finally {
+            Utils.close(is);
+         }
+      }
+   }
+
 
 }

--- a/plugins/tomcat8/pom.xml
+++ b/plugins/tomcat8/pom.xml
@@ -19,6 +19,12 @@
    <dependencies>
       <dependency>
          <groupId>org.radargun</groupId>
+         <artifactId>radargun-core</artifactId>
+         <version>${project.version}</version>
+         <scope>provided</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.radargun</groupId>
          <artifactId>radargun-cache</artifactId>
          <version>${project.version}</version>
          <scope>provided</scope>

--- a/plugins/tomcat8/src/main/java/org/radargun/service/TomcatConfigurationProvider.java
+++ b/plugins/tomcat8/src/main/java/org/radargun/service/TomcatConfigurationProvider.java
@@ -2,29 +2,35 @@ package org.radargun.service;
 
 import java.util.HashMap;
 import java.util.Map;
-
+import java.util.Properties;
 import org.radargun.logging.Log;
 import org.radargun.logging.LogFactory;
 import org.radargun.traits.ConfigurationProvider;
 import org.radargun.utils.Utils;
 
 /**
- * @author Matej Cimbora &lt;mcimbora@redhat.com&gt;
+ * @author Martin Gencur
  */
-public abstract class AbstractConfigurationProvider implements ConfigurationProvider {
+public class TomcatConfigurationProvider implements ConfigurationProvider {
 
    protected final Log log = LogFactory.getLog(getClass());
 
-   protected abstract String getConfigFile();
+   private TomcatServerService service;
 
-   protected abstract String getJGroupsConfigFile();
+   public TomcatConfigurationProvider(TomcatServerService service) {
+      this.service = service;
+   }
+
+   @Override
+   public Map<String, Properties> getNormalizedConfigs() {
+      return new HashMap<String, Properties>();
+   }
 
    @Override
    public Map<String, byte[]> getOriginalConfigs() {
       Map<String, byte[]> configs = new HashMap<String, byte[]>();
       try {
-         Utils.loadConfigFile(getJGroupsConfigFile(), configs);
-         Utils.loadConfigFile(getConfigFile(), configs);
+         Utils.loadConfigFile(service.file, configs);
       } catch (Exception e) {
          log.error("Error while reading original configuration files", e);
       }

--- a/plugins/tomcat8/src/main/java/org/radargun/service/TomcatServerService.java
+++ b/plugins/tomcat8/src/main/java/org/radargun/service/TomcatServerService.java
@@ -74,6 +74,11 @@ public class TomcatServerService extends JavaProcessService {
 
    protected TomcatServerLifecycle lifecycle;
 
+   @ProvidesTrait
+   public TomcatConfigurationProvider createTomcatConfigurationProvider() {
+      return new TomcatConfigurationProvider(this);
+   }
+
    @Init
    public void init() {
       if (catalinaBase == null || "".equals(catalinaBase))

--- a/reporters/reporter-default/src/main/resources/html/templates/index.ftl
+++ b/reporters/reporter-default/src/main/resources/html/templates/index.ftl
@@ -30,7 +30,7 @@
                      <ul>
                         <li>Plugin: ${setup.plugin}</li>
                         <li>Service: ${setup.service}</li>
-                        <#if (indexDocument.getConfigs(report))?size == 0>
+                        <#if (indexDocument.getConfigs(report, setup.group))?size == 0>
                            <#assign fileName = (setup.properties["file"])!" no file" />
                               <li>Configuration file: ${fileName}</li>
 
@@ -38,7 +38,7 @@
                            <li>
                               Configuration files:
                               <ul>
-                                 <#list (indexDocument.getConfigs(report)) as config>
+                                 <#list (indexDocument.getConfigs(report, setup.group)) as config>
                                     <li>
                                        <a href="${getConfigFileName(setup.configuration.name, setup.group, report.cluster.clusterIndex, config.filename)}"> ${config.filename}</a>
                                     </li>


### PR DESCRIPTION
Fixes https://github.com/radargun/radargun/issues/371 and also adds configuration provider for Tomcat.

The server configuration file now appears as a clickable link in the report, both for Infinispan server and Tomcat server.