### PR TITLE
Separate normalized configs

### DIFF
--- a/plugins/hazelcast2/src/main/java/org/radargun/service/HazelcastConfigurationProvider.java
+++ b/plugins/hazelcast2/src/main/java/org/radargun/service/HazelcastConfigurationProvider.java
@@ -1,0 +1,40 @@
+package org.radargun.service;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import org.radargun.logging.Log;
+import org.radargun.logging.LogFactory;
+import org.radargun.traits.ConfigurationProvider;
+import org.radargun.utils.Utils;
+
+/**
+ * @author Martin Gencur
+ */
+public class HazelcastConfigurationProvider implements ConfigurationProvider {
+
+   protected final Log log = LogFactory.getLog(getClass());
+
+   protected HazelcastService service;
+
+   public HazelcastConfigurationProvider(HazelcastService service) {
+      this.service = service;
+   }
+
+   @Override
+   public Map<String, Properties> getNormalizedConfigs() {
+      return Collections.EMPTY_MAP; //not implemented
+   }
+
+   @Override
+   public Map<String, byte[]> getOriginalConfigs() {
+      Map<String, byte[]> configs = new HashMap<>();
+      try {
+         Utils.loadConfigFile(service.config, configs);
+      } catch (Exception e) {
+         log.error("Error while reading original configuration file!", e);
+      }
+      return configs;
+   }
+}

--- a/plugins/hazelcast2/src/main/java/org/radargun/service/HazelcastService.java
+++ b/plugins/hazelcast2/src/main/java/org/radargun/service/HazelcastService.java
@@ -45,7 +45,7 @@ public class HazelcastService implements Lifecycle, Clustered {
    protected List<Membership> membershipHistory = new ArrayList<>();
 
    @Property(name = Service.FILE, doc = "Configuration file.")
-   private String config;
+   protected String config;
 
    @Property(name = "cache", doc = "Name of the map ~ cache", deprecatedName = "map")
    protected String mapName = "default";
@@ -71,6 +71,11 @@ public class HazelcastService implements Lifecycle, Clustered {
    @ProvidesTrait
    public HazelcastOperations createOperations() {
       return new HazelcastOperations(this);
+   }
+
+   @ProvidesTrait
+   public HazelcastConfigurationProvider createConfigurationProvider() {
+      return new HazelcastConfigurationProvider(this);
    }
 
    @Override

--- a/reporters/reporter-default/src/main/resources/html/templates/index.ftl
+++ b/reporters/reporter-default/src/main/resources/html/templates/index.ftl
@@ -74,7 +74,7 @@
                            <li>
                               Normalized configurations:
                                <ul>
-                                  <#list indexDocument.getNormalized() as config>
+                                  <#list indexDocument.getNormalized(report, setup.group) as config>
                                     <li>
                                        <a href="${indexDocument.getFilename(report.getConfiguration().name, setup.group, report.getCluster(), config)}">
                                              ${config}


### PR DESCRIPTION
Without separating the normalized configs the html page reports normalized configs from JDG in Hazelcast's section.
