### PR TITLE
Log information about pid

### DIFF
--- a/plugins/process/src/main/java/org/radargun/service/JavaProcessService.java
+++ b/plugins/process/src/main/java/org/radargun/service/JavaProcessService.java
@@ -112,7 +112,10 @@ public class JavaProcessService extends ProcessService {
    }
 
    public String getJavaPIDs() {
-      if (getPid() != null) {
+
+      String currentPid = getPid();
+
+      if (currentPid != null) {
          ProcessBuilder pb = new ProcessBuilder()
                .command(Arrays.asList(getCommandPrefix() + "jvms" + getCommandSuffix(), getPid()));
          pb.redirectError(ProcessBuilder.Redirect.INHERIT);
@@ -125,13 +128,18 @@ public class JavaProcessService extends ProcessService {
                while ((line = reader.readLine()) != null)
                   sb.append(line);
             }
-            return sb.toString().split(" ")[0];
+
+            log.info("All Java PIDs: '" + sb.toString() + "'");
+
+            currentPid = sb.toString().split(" ")[0];
          } catch (IOException e) {
             log.error("Failed to read JVM PIDs", e);
-            return null;
          }
       }
-      return null;
+
+      log.info("Java PIDs: '" + currentPid + "'");
+
+      return currentPid;
    }
 
    @Override


### PR DESCRIPTION
Sometimes we are facing an issue on Jenkins related with an
"Invalid process identifier".
With this commit, we are now able to know which is the pid number.
Also, I added a single quotation marks to quickly identify an empty
string.