### PR TITLE
Classpath scanning from Maven build

### DIFF
--- a/core/src/main/java/org/radargun/config/AntClassLoaderHandler.java
+++ b/core/src/main/java/org/radargun/config/AntClassLoaderHandler.java
@@ -1,0 +1,29 @@
+package org.radargun.config;
+
+import java.io.File;
+import java.util.Vector;
+
+import io.github.lukehutch.fastclasspathscanner.classloaderhandler.ClassLoaderHandler;
+import io.github.lukehutch.fastclasspathscanner.scanner.ClasspathFinder;
+import io.github.lukehutch.fastclasspathscanner.utils.ReflectionUtils;
+
+/**
+ * Allows loading classes from AntClassLoader
+ */
+public class AntClassLoaderHandler implements ClassLoaderHandler {
+   @Override
+   public boolean handle(ClassLoader classloader, ClasspathFinder classpathFinder) throws Exception {
+      for (Class<?> c = classloader.getClass(); c != null; c = c.getSuperclass()) {
+         if ("org.apache.tools.ant.AntClassLoader".equals(c.getName())) {
+            Object pathComponents = ReflectionUtils.getFieldVal(classloader, "pathComponents");
+            if (pathComponents != null && pathComponents instanceof Vector) {
+               for (File file : ((Vector<File>) pathComponents)) {
+                  classpathFinder.addClasspathElement(file.getAbsolutePath());
+               }
+            }
+            return true;
+         }
+      }
+      return false;
+   }
+}

--- a/core/src/main/java/org/radargun/config/ClasspathScanner.java
+++ b/core/src/main/java/org/radargun/config/ClasspathScanner.java
@@ -1,7 +1,6 @@
 package org.radargun.config;
 
 import java.lang.annotation.Annotation;
-import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -14,9 +13,7 @@ import org.radargun.logging.Log;
 import org.radargun.logging.LogFactory;
 
 /**
- * 
  * Helper for listing classes on classpath.
- *
  */
 public final class ClasspathScanner {
    private static final Log log = LogFactory.getLog(ClasspathScanner.class);
@@ -26,9 +23,9 @@ public final class ClasspathScanner {
 
    @SuppressWarnings("unchecked")
    /**
-    * 
+    *
     * Scan the classpath for classes with the specified annotations
-    * 
+    *
     * @param superClass
     *           restrict the search to annotations that are subclasses of this class, or
     *           <code>null</code> to search all classes
@@ -54,10 +51,11 @@ public final class ClasspathScanner {
       } else {
          fcs = new FastClasspathScanner("!");
       }
+      fcs.registerClassLoaderHandler(new AntClassLoaderHandler());
 
       ScanResult scanResults = fcs.scan();
 
-      List<String> matches = Collections.EMPTY_LIST;
+      List<String> matches;
       if (superClass != null) {
          matches = scanResults.getClassNameToClassInfo().values().stream()
                .filter(ci -> ci.hasSuperclass(superClass.getName()) || ci.implementsInterface(superClass.getName()))


### PR DESCRIPTION
 * Fast classpath scanner does not recognize AntClassLoader (which is used when invoking non-forking `java` task from Ant)