### PR TITLE
Fix JMX connections for the Java Process Service

### DIFF
--- a/core/src/main/java/org/radargun/RemoteSlaveConnection.java
+++ b/core/src/main/java/org/radargun/RemoteSlaveConnection.java
@@ -408,8 +408,8 @@ public class RemoteSlaveConnection {
       } else {
          address = new InetSocketAddress(host, port);
       }
+      log.info("Attempting to start Master listening for connection on: " + address);
       serverSocketChannel.socket().bind(address);
-      log.info("Master started and listening for connection on: " + address);
       log.info("Waiting 5 seconds for server socket to open completely");
       try {
          Thread.sleep(5000);

--- a/plugins/process/src/main/java/org/radargun/service/JavaProcessService.java
+++ b/plugins/process/src/main/java/org/radargun/service/JavaProcessService.java
@@ -68,6 +68,7 @@ public class JavaProcessService extends ProcessService {
          return null;
       }
       if (!jmxConnectionEnabled) {
+         log.info("Connecting to the service via JMX is disabled.");
          return null;
       }
       return new JmxConnectionProvider() {


### PR DESCRIPTION
InfinispanServerClustered
   Check for null CacheManagerName in checkAndUpdateMembership
   Use correct type name in getCacheManagerObjectName
   Throw exception if no CacheManager is found in
getCacheManagerObjectName

JavaProcessService
   Log message if JMX connections have been disabled in the benchmark
configuration

RemoteSlaveConnection
   Log the master address and port before trying to open the connection