### PR TITLE
Enable logs in tests

### DIFF
--- a/extensions/cache/pom.xml
+++ b/extensions/cache/pom.xml
@@ -36,6 +36,11 @@
             </executions>
          </plugin>
       </plugins>
+         <resources>
+            <resource>
+               <directory>../../core/target/distribution/radargun-core-bin/radargun-core/conf/</directory>
+            </resource>
+         </resources>
    </build>
 
 </project>


### PR DESCRIPTION
There are some random failures in CI job, I can't reproduce them locally so at least enabling logs on tests so that we have something to investigate next time they happen.