### PR TITLE
Example benchmarks fix

### DIFF
--- a/core/src/main/java/org/radargun/utils/ReflexiveConverters.java
+++ b/core/src/main/java/org/radargun/utils/ReflexiveConverters.java
@@ -168,10 +168,10 @@ public class ReflexiveConverters {
       public List convert(ComplexDefinition definition, Type type) {
          if (type instanceof Class<?>) {
             Class<?> clazz = (Class<?>) type;
-            if (!List.class.isAssignableFrom(clazz)) throw new IllegalArgumentException(type.toString());
+            if (!Collection.class.isAssignableFrom(clazz)) throw new IllegalArgumentException(type.toString());
          } else if (type instanceof ParameterizedType) {
             ParameterizedType ptype = (ParameterizedType) type;
-            if (!List.class.isAssignableFrom((Class<?>) ptype.getRawType()))
+            if (!Collection.class.isAssignableFrom((Class<?>) ptype.getRawType()))
                throw new IllegalArgumentException(type.toString());
          }
          List list = new ArrayList();

--- a/core/src/main/resources/benchmark-jgroups.xml
+++ b/core/src/main/resources/benchmark-jgroups.xml
@@ -35,7 +35,7 @@
             <query value="remove-protocol=MERGE3"/>
             <query value="insert-protocol=MERGE2=above=PING"/>
             <!-- insert custom protocol (just for illustration -->
-            <query value="insert-protocol=org.radargun.protocols.SLAVE_PARTITION=above=UDP"/>
+            <query value="insert-protocol=org.radargun.protocols.SLAVE_PARTITION_36=above=UDP"/>
             <!-- Print information per protocol -->
             <query value="jmx=NAKACK2"/>
             <!-- Print information for the whole stack -->

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -71,6 +71,7 @@
                 <li>Other docs
                   <ul>
                     <li><a href="{{page.path_to_root}}other_docs/failover_tests.html">Failover tests</a></li>
+                    <li><a href="{{page.path_to_root}}other_docs/coherence_plugin.html">Coherence plugin</a></li>
                   </ul>
                 </li>
                 <li>Download

--- a/docs/getting_started/example_configurations.md
+++ b/docs/getting_started/example_configurations.md
@@ -6,13 +6,19 @@ Example configurations
 
 Following benchmark [configuration]({{page.path_to_root}}benchmark_configuration/general.html) files can be found in `/conf` folder of [built](./building_binaries.html) project.
 
+**NOTE:** When working with external application builds always check you have appropriate version, in case of weird errors check again.
+
 **[benchmark-aggregation-query.xml](https://github.com/radargun/radargun/blob/master/extensions/query/src/main/resources/benchmark-aggregation-query.xml)** - Shows correct usage of `query` extension on Infinispan 9.0
 
 **[benchmark-analysis.xml](https://github.com/radargun/radargun/blob/master/extensions/cache/src/main/resources/benchmark-analysis.xml)** - Shows how to analyze results of a stage and then re-use the results in another stage/store them to results via `analyze-test` and `add-result` stages
 
 **[benchmark-coherence-hazelcast.xml](https://github.com/radargun/radargun/blob/master/extensions/cache/src/main/resources/benchmark-coherence-hazelcast.xml)** - Shows how to run comparative analysis of three products (Coherence, Hazelcast and Infinispan)
 
+This benchmark requires [Coherence plugin]({{page.path_to_root}}other_docs/coherence_plugin.html) which is not built by default due to licensing constraints.
+
 **[benchmark-combined-report.xml](https://github.com/radargun/radargun/blob/master/extensions/cache/src/main/resources/benchmark-combined-report.xml)** - Shows how to property handle combining different tests
+
+This benchmark is using colliding-keys [key selector]({{page.path_to_root}}benchmark_configuration/key_selectors.html), consequently it produces a **lot** of errors in logs due to key clashes.
 
 **[benchmark-condition.xml](https://github.com/radargun/radargun/blob/master/extensions/cache/src/main/resources/benchmark-condition.xml)** - Shows how to use conditions in the `repeat` stage
 
@@ -28,11 +34,22 @@ Following benchmark [configuration]({{page.path_to_root}}benchmark_configuration
 
 **[benchmark-hotrod-rest-memcached.xml](https://github.com/radargun/radargun/blob/master/extensions/cache/src/main/resources/benchmark-hotrod-rest-memcached.xml)** - Shows performance testing for same-server/different-client configurations
 
+> Environment variables:
+> * *ISPN_8_HOME*	- pointing to Infinispan server home directory
+
 **[benchmark-hotrod-spark-mapreduce.xml](https://github.com/radargun/radargun/blob/master/extensions/mapreduce/src/main/resources/benchmark-hotrod-spark-mapreduce.xml)** - Shows how to benchmark MapReduce operations on Infinispan coupled with Spark
+
+> Environment variables:
+> * *SPARK_161_HOME*	- pointing to Spark home directory
+> * *ISPN_82_HOME*	- pointing to Infinispan server home directory
 
 **[benchmark-hotrod-streaming.xml](https://github.com/radargun/radargun/blob/master/extensions/cache/src/main/resources/benchmark-hotrod-streaming.xml)** - Shows how to compare memory usage on Infinispan clients using and not using Streaming API
 
-**[benchmark-iteration.xml](https://github.com/radargun/radargun/blob/master/extensions/cache/src/main/resources/benchmark-iteration.xml)** - Shows how to use `iterate` stage to iterate over all entries in the cache
+> Environment variables:
+> * *ISPN_9_ZIP_PATH*	- path to Infinispan server distribution file
+> * *RG_WORK*		- the directory RadarGun will use to unpack Infinispan server instances to
+
+**[benchmark-iteration.xml](https://github.com/radargun/radargun/blob/master/extensions/cache/src/main/resources/benchmark-iteration.xml)** - Shows how to used`iterate` stage to iterate over all entries in the cache
 
 **[benchmark-jcache.xml](https://github.com/radargun/radargun/blob/master/extensions/cache/src/main/resources/benchmark-jcache.xml)** - Shows how to configure comparative benchmark on two products over JCache
 
@@ -44,10 +61,26 @@ Following benchmark [configuration]({{page.path_to_root}}benchmark_configuration
 
 **[benchmark-redis.xml](https://github.com/radargun/radargun/blob/master/extensions/cache/src/main/resources/benchmark-redis.xml)** - Shows how to setup a performance test for Redis
 
-Environment variables:
-* *REDIS_DISTRO_ZIP_PATH*  - pointing to zip containing built Redis
+This benchmark requires re-packaged Redis distribution, in order to run it you will have to download and build it according to instruction on [Redis homepage](https://redis.io/), then pack the folder contents (not folder itself) as `redisdistro.zip` and provide path to it as environment variable.
+
+> Environment variables:
+> * *REDIS_DISTRO_ZIP_PATH*  - pointing to zip containing built Redis
 
 **[benchmark-rest-cs-tomcat.xml](https://github.com/radargun/radargun/blob/master/extensions/rest/src/main/resources/benchmark-rest-cs-tomcat.xml)** - Shows how to call REST operation on web server using `rest-operations-test` stage
+
+This configurations requires manual intervention in Tomcat installation which is to be used, specifically:
+
+* `conf/tomcat-users.xml` file in the Tomcat home folder has to contain following lines:
+
+{% highlight xml %}
+    <role rolename="manager-script"/>
+    <user username="tomcat" password="tomcat" roles="manager-script"/>
+{% endhighlight %}
+
+* [clusterbench ee7](https://github.com/clusterbench/clusterbench) application has to be deployed as `clusterbench`, follow instructions on the site
+
+> Environment variables:
+> * *CATALINA_HOME*	- path to tomcat folder
 
 **[benchmark-stream.xml](https://github.com/radargun/radargun/blob/master/extensions/cache/src/main/resources/benchmark-stream.xml)** - Shows how to execute distributed stream tasks via `stream` stage
 

--- a/docs/other_docs/coherence_plugin.md
+++ b/docs/other_docs/coherence_plugin.md
@@ -1,0 +1,21 @@
+---
+---
+
+Coherence plugin
+----------------
+
+**Note:** This document reffers to application/dependency provided by a 3rd party, the details of which can change at any time in any way, it is therefore not inconcieveable that this document not up to date at some point.
+
+Due to licensing constraints we are not able to provide [Oracle Coherence](http://www.oracle.com/technetwork/middleware/coherence/overview/index.html) dependency for Coherence plugin and anyone wishing to use it has to download and add it himself. There are two Coherence plugins, for version 3.7.1 and 12.1.2, latter depends on the former so the dependencies have to de satisfied for both is you want the latter.
+
+Both versions are downloadable from [OTN](http://www.oracle.com/technetwork/middleware/coherence/downloads/coherence-archive-165749.html) upon registration and acceptance of Terms of use.
+
+#### Version 3.7.1
+
+This dependency is available in a compressed file, specifically as `coherence/lib/coherence.jar` file, copy into maven repository folder as `repository/com/oracle/coherence/coherence/3.7.1/coherence-3.7.1.jar`.
+
+#### Version 12.1.2
+
+This dependency is sadly available only as part of the installation, you will have to install stand-alone version and then pick up the file from installation folder `coherence/lib/coherence.jar` and copy it into maven repository as `repository/com/oracle/coherence/coherence/12.1.2/coherence-12.1.2.jar`.
+
+If both operations went smoothly Coherence plugin should now be buildable, run the usual [maven build]({{page.path_to_root}}getting_started/building_binaries.html) with `-Dcoherence` parameter.

--- a/extensions/cache/src/main/resources/benchmark-coherence-hazelcast.xml
+++ b/extensions/cache/src/main/resources/benchmark-coherence-hazelcast.xml
@@ -32,7 +32,7 @@
       <jvm-monitor-start />
 
       <cache:load num-entries="5000"/>
-      <cache:basic-operations-test test-name="warmup" num-requests="100000" num-threads-per-node="5">
+      <cache:basic-operations-test test-name="warmup" duration="${warmup.duration:30s}" num-threads-per-node="5">
          <cache:key-selector>
             <cache:concurrent-keys total-entries="5000" />
          </cache:key-selector>

--- a/extensions/cache/src/main/resources/benchmark-combined-report.xml
+++ b/extensions/cache/src/main/resources/benchmark-combined-report.xml
@@ -49,7 +49,7 @@
          </cache:key-selector>
       </cache:basic-operations-test>
 
-      <rg:repeat from="1" to="${repeat.times:10}">
+      <rg:repeat from="1" to="${repeat.times:3}">
          <cache:basic-operations-test test-name="iterating" amend-test="true"
                                 iteration-property="num-threads-per-node"
                                 duration="${test.short.duration:5s}" num-threads-per-node="#{2 ^ ${repeat.counter}}">

--- a/extensions/cache/src/main/resources/benchmark-dist-custom-vars.xml
+++ b/extensions/cache/src/main/resources/benchmark-dist-custom-vars.xml
@@ -48,7 +48,7 @@
       <cache:load num-entries="5000"/>
       <!-- 5 threads will execute random requests against the default cache ('testCache') for 1 minute-->
       <!-- As the test is called 'warmup', performance statistics won't be reported -->
-      <cache:basic-operations-test test-name="warmup" duration="${warmup.duration:1m}" num-threads-per-node="5">
+      <cache:basic-operations-test test-name="warmup" duration="${warmup.duration:30s}" num-threads-per-node="5">
          <cache:key-selector>
             <cache:concurrent-keys total-entries="5000" />
          </cache:key-selector>
@@ -66,7 +66,7 @@
 
       <rg:repeat from="0" to="#{${threads}.size - 1}" inc="1">
          <cache:basic-operations-test test-name="stress-test" amend-test="true"
-                                duration="${test.duration:1m}" num-threads-per-node="#{${threads}.get(${repeat.counter})}">
+                                duration="${test.duration:30s}" num-threads-per-node="#{${threads}.get(${repeat.counter})}">
             <statistics>
                <common period="1s"/>
             </statistics>

--- a/extensions/cache/src/main/resources/benchmark-distexec.xml
+++ b/extensions/cache/src/main/resources/benchmark-distexec.xml
@@ -36,8 +36,11 @@
 
 		<!-- Execute a distributed executor that searches the cache values for a string -->
 		<cache:distributed-task
-			callable="org.infinispan.demo.distexec.CacheValueRegEx"
-			callable-params="setPattern: tJêÇvJrTÇëälJú" />
+			callable="org.infinispan.demo.distexec.CacheValueRegEx">
+          <cache:callable-params>
+            <cache:property key="setPattern" value="tJêÇvJrTÇëälJú"/>
+          </cache:callable-params>
+        </cache:distributed-task>
 
 		<!-- Stop services on all nodes -->
 		<service-stop />

--- a/extensions/cache/src/main/resources/benchmark-hotrod-rest-memcached.xml
+++ b/extensions/cache/src/main/resources/benchmark-hotrod-rest-memcached.xml
@@ -23,7 +23,7 @@
                <!-- Additional arguments passed to ${env.ISPN_HOME}/bin/standalone.sh -->
                <args>-DudpGroup=224.0.0.1</args>
                <!-- Home directory for the Infinispan Server -->
-               <home>${env.ISPN_HOME}</home>
+               <home>${env.ISPN_8_HOME}</home>
             </server>
          </setup>
          <!-- Configuration for the HotRod client -->
@@ -39,7 +39,7 @@
          <setup group="server" plugin="infinispan80" >
             <server xmlns="urn:radargun:plugins:infinispan80:3.0" file="server.xml" jmx-domain="jboss.datagrid-infinispan">
                <args>-DudpGroup=224.0.0.1</args>
-               <home>${env.ISPN_HOME}</home>
+               <home>${env.ISPN_8_HOME}</home>
             </server>
          </setup>
          <!-- Configuration for the HotRod client -->
@@ -57,7 +57,7 @@
          <!-- Configuration for the server group - this is identical to HotRod -->
             <server xmlns="urn:radargun:plugins:infinispan80:3.0" file="server.xml" jmx-domain="jboss.datagrid-infinispan">
                <args>-DudpGroup=224.0.0.1</args>
-               <home>${env.ISPN_HOME}</home>
+               <home>${env.ISPN_8_HOME}</home>
             </server>
          </setup>
          <!-- Configuration for the REST client -->

--- a/extensions/cache/src/main/resources/benchmark-hotrod-streaming.xml
+++ b/extensions/cache/src/main/resources/benchmark-hotrod-streaming.xml
@@ -28,7 +28,7 @@
                <!-- Working directory for slave -->
                <home>${env.RG_WORK}/slave${slave.index}</home>
                <!-- Path to server ZIP file -->
-               <server-zip>${env.ISPN_ZIP_PATH}/infinispan-server-9.0.0-SNAPSHOT.zip</server-zip>
+               <server-zip>${env.ISPN_9_ZIP_PATH}/infinispan-server-9.0.0-SNAPSHOT.zip</server-zip>
                <env>JAVA_OPTS=-server -Xms2g -Xmx4g
                   -XX:MaxPermSize=4G
                   -verbose:gc

--- a/extensions/mapreduce/src/main/resources/benchmark-hotrod-spark-mapreduce.xml
+++ b/extensions/mapreduce/src/main/resources/benchmark-hotrod-spark-mapreduce.xml
@@ -20,21 +20,15 @@
       <config name="Spark">
          <!-- Configuration for the Spark master group -->
          <setup group="master" plugin="spark">
-            <master xmlns="urn:radargun:plugins:spark:3.0" home="${env.SPARK_HOME}">
-            </master>
+            <master xmlns="urn:radargun:plugins:spark:3.0" home="${env.SPARK_161_HOME}"/>
          </setup>
          <!-- Configuration for the Spark worker group -->
          <setup group="worker" plugin="spark">
-            <worker xmlns="urn:radargun:plugins:spark:3.0" home="${env.SPARK_HOME}">
-               <host>localhost.localdomain</host>
-               <port>7077</port>
-            </worker>
+            <worker xmlns="urn:radargun:plugins:spark:3.0" home="${env.SPARK_161_HOME}"/>
          </setup>
          <!-- Configuration for the Spark driver group -->
          <setup group="driver" plugin="spark">
             <driver xmlns="urn:radargun:plugins:spark:3.0">
-               <host>localhost.localdomain</host>
-               <port>7077</port>
                <properties>
                   <property key="spark.serializer" value="org.apache.spark.serializer.KryoSerializer"/>
                </properties>
@@ -46,10 +40,10 @@
          </setup>
          <!-- Configuration for the ISPN server group-->
          <setup group="ispn-server" plugin="infinispan82">
-            <server xmlns="urn:radargun:plugins:infinispan82:3.0" file="server.xml" jmx-domain="jboss.datagrid-infinispan" cache-manager-name="clustered">
+            <server xmlns="urn:radargun:plugins:infinispan82:3.0" file="standalone.xml" jmx-domain="jboss.datagrid-infinispan" cache-manager-name="local">
                <!-- Avoid port collisions with Spark nodes -->
                <args>-Djboss.socket.binding.port-offset=100</args>
-               <home>${env.ISPN_HOME}</home>
+               <home>${env.ISPN_82_HOME}</home>
             </server>
          </setup>
          <!-- Configuration for the ISPN client group -->
@@ -89,7 +83,6 @@
                   source-name="org.radargun.service.demo.ispn.WordCountSource"
                   mapper-fqn="org.radargun.service.demo.ispn.WordCountMapper"
                   reducer-fqn="org.radargun.service.demo.ispn.WordCountReducer"
-                  print-result="true"
       />
 
       <!-- Stop services on all nodes -->

--- a/extensions/query/src/main/java/org/radargun/traits/Query.java
+++ b/extensions/query/src/main/java/org/radargun/traits/Query.java
@@ -87,9 +87,9 @@ public interface Query {
     * Used to represent aggregated attributes and also order by expressions
     */
    class SelectExpression {
-      public String attribute;
-      public AggregationFunction function;
-      public boolean asc;
+      public final String attribute;
+      public final AggregationFunction function;
+      public final Boolean asc;
 
       public SelectExpression(String attribute) {
          this(attribute, AggregationFunction.NONE, true);
@@ -107,6 +107,10 @@ public interface Query {
          this.attribute = attribute;
          this.function = function;
          this.asc = asc;
+      }
+      
+      public String attribute(){
+         return attribute;
       }
    }
 }

--- a/extensions/rest/src/main/resources/benchmark-rest-cs-tomcat.xml
+++ b/extensions/rest/src/main/resources/benchmark-rest-cs-tomcat.xml
@@ -15,7 +15,7 @@
          <setup group="servers" plugin="${productName:tomcat8}">
             <tomcat xmlns="urn:radargun:plugins:tomcat8:3.0" file="${server.config:server.xml}">
                 <!-- path to tomcat server -->
-               <catalina-home>$CATALINA_HOME</catalina-home>
+               <catalina-home>${env.CATALINA_HOME}</catalina-home>
                <!-- user and password for the user with manager-script role defined in tomcat-users.xml -->
                <user>tomcat</user>
                <pass>tomcat</pass>

--- a/plugins/infinispan52/src/main/java/org/radargun/service/InfinispanServerService.java
+++ b/plugins/infinispan52/src/main/java/org/radargun/service/InfinispanServerService.java
@@ -71,8 +71,6 @@ public class InfinispanServerService extends JavaProcessService {
    protected int executorPoolSize = 2;
 
    protected ScheduledExecutorService executor;
-
-   protected InfinispanServerLifecycle lifecycle;
    protected InfinispanServerClustered clustered;
 
    protected volatile MBeanServerConnection connection;
@@ -160,12 +158,6 @@ public class InfinispanServerService extends JavaProcessService {
    @Destroy
    public void destroy() {
       Utils.shutdownAndWait(executor);
-   }
-
-   @ProvidesTrait
-   @Override
-   public InfinispanServerLifecycle createLifecycle() {
-      return lifecycle;
    }
 
    @ProvidesTrait

--- a/plugins/infinispan70/src/main/java/org/radargun/protocols/SLAVE_PARTITION_36.java
+++ b/plugins/infinispan70/src/main/java/org/radargun/protocols/SLAVE_PARTITION_36.java
@@ -1,0 +1,19 @@
+package org.radargun.protocols;
+
+import org.jgroups.Event;
+import org.jgroups.Message;
+import org.radargun.service.SLAVE_PARTITION_33;
+
+public class SLAVE_PARTITION_36 extends SLAVE_PARTITION_33 {
+   
+   @Override
+   public Object down(Event evt) {
+      switch (evt.getType()) {
+         case Event.MSG:
+            Message msg = (Message) evt.getArg();
+            // putHeader signature has changed
+            msg.putHeader(PROTOCOL_ID, new SlaveHeader(this.slaveIndex));
+      }
+      return down_prot.down(evt);
+   }
+}

--- a/plugins/infinispan72/src/main/resources/dist-sync.xml
+++ b/plugins/infinispan72/src/main/resources/dist-sync.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<infinispan
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="urn:infinispan:config:7.0 http://www.infinispan.org/schemas/infinispan-config-7.0.xsd"
+        xmlns="urn:infinispan:config:7.0">
+    <jgroups>
+        <stack-file name="jgroupsStack" path="default-configs/default-jgroups-udp.xml"/>
+    </jgroups>
+
+    <cache-container name="default" default-cache="testCache">
+        <transport stack="jgroupsStack" lock-timeout="600000" cluster="default" />
+        <serialization></serialization>
+        <jmx>
+            <property name="enabled">true</property>
+        </jmx>
+        <distributed-cache name="testCache" mode="SYNC" remote-timeout="60000" statistics="true" l1-lifespan="-1" owners="2" segments="512" >
+            <locking acquire-timeout="3000" concurrency-level="1000" />
+            <state-transfer timeout="60000" />
+        </distributed-cache>
+    </cache-container>
+
+</infinispan>

--- a/plugins/infinispan82/src/main/resources/standalone.xml
+++ b/plugins/infinispan82/src/main/resources/standalone.xml
@@ -1,0 +1,258 @@
+<?xml version="1.0" ?>
+
+<server xmlns="urn:jboss:domain:4.0">
+    <extensions>
+        <extension module="org.infinispan.extension"/>
+        <extension module="org.infinispan.server.endpoint"/>
+        <extension module="org.jboss.as.connector"/>
+        <extension module="org.jboss.as.deployment-scanner"/>
+        <extension module="org.jboss.as.jdr"/>
+        <extension module="org.jboss.as.jmx"/>
+        <extension module="org.jboss.as.logging"/>
+        <extension module="org.jboss.as.naming"/>
+        <extension module="org.jboss.as.remoting"/>
+        <extension module="org.jboss.as.security"/>
+        <extension module="org.jboss.as.transactions"/>
+        <extension module="org.wildfly.extension.io"/>
+        <extension module="org.wildfly.extension.security.manager"/>
+    </extensions>
+    <management>
+        <security-realms>
+            <security-realm name="ManagementRealm">
+                <authentication>
+                    <local default-user="$local" skip-group-loading="true"/>
+                    <properties path="mgmt-users.properties" relative-to="jboss.server.config.dir"/>
+                </authentication>
+                <authorization map-groups-to-roles="false">
+                    <properties path="mgmt-groups.properties" relative-to="jboss.server.config.dir"/>
+                </authorization>
+            </security-realm>
+            <security-realm name="ApplicationRealm">
+                <authentication>
+                    <local default-user="$local" allowed-users="*" skip-group-loading="true"/>
+                    <properties path="application-users.properties" relative-to="jboss.server.config.dir"/>
+                </authentication>
+                <authorization>
+                    <properties path="application-roles.properties" relative-to="jboss.server.config.dir"/>
+                </authorization>
+            </security-realm>
+        </security-realms>
+        <audit-log>
+            <formatters>
+                <json-formatter name="json-formatter"/>
+            </formatters>
+            <handlers>
+                <file-handler name="file" formatter="json-formatter" relative-to="jboss.server.data.dir" path="audit-log.log"/>
+            </handlers>
+            <logger log-boot="true" log-read-only="false" enabled="false">
+                <handlers>
+                    <handler name="file"/>
+                </handlers>
+            </logger>
+        </audit-log>
+        <management-interfaces>
+            <http-interface security-realm="ManagementRealm" http-upgrade-enabled="true">
+                <socket-binding http="management-http"/>
+            </http-interface>
+        </management-interfaces>
+        <access-control provider="simple">
+            <role-mapping>
+                <role name="SuperUser">
+                    <include>
+                        <user name="$local"/>
+                    </include>
+                </role>
+            </role-mapping>
+        </access-control>
+    </management>
+    <profile>
+        <subsystem xmlns="urn:jboss:domain:logging:3.0">
+            <console-handler name="CONSOLE">
+                <level name="INFO"/>
+                <formatter>
+                    <named-formatter name="COLOR-PATTERN"/>
+                </formatter>
+            </console-handler>
+            <periodic-rotating-file-handler name="FILE" autoflush="true">
+                <formatter>
+                    <named-formatter name="PATTERN"/>
+                </formatter>
+                <file relative-to="jboss.server.log.dir" path="server.log"/>
+                <suffix value=".yyyy-MM-dd"/>
+                <append value="true"/>
+            </periodic-rotating-file-handler>
+            <logger category="com.arjuna">
+                <level name="WARN"/>
+            </logger>
+            <logger category="org.jboss.as.config">
+                <level name="DEBUG"/>
+            </logger>
+            <logger category="sun.rmi">
+                <level name="WARN"/>
+            </logger>
+            <root-logger>
+                <level name="INFO"/>
+                <handlers>
+                    <handler name="CONSOLE"/>
+                    <handler name="FILE"/>
+                </handlers>
+            </root-logger>
+            <formatter name="PATTERN">
+                <pattern-formatter pattern="%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n"/>
+            </formatter>
+            <formatter name="COLOR-PATTERN">
+                <pattern-formatter pattern="%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n"/>
+            </formatter>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:deployment-scanner:2.0">
+            <deployment-scanner path="deployments" relative-to="jboss.server.base.dir" scan-interval="5000" runtime-failure-causes-rollback="${jboss.deployment.scanner.rollback.on.failure:false}"/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:datasources:4.0">
+            <datasources>
+                <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
+                    <connection-url>jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE</connection-url>
+                    <driver>h2</driver>
+                    <security>
+                        <user-name>sa</user-name>
+                        <password>sa</password>
+                    </security>
+                </datasource>
+                <drivers>
+                    <driver name="h2" module="com.h2database.h2">
+                        <xa-datasource-class>org.h2.jdbcx.JdbcDataSource</xa-datasource-class>
+                    </driver>
+                </drivers>
+            </datasources>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:io:1.1">
+            <worker name="default"/>
+            <buffer-pool name="default"/>
+        </subsystem>
+        <subsystem xmlns="urn:infinispan:server:core:8.2" default-cache-container="local">
+            <cache-container name="local" default-cache="default" statistics="true">
+                <global-state/>
+                <local-cache name="default" start="EAGER">
+                    <locking acquire-timeout="30000" concurrency-level="1000" striping="false"/>
+                    <transaction mode="NONE"/>
+                </local-cache>
+                <local-cache name="memcachedCache" start="EAGER">
+                    <locking acquire-timeout="30000" concurrency-level="1000" striping="false"/>
+                    <transaction mode="NONE"/>
+                </local-cache>
+                <local-cache name="namedCache" start="EAGER"/>
+            </cache-container>
+        </subsystem>
+        <subsystem xmlns="urn:infinispan:server:endpoint:8.0">
+            <hotrod-connector socket-binding="hotrod" cache-container="local">
+                <topology-state-transfer lazy-retrieval="false" lock-timeout="1000" replication-timeout="5000"/>
+            </hotrod-connector>
+            <memcached-connector socket-binding="memcached" cache-container="local"/>
+            <rest-connector socket-binding="rest" cache-container="local" security-domain="other" auth-method="BASIC"/>
+            <websocket-connector socket-binding="websocket" cache-container="local"/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:jca:4.0">
+            <archive-validation enabled="true" fail-on-error="true" fail-on-warn="false"/>
+            <bean-validation enabled="true"/>
+            <default-workmanager>
+                <short-running-threads>
+                    <core-threads count="50"/>
+                    <queue-length count="50"/>
+                    <max-threads count="50"/>
+                    <keepalive-time time="10" unit="seconds"/>
+                </short-running-threads>
+                <long-running-threads>
+                    <core-threads count="50"/>
+                    <queue-length count="50"/>
+                    <max-threads count="50"/>
+                    <keepalive-time time="10" unit="seconds"/>
+                </long-running-threads>
+            </default-workmanager>
+            <cached-connection-manager/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:jdr:1.0"/>
+        <subsystem xmlns="urn:jboss:domain:jmx:1.3">
+            <expose-resolved-model/>
+            <expose-expression-model/>
+            <remoting-connector/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:naming:2.0">
+            <remote-naming/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:remoting:3.0">
+            <endpoint/>
+            <http-connector name="http-remoting-connector" connector-ref="default" security-realm="ApplicationRealm"/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:security:1.2">
+            <security-domains>
+                <security-domain name="other" cache-type="default">
+                    <authentication>
+                        <login-module code="Remoting" flag="optional">
+                            <module-option name="password-stacking" value="useFirstPass"/>
+                        </login-module>
+                        <login-module code="RealmDirect" flag="required">
+                            <module-option name="password-stacking" value="useFirstPass"/>
+                        </login-module>
+                    </authentication>
+                </security-domain>
+                <security-domain name="jboss-web-policy" cache-type="default">
+                    <authorization>
+                        <policy-module code="Delegating" flag="required"/>
+                    </authorization>
+                </security-domain>
+                <security-domain name="jboss-ejb-policy" cache-type="default">
+                    <authorization>
+                        <policy-module code="Delegating" flag="required"/>
+                    </authorization>
+                </security-domain>
+                <security-domain name="jaspitest" cache-type="default">
+                    <authentication-jaspi>
+                        <login-module-stack name="dummy">
+                            <login-module code="Dummy" flag="optional"/>
+                        </login-module-stack>
+                        <auth-module code="Dummy"/>
+                    </authentication-jaspi>
+                </security-domain>
+            </security-domains>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:security-manager:1.0">
+            <deployment-permissions>
+                <maximum-set>
+                    <permission class="java.security.AllPermission"/>
+                </maximum-set>
+            </deployment-permissions>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:transactions:3.0">
+            <core-environment>
+                <process-id>
+                    <uuid/>
+                </process-id>
+            </core-environment>
+            <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager"/>
+        </subsystem>
+    </profile>
+    <interfaces>
+        <interface name="management">
+            <inet-address value="${jboss.bind.address.management:127.0.0.1}"/>
+        </interface>
+        <interface name="public">
+            <inet-address value="${jboss.bind.address:127.0.0.1}"/>
+        </interface>
+    </interfaces>
+    <socket-binding-group name="standard-sockets" default-interface="public" port-offset="${jboss.socket.binding.port-offset:0}">
+        <socket-binding name="management-http" interface="management" port="${jboss.management.http.port:9990}"/>
+        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9993}"/>
+        <socket-binding name="hotrod" port="11222"/>
+        <socket-binding name="hotrod-internal" port="11223"/>
+        <socket-binding name="memcached" port="11211"/>
+        <socket-binding name="rest" port="8080"/>
+        <socket-binding name="txn-recovery-environment" port="4712"/>
+        <socket-binding name="txn-status-manager" port="4713"/>
+        <socket-binding name="websocket" port="8181"/>
+        <outbound-socket-binding name="remote-store-hotrod-server">
+            <remote-destination host="remote-host" port="11222"/>
+        </outbound-socket-binding>
+        <outbound-socket-binding name="remote-store-rest-server">
+            <remote-destination host="remote-host" port="8080"/>
+        </outbound-socket-binding>
+    </socket-binding-group>
+</server>

--- a/plugins/process/src/main/java/org/radargun/service/JavaProcessService.java
+++ b/plugins/process/src/main/java/org/radargun/service/JavaProcessService.java
@@ -112,9 +112,9 @@ public class JavaProcessService extends ProcessService {
    }
 
    public String getJavaPIDs() {
-      if (getPid() != null) {
+      if (lifecycle.getPid() != null) {
          ProcessBuilder pb = new ProcessBuilder()
-               .command(Arrays.asList(getCommandPrefix() + "jvms" + getCommandSuffix(), getPid()));
+               .command(Arrays.asList(getCommandPrefix() + "jvms" + getCommandSuffix(), lifecycle.getPid()));
          pb.redirectError(ProcessBuilder.Redirect.INHERIT);
          pb.redirectInput(ProcessBuilder.Redirect.INHERIT);
          try {

--- a/plugins/process/src/main/java/org/radargun/service/ProcessService.java
+++ b/plugins/process/src/main/java/org/radargun/service/ProcessService.java
@@ -48,12 +48,14 @@ public class ProcessService {
    public boolean stderrToStdout = false;
 
    private CopyOnWriteArrayList<Action> actions = new CopyOnWriteArrayList<Action>();
-   protected String pid;
 
+   protected ProcessLifecycle<?> lifecycle;
+   
    @ProvidesTrait
-   public ProcessLifecycle createLifecycle() {
-      return new ProcessLifecycle(this);
+   public ProcessLifecycle<?> createLifecycle() {
+      return lifecycle;
    }
+
 
    protected List<String> getCommand() {
       ArrayList<String> command = new ArrayList<String>(args.size() + 2);
@@ -76,14 +78,6 @@ public class ProcessService {
 
    public Map<String, String> getEnvironment() {
       return env;
-   }
-
-   public String getPid() {
-      return pid;
-   }
-
-   public void setPid(String pid) {
-      this.pid = pid;
    }
 
    public void registerAction(Pattern pattern, OutputListener action) {

--- a/plugins/process/src/main/resources/unix-is_alive.sh
+++ b/plugins/process/src/main/resources/unix-is_alive.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo $(ps -o pid= -p $1);

--- a/plugins/spark/src/main/java/org/radargun/service/AbstractSparkLifecycle.java
+++ b/plugins/spark/src/main/java/org/radargun/service/AbstractSparkLifecycle.java
@@ -1,8 +1,12 @@
 package org.radargun.service;
 
+import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
+import java.io.FilenameFilter;
 import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.regex.Pattern;
 
@@ -21,7 +25,6 @@ public abstract class AbstractSparkLifecycle extends ProcessLifecycle<AbstractSp
    }
 
    protected void startInternal() {
-      super.startInternal();
       service.registerAction(getStartPattern(), m -> {
          long end = TimeService.currentTimeMillis() + service.logCreationTimeout;
          while (TimeService.currentTimeMillis() <= end) {
@@ -39,6 +42,44 @@ public abstract class AbstractSparkLifecycle extends ProcessLifecycle<AbstractSp
          }
          throw new IllegalStateException("Failed to attach reader to log file");
       });
+      super.startInternal();
+   }
+
+   @Override
+   public String getProcessId(Process process) {
+      long end = TimeService.currentTimeMillis() + service.startupProcessTimeout;
+      while (process.isAlive() && TimeService.currentTimeMillis() <= end) {
+         try {
+            Thread.sleep(500);
+         } catch (InterruptedException e) {
+            log.error("Interrupted while waiting for start process to finish ", e);
+            Thread.currentThread().interrupt();
+         }
+
+      }
+
+      File[] pidFiles = FileSystems.getDefault().getPath(service.home, "pids").toFile().listFiles(new PidFileNameFilter());
+      if (pidFiles.length != 1) {
+         log.error("Multiple or no PID files containing " + service.getPidFileIdent() + " found, something has gone wrong");
+         return super.getProcessId(process);
+      }
+
+      byte[] buffer;
+      try {
+         buffer = Files.readAllBytes(pidFiles[0].toPath());
+      } catch (IOException e) {
+         log.error("Error reading PID file" + pidFiles[0].getName(), e);
+         return super.getProcessId(process);
+      }
+
+      return new String(buffer).trim();
+   }
+
+   private class PidFileNameFilter implements FilenameFilter {
+      public boolean accept(File dir, String name) {
+         return name.contains(service.getPidFileIdent());
+      }
+
    }
 
    @Override

--- a/plugins/spark/src/main/java/org/radargun/service/AbstractSparkService.java
+++ b/plugins/spark/src/main/java/org/radargun/service/AbstractSparkService.java
@@ -1,5 +1,8 @@
 package org.radargun.service;
 
+import java.nio.file.FileSystems;
+import java.util.Map;
+
 import org.radargun.Service;
 import org.radargun.config.Property;
 import org.radargun.utils.TimeConverter;
@@ -16,5 +19,18 @@ public abstract class AbstractSparkService extends JavaProcessService {
    @Property(doc = "Maximum time to wait until Spark's log file gets created after service was started. " +
          "Default is 30 seconds.", converter = TimeConverter.class)
    protected long logCreationTimeout = 30000;
+   
+   @Property(doc = "Maximum time to wait until Spark's startup process finishes. " +
+         "Default is 5 seconds.", converter = TimeConverter.class)
+   protected long startupProcessTimeout = 5000;
 
+   @Override
+   public Map<String, String> getEnvironment() {
+      Map<String, String> envMap = super.getEnvironment();
+      envMap.put("SPARK_PID_DIR", FileSystems.getDefault().getPath(home, "pids").toString());
+      envMap.put("SPARK_IDENT_STRING", getPidFileIdent());
+      return envMap;
+   }
+
+   protected abstract String getPidFileIdent();
 }

--- a/plugins/spark/src/main/java/org/radargun/service/SparkMasterService.java
+++ b/plugins/spark/src/main/java/org/radargun/service/SparkMasterService.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 import org.radargun.Service;
 import org.radargun.config.Init;
-import org.radargun.traits.ProvidesTrait;
+import org.radargun.config.Property;
 
 /**
  * @author Matej Cimbora
@@ -14,23 +14,27 @@ import org.radargun.traits.ProvidesTrait;
 @Service(doc = "Service encapsulating Apache Spark (master node).")
 public class SparkMasterService extends AbstractSparkService {
 
-   private SparkMasterLifecycle lifecycle;
+   @Property(doc = "Name of the host where master node will be deployed. Default is localhost.")
+   protected String host = "localhost";
+
+   @Property(doc = "Port under which master node is to be accessible. Default is 7077.")
+   protected int port = 7077;
 
    @Init
    public void init() {
       this.lifecycle = new SparkMasterLifecycle(this);
    }
 
-   @Override
-   @ProvidesTrait
-   public ProcessLifecycle createLifecycle() {
-      return lifecycle;
-   }
 
    @Override
    protected List<String> getCommand() {
       ArrayList<String> command = new ArrayList<String>();
       command.add(FileSystems.getDefault().getPath(home, "sbin", "start-master.sh").toString());
+      command.add(" -h " + host + " -p " + port);
       return command;
+   }
+
+   protected String getPidFileIdent() {
+      return "radargun_master_" + this.port;
    }
 }

--- a/plugins/spark/src/main/java/org/radargun/service/SparkWorkerLifecycle.java
+++ b/plugins/spark/src/main/java/org/radargun/service/SparkWorkerLifecycle.java
@@ -21,10 +21,10 @@ public class SparkWorkerLifecycle extends AbstractSparkLifecycle {
 
    @Override
    protected void startInternal() {
-      super.startInternal();
       service.registerAction(CONNECTED_TO_MASTER_PATTERN, m -> {
          setConnectedToMaster();
       });
+      super.startInternal();
       long startTime = TimeService.currentTimeMillis();
       synchronized (this) {
          while (!connectedToMaster) {

--- a/plugins/spark/src/main/java/org/radargun/service/SparkWorkerService.java
+++ b/plugins/spark/src/main/java/org/radargun/service/SparkWorkerService.java
@@ -7,12 +7,11 @@ import java.util.List;
 import org.radargun.Service;
 import org.radargun.config.Init;
 import org.radargun.config.Property;
-import org.radargun.traits.ProvidesTrait;
 
 /**
  * @author Matej Cimbora
  */
-@Service(doc = "Service encapsulating Apache Spark (worker node).")
+@Service(doc = "Service encapsulating Apache Spark (worker node). Current implementation is limited to one slave per host.")
 public class SparkWorkerService extends AbstractSparkService {
 
    @Property(doc = "Name of the host where master node is deployed. Default is localhost.")
@@ -21,17 +20,9 @@ public class SparkWorkerService extends AbstractSparkService {
    @Property(doc = "Port under which master node is accessible. Default is 7077.")
    protected int port = 7077;
 
-   private SparkWorkerLifecycle lifecycle;
-
    @Init
    public void init() {
-      this.lifecycle = new SparkWorkerLifecycle(this);
-   }
-
-   @Override
-   @ProvidesTrait
-   public ProcessLifecycle createLifecycle() {
-      return lifecycle;
+      lifecycle = new SparkWorkerLifecycle(this);
    }
 
    @Override
@@ -40,5 +31,10 @@ public class SparkWorkerService extends AbstractSparkService {
       command.add(FileSystems.getDefault().getPath(home, "sbin", "start-slave.sh").toString());
       command.add("spark://" + host + ":" + port);
       return command;
+   }
+   
+   
+   protected String getPidFileIdent() {
+      return "radargun_worker_1";
    }
 }

--- a/plugins/tomcat8/src/main/java/org/radargun/service/TomcatServerService.java
+++ b/plugins/tomcat8/src/main/java/org/radargun/service/TomcatServerService.java
@@ -72,8 +72,6 @@ public class TomcatServerService extends JavaProcessService {
    @Property(doc = "Logging properties file. Default is ${CATALINA_HOME}/conf/logging.properties")
    private String loggingProperties = "logging.properties";
 
-   protected TomcatServerLifecycle lifecycle;
-
    @ProvidesTrait
    public TomcatConfigurationProvider createTomcatConfigurationProvider() {
       return new TomcatConfigurationProvider(this);
@@ -112,12 +110,6 @@ public class TomcatServerService extends JavaProcessService {
          log.error("Failed to copy file", e);
          throw new RuntimeException(e);
       }
-   }
-
-   @ProvidesTrait
-   @Override
-   public TomcatServerLifecycle createLifecycle() {
-      return lifecycle;
    }
 
    @Override

--- a/plugins/tomcat8/src/main/resources/server.xml
+++ b/plugins/tomcat8/src/main/resources/server.xml
@@ -1,0 +1,142 @@
+<?xml version='1.0' encoding='utf-8'?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!-- Note:  A "Server" is not itself a "Container", so you may not
+     define subcomponents such as "Valves" at this level.
+     Documentation at /docs/config/server.html
+ -->
+<Server port="8005" shutdown="SHUTDOWN">
+  <Listener className="org.apache.catalina.startup.VersionLoggerListener" />
+  <!-- Security listener. Documentation at /docs/config/listeners.html
+  <Listener className="org.apache.catalina.security.SecurityListener" />
+  -->
+  <!--APR library loader. Documentation at /docs/apr.html -->
+  <Listener className="org.apache.catalina.core.AprLifecycleListener" SSLEngine="on" />
+  <!-- Prevent memory leaks due to use of particular java/javax APIs-->
+  <Listener className="org.apache.catalina.core.JreMemoryLeakPreventionListener" />
+  <Listener className="org.apache.catalina.mbeans.GlobalResourcesLifecycleListener" />
+  <Listener className="org.apache.catalina.core.ThreadLocalLeakPreventionListener" />
+
+  <!-- Global JNDI resources
+       Documentation at /docs/jndi-resources-howto.html
+  -->
+  <GlobalNamingResources>
+    <!-- Editable user database that can also be used by
+         UserDatabaseRealm to authenticate users
+    -->
+    <Resource name="UserDatabase" auth="Container"
+              type="org.apache.catalina.UserDatabase"
+              description="User database that can be updated and saved"
+              factory="org.apache.catalina.users.MemoryUserDatabaseFactory"
+              pathname="conf/tomcat-users.xml" />
+  </GlobalNamingResources>
+
+  <!-- A "Service" is a collection of one or more "Connectors" that share
+       a single "Container" Note:  A "Service" is not itself a "Container",
+       so you may not define subcomponents such as "Valves" at this level.
+       Documentation at /docs/config/service.html
+   -->
+  <Service name="Catalina">
+
+    <!--The connectors can use a shared executor, you can define one or more named thread pools-->
+    <!--
+    <Executor name="tomcatThreadPool" namePrefix="catalina-exec-"
+        maxThreads="150" minSpareThreads="4"/>
+    -->
+
+
+    <!-- A "Connector" represents an endpoint by which requests are received
+         and responses are returned. Documentation at :
+         Java HTTP Connector: /docs/config/http.html (blocking & non-blocking)
+         Java AJP  Connector: /docs/config/ajp.html
+         APR (HTTP/AJP) Connector: /docs/apr.html
+         Define a non-SSL/TLS HTTP/1.1 Connector on port 8080
+    -->
+    <Connector port="8080" protocol="HTTP/1.1"
+               connectionTimeout="20000"
+               redirectPort="8443" />
+    <!-- A "Connector" using the shared thread pool-->
+    <!--
+    <Connector executor="tomcatThreadPool"
+               port="8080" protocol="HTTP/1.1"
+               connectionTimeout="20000"
+               redirectPort="8443" />
+    -->
+    <!-- Define a SSL/TLS HTTP/1.1 Connector on port 8443
+         This connector uses the NIO implementation that requires the JSSE
+         style configuration. When using the APR/native implementation, the
+         OpenSSL style configuration is required as described in the APR/native
+         documentation -->
+    <!--
+    <Connector port="8443" protocol="org.apache.coyote.http11.Http11NioProtocol"
+               maxThreads="150" SSLEnabled="true" scheme="https" secure="true"
+               clientAuth="false" sslProtocol="TLS" />
+    -->
+
+    <!-- Define an AJP 1.3 Connector on port 8009 -->
+    <Connector port="8009" protocol="AJP/1.3" redirectPort="8443" />
+
+
+    <!-- An Engine represents the entry point (within Catalina) that processes
+         every request.  The Engine implementation for Tomcat stand alone
+         analyzes the HTTP headers included with the request, and passes them
+         on to the appropriate Host (virtual host).
+         Documentation at /docs/config/engine.html -->
+
+    <!-- You should set jvmRoute to support load-balancing via AJP ie :
+    <Engine name="Catalina" defaultHost="localhost" jvmRoute="jvm1">
+    -->
+    <Engine name="Catalina" defaultHost="localhost">
+
+      <!--For clustering, please take a look at documentation at:
+          /docs/cluster-howto.html  (simple how to)
+          /docs/config/cluster.html (reference documentation) -->
+      <!--
+      <Cluster className="org.apache.catalina.ha.tcp.SimpleTcpCluster"/>
+      -->
+
+      <!-- Use the LockOutRealm to prevent attempts to guess user passwords
+           via a brute-force attack -->
+      <Realm className="org.apache.catalina.realm.LockOutRealm">
+        <!-- This Realm uses the UserDatabase configured in the global JNDI
+             resources under the key "UserDatabase".  Any edits
+             that are performed against this UserDatabase are immediately
+             available for use by the Realm.  -->
+        <Realm className="org.apache.catalina.realm.UserDatabaseRealm"
+               resourceName="UserDatabase"/>
+      </Realm>
+
+      <Host name="localhost"  appBase="webapps"
+            unpackWARs="true" autoDeploy="true">
+
+        <!-- SingleSignOn valve, share authentication between web applications
+             Documentation at: /docs/config/valve.html -->
+        <!--
+        <Valve className="org.apache.catalina.authenticator.SingleSignOn" />
+        -->
+
+        <!-- Access log processes all example.
+             Documentation at: /docs/config/valve.html
+             Note: The pattern used is equivalent to using pattern="common" -->
+        <Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs"
+               prefix="localhost_access_log" suffix=".txt"
+               pattern="%h %l %u %t &quot;%r&quot; %s %b" />
+
+      </Host>
+    </Engine>
+  </Service>
+</Server>

--- a/pom.xml
+++ b/pom.xml
@@ -700,10 +700,10 @@
                         <ac:if xmlns:ac="antlib:net.sf.antcontrib">
                            <isset property="package-latest"/>
                            <ac:then>
-                                <property name="plugin.list" value="${plugins.chm},${plugins.jcache},${plugins.ehcache-latest},${plugins.hazelcast-latest},${plugins.redis-latest},${plugins.jbosscache-latest},${plugins.jgroups-latest},${plugins.infinispan-latest},${plugins.jdg-latest},${plugins.coherence-latest},${plugins.process},${plugins.resteasy-http},${plugins.spymemcached},${plugins.tomcat},${plugins.docker}" />
+                                <property name="plugin.list" value="${plugins.chm},${plugins.jcache},${plugins.ehcache-latest},${plugins.hazelcast-latest},${plugins.redis-latest},${plugins.jbosscache-latest},${plugins.jgroups-latest},${plugins.infinispan-latest},${plugins.jdg-latest},${plugins.coherence-latest},${plugins.process},${plugins.resteasy-http},${plugins.spymemcached},${plugins.tomcat},${plugins.docker},${plugins.spark}" />
                            </ac:then>
                            <ac:else>
-                              <property name="plugin.list" value="${plugins.chm},${plugins.jcache},${plugins.ehcache},${plugins.hazelcast},${plugins.redis},${plugins.jbosscache},${plugins.jgroups},${plugins.infinispan},${plugins.jdg-early},${plugins.jdg},${plugins.coherence},${plugins.process},${plugins.resteasy-http},${plugins.spymemcached},${plugins.tomcat},${plugins.docker}"/>
+                              <property name="plugin.list" value="${plugins.chm},${plugins.jcache},${plugins.ehcache},${plugins.hazelcast},${plugins.redis},${plugins.jbosscache},${plugins.jgroups},${plugins.infinispan},${plugins.jdg-early},${plugins.jdg},${plugins.coherence},${plugins.process},${plugins.resteasy-http},${plugins.spymemcached},${plugins.tomcat},${plugins.docker},${plugins.spark}"/>
                            </ac:else>
                         </ac:if>
                         <echo message="Plugin list: ${plugin.list}" />


### PR DESCRIPTION
* Minor fixes on benchmarks, documentation updates
* Fixed up Coherence plugin (query API change)
* Decoupled PID retrieval from started process (and possibly did not mess up whole lot of other things)
* Added some missing configs
* Fixed up Coherence plugin
* Moved PID management from Service to Lifecycle
* Fixed spark PID retrieval
* Added some comments on example benchmarks
* Minor fix on properties parsing

This set of changes fixes all example benchmarks with exception of continuous-query, which suffers from #477 .

In retrospect it might have been prudent to divide this into multiple discrete pull requests, I apologize for that, I suffer from severe "just one more little change..." syndrome.