### PR TITLE
PREVIEW: OpenShift support - library mode

### DIFF
--- a/core/src/main/java/org/radargun/Slave.java
+++ b/core/src/main/java/org/radargun/Slave.java
@@ -93,10 +93,6 @@ public class Slave extends SlaveBase {
       Slave slave = new Slave(new RemoteMasterConnection(ArgsHolder.getMasterHost(), ArgsHolder.getMasterPort()));
       try {
          slave.run(ArgsHolder.getSlaveIndex());
-      } catch (IOException e) {
-         System.err.println("Communication with master failed");
-         e.printStackTrace();
-         ShutDownHook.exit(127);
       } catch (Exception e) {
          System.err.println("Unexpected error in scenario");
          e.printStackTrace();

--- a/core/src/main/java/org/radargun/Slave.java
+++ b/core/src/main/java/org/radargun/Slave.java
@@ -93,7 +93,12 @@ public class Slave extends SlaveBase {
       Slave slave = new Slave(new RemoteMasterConnection(ArgsHolder.getMasterHost(), ArgsHolder.getMasterPort()));
       try {
          slave.run(ArgsHolder.getSlaveIndex());
+      } catch (IOException e) {
+         System.err.println("Communication with master failed");
+         e.printStackTrace();
+         ShutDownHook.exit(127);
       } catch (Exception e) {
+         System.err.println("Unexpected error in scenario");
          e.printStackTrace();
          ShutDownHook.exit(127);
       }

--- a/core/src/main/java/org/radargun/SlaveBase.java
+++ b/core/src/main/java/org/radargun/SlaveBase.java
@@ -156,10 +156,6 @@ public abstract class SlaveBase {
       public void run() {
          try {
             scenarioLoop();
-         } catch (IOException e) {
-            log.error("Communication with master failed", e);
-            e.printStackTrace();
-            ShutDownHook.exit(127);
          } catch (Throwable t) {
             log.error("Unexpected error in scenario", t);
             t.printStackTrace();

--- a/core/src/main/resources/includes.sh
+++ b/core/src/main/resources/includes.sh
@@ -108,7 +108,7 @@ tail_log() {
    tail -f ${1} | while true
    do
       # Read from stdin with a 10 min timeout
-      IFS= read -r -u 0 -t 200
+      IFS= read -r -u 0 -t 600
       if (($? == 0))
       then
          echo "${REPLY}"

--- a/core/src/main/resources/includes.sh
+++ b/core/src/main/resources/includes.sh
@@ -108,7 +108,7 @@ tail_log() {
    tail -f ${1} | while true
    do
       # Read from stdin with a 10 min timeout
-      IFS= read -r -u 0 -t 600
+      IFS= read -r -u 0 -t 200
       if (($? == 0))
       then
          echo "${REPLY}"
@@ -119,7 +119,7 @@ tail_log() {
          fi
       else
          # Kill tail if no java process spawned from the shell script is found
-         if ! (ps -ef | grep "${3}" &>/dev/null)
+         if ! (ps -ef | grep "${3}" | grep -v "grep" | grep -v "tail" &>/dev/null)
          then
             kill -9 `pgrep -P $$ tail`
             break
@@ -127,4 +127,16 @@ tail_log() {
       fi
    done
    return 0
+}
+
+wait_pid() {
+    PID=$1
+    if [ ! "$PID" == "" ]; then
+        echo "Waiting for process $PID"
+        while [ -e /proc/$PID ]
+        do
+            sleep 5
+        done
+        echo "Process $PID has finished"
+    fi
 }

--- a/core/src/main/resources/slave.sh
+++ b/core/src/main/resources/slave.sh
@@ -182,4 +182,10 @@ fi
 if [ $WAIT == "true" ]
 then
   wait $SLAVE_PID
+  EXIT_VALUE=$?
+  if [ ! $EXIT_VALUE -eq 0 ]; then
+    echo "Slave $SLAVE_PID finished with value $EXIT_VALUE"
+    exit $EXIT_VALUE
+  fi
+  wait_pid `ps -ef | grep ${LOG4J_PREFIX} | grep org.radargun.Slave | awk '{print $2}'`
 fi

--- a/openshift/Dockerfile
+++ b/openshift/Dockerfile
@@ -2,11 +2,8 @@ FROM centos:centos7
 
 MAINTAINER Martin Gencur <mgencur@redhat.com>
 
-#ENV RADARGUN_VERSION=
-#ENV DESCRIPTION=
-
 RUN yum -y update && \
-        yum -y install unzip java-1.8.0-openjdk-devel maven openssh-server which hostname ls ps grep pwd id rsync && \
+        yum -y install unzip java-1.8.0-openjdk-devel which hostname ls ps grep pwd id rsync && \
         yum clean all -y
 
 RUN mkdir /opt/radargun /opt/radargun-data 
@@ -20,6 +17,9 @@ EXPOSE 2103 7800
 
 WORKDIR /opt/radargun-data
 USER 1001
+
+# Set the JAVA_HOME variable to make it clear where Java is located
+ENV JAVA_HOME /usr/lib/jvm/java
 
 COPY run_master.sh /opt/radargun/
 COPY run_slave.sh /opt/radargun/

--- a/openshift/Dockerfile
+++ b/openshift/Dockerfile
@@ -1,0 +1,27 @@
+FROM centos:centos7
+
+MAINTAINER Martin Gencur <mgencur@redhat.com>
+
+#ENV RADARGUN_VERSION=
+#ENV DESCRIPTION=
+
+RUN yum -y update && \
+        yum -y install unzip java-1.8.0-openjdk-devel maven openssh-server which hostname ls ps grep pwd id rsync && \
+        yum clean all -y
+
+RUN mkdir /opt/radargun /opt/radargun-data 
+COPY RadarGun-3.0.0-SNAPSHOT /opt/radargun/
+
+RUN chown -R 0 /opt/radargun /opt/radargun-data && \
+        chmod -R g=u /opt/radargun /opt/radargun-data
+
+# Expose RadarGun master port AND clustering port
+EXPOSE 2103 7800
+
+WORKDIR /opt/radargun-data
+USER 1001
+
+COPY run_master.sh /opt/radargun/
+COPY run_slave.sh /opt/radargun/
+
+CMD ["/opt/radargun/run_master.sh"]

--- a/openshift/README.md
+++ b/openshift/README.md
@@ -1,0 +1,44 @@
+# RadarGun in OpenShift
+
+Follow these steps to build and deploy RadarGun image in OpenShift and run performance tests there:
+
+1) export DOCKER_REGISTRY address where RadarGun images will be pushed for consumption by OpenShift deployments.
+
+    `export DOCKER_REGISTRY=<OpenShift's internal docker registry address>`
+    
+    Note: The registry address can be usually obtained by opening "About" link in the top-right corner of your OpenShift project's web UI.
+    
+2) Pass login command specific to OpenShift provider and log in
+
+    `./openshift.sh -L "oc login https://api.rh-us-xxx-1.openshift.com --token=l5gGjuKOPAWsdf6564sdfeOI7qhmQCGhJLvyj4oa4"`
+    
+    Note: The login command can be usually obtained by opening "Command line tools" link in the top-right corner of your OpenShift project's web UI. 
+
+3) Create your project
+
+    `./openshift.sh -n`
+
+4) Build RG image and push it to the remote Docker registry
+
+    `./openshift.sh -b`
+
+5) Create a subdirectory with configuration files for RadarGun and individual plugins. This directory will be mounted in master
+     and slave pods in OpenShift as /opt/radargun-configs. 
+
+6) Create RadarGun deployment via template.
+
+    `./openshift.sh -d -cd "config/" -cf "/opt/radargun-configs/library-dist-reads.xml" -n 2`
+    
+    Note: The RadarGun config file is library-dist-reads.xml which we placed in the config/ sub-directory.
+
+7) Collect results and log files when the tests finish. Results are available in the Master pod as /opt/radargun-data/results.
+     Logs are available in all RadarGun pods in /opt/radargun-data
+
+    `./openshift.sh -r`
+
+8) Optional: Purge your project before running the tests again
+
+    `./openshift.sh -p`
+
+
+

--- a/openshift/README.md
+++ b/openshift/README.md
@@ -1,44 +1,60 @@
 # RadarGun in OpenShift
 
-Follow these steps to build and deploy RadarGun image in OpenShift and run performance tests there:
+The openshift.sh script provides functionality for building Docker image for RadarGun, pushing the image to the
+given Docker repository, running performance tests within a remote OpenShift instance and downloading results to 
+the local filesystem when the tests finish. All processes run inside OpenShift within a common namespace/project.
 
-1) export DOCKER_REGISTRY address where RadarGun images will be pushed for consumption by OpenShift deployments.
+The master and slave processes will run in separate Pods in OpenShift. The user can specify the number of slaves that will result
+in creating that many Pods for slaves in OpenShift. There's always a single Pod for the master process. The user can also specify
+custom JVM options for RadarGun processes.
+
+Follow these steps to build and deploy RadarGun image in OpenShift and run performance tests:
+
+1) Build RadarGun from top-level directory using Maven. This will produce target/distribution/RadarGun-3.0.0-SNAPSHOT directory
+     that will be used in the resulting Docker image.
+
+    `mvn clean install`
+
+2) export DOCKER_REGISTRY address where RadarGun images will be pushed for consumption by OpenShift deployments.
 
     `export DOCKER_REGISTRY=<OpenShift's internal docker registry address>`
     
     Note: The registry address can be usually obtained by opening "About" link in the top-right corner of your OpenShift project's web UI.
     
-2) Pass login command specific to OpenShift provider and log in
+3) Pass login command specific to OpenShift provider and log in
 
-    `./openshift.sh -L "oc login https://api.rh-us-xxx-1.openshift.com --token=l5gGjuKOPAWsdf6564sdfeOI7qhmQCGhJLvyj4oa4"`
+    `./openshift -L "oc login https://api.rh-us-xxx-1.openshift.com --token=l5gGjuKOPAWsdf6564sdfeOI7qhmQCGhJLvyj4oa4"`
     
     Note: The login command can be usually obtained by opening "Command line tools" link in the top-right corner of your OpenShift project's web UI. 
 
-3) Create your project
+4) Create your project. By default called "myproject". Customization is only possible by changing the openshift.sh script.
 
-    `./openshift.sh -n`
+    `./openshift -n`
 
-4) Build RG image and push it to the remote Docker registry
+5) Build RG image and push it to the remote Docker registry.
 
-    `./openshift.sh -b`
+    `./openshift -b`
 
-5) Create a subdirectory with configuration files for RadarGun and individual plugins. This directory will be mounted in master
+6) Create a subdirectory with configuration files for RadarGun and individual plugins. This directory will be mounted in master
      and slave pods in OpenShift as /opt/radargun-configs. 
 
-6) Create RadarGun deployment via template.
+7) Create RadarGun deployment via template.
 
-    `./openshift.sh -d -cd "config/" -cf "/opt/radargun-configs/library-dist-reads.xml" -n 2`
+    `./openshift -d -cd "config/" -cf "radargun-benchmark.xml" -n 2`
     
-    Note: The RadarGun config file is library-dist-reads.xml which we placed in the config/ sub-directory.
+    Note: The example uses a RadarGun config file named "radargun-benchmark.xml" . It needs to be placed in the config/ sub-directory before
+    running the command. 
+    
+    Note: The config file will be finally placed in the running container under /opt/radargun-configs/ and RadarGun will consume it from there.
 
-7) Collect results and log files when the tests finish. Results are available in the Master pod as /opt/radargun-data/results.
+8) Collect results and log files when the tests finish. Results are available in the Master pod as /opt/radargun-data/results.
      Logs are available in all RadarGun pods in /opt/radargun-data
 
-    `./openshift.sh -r`
+    `./openshift -r`
 
-8) Optional: Purge your project before running the tests again
+9) Optional: Purge your project before running the tests again
 
-    `./openshift.sh -p`
+    `./openshift -p`
 
 
 

--- a/openshift/openshift
+++ b/openshift/openshift
@@ -13,9 +13,8 @@ RADARGUN_IMAGE=radargun
 FULL_IMAGE=${DOCKER_REGISTRY}/${TEST_PROJECT}/${RADARGUN_IMAGE}
 RADARGUN_MASTER="radargun-master.${TEST_PROJECT}.svc"
 CONFIG_DIR=configs/
-RADARGUN_CONFIG="/opt/radargun-configs/library-dist-reads.xml"
+RADARGUN_CONFIG="library-dist-reads.xml"
 CUSTOM_JAVA_OPTS="-Xmx300M -XX:+UseG1GC -XX:MaxGCPauseMillis=300 -XX:InitiatingHeapOccupancyPercent=70 -verbose:gc -XX:+PrintGCDateStamps -XX:+PrintGCDetails"
-                                    #-Dlog4j.configurationFile=file:///opt/radargun-configs/log4j2-trace.xml           
 TOTAL_CONTAINER_MEM=768
 NUMBER_OF_SLAVES=2
 

--- a/openshift/openshift.sh
+++ b/openshift/openshift.sh
@@ -1,0 +1,148 @@
+#!/bin/bash
+
+if [ "x$RADARGUN_HOME" = "x" ]; then
+  DIRNAME=`dirname $0`
+  RADARGUN_HOME=`cd $DIRNAME/..; pwd`
+fi;
+export RADARGUN_HOME
+
+OSE_MAIN_VERSION=v3.7.1
+OSE_SHA1_VERSION=ab0f056
+TEST_PROJECT=myproject
+RADARGUN_IMAGE=radargun
+FULL_IMAGE=${DOCKER_REGISTRY}/${TEST_PROJECT}/${RADARGUN_IMAGE}
+RADARGUN_MASTER="radargun-master.${TEST_PROJECT}.svc"
+CONFIG_DIR=configs/
+RADARGUN_CONFIG="/opt/radargun-configs/library-dist-reads.xml"
+CUSTOM_JAVA_OPTS="-Xmx300M -XX:+UseG1GC -XX:MaxGCPauseMillis=300 -XX:InitiatingHeapOccupancyPercent=70 -verbose:gc -XX:+PrintGCDateStamps -XX:+PrintGCDetails"
+                                    #-Dlog4j.configurationFile=file:///opt/radargun-configs/log4j2-trace.xml           
+TOTAL_CONTAINER_MEM=768
+NUMBER_OF_SLAVES=2
+
+help_and_exit() {
+  echo "Usage: TBD"
+  exit 0
+}
+
+function wrappedecho {
+  echo "${1}" | fold -s -w 80
+}
+
+function download_oc_client {
+  if [ -f ./oc ]; then
+    echo "OC client installed"
+  else
+    echo "Installing OC Client ..."
+    wget -q -N https://github.com/openshift/origin/releases/download/$OSE_MAIN_VERSION/openshift-origin-client-tools-$OSE_MAIN_VERSION-$OSE_SHA1_VERSION-linux-64bit.tar.gz
+    tar -zxf openshift-origin-client-tools-$OSE_MAIN_VERSION-$OSE_SHA1_VERSION-linux-64bit.tar.gz
+    cp openshift-origin-client-tools-$OSE_MAIN_VERSION-$OSE_SHA1_VERSION-linux-64bit/oc .
+    rm -rf openshift-origin-client-tools-$OSE_MAIN_VERSION+$OSE_SHA1_VERSION-linux-64bit
+    rm -rf openshift-origin-client-tools-$OSE_MAIN_VERSION-$OSE_SHA1_VERSION-linux-64bit.tar.gz
+  fi
+}
+    
+function build_radargun_image {
+    cp -R ${RADARGUN_HOME}/target/distribution/RadarGun-3.0.0-SNAPSHOT ./
+    sudo docker build -t ${RADARGUN_IMAGE} .
+    sudo docker login -u $(./oc whoami) -p $(./oc whoami -t) ${DOCKER_REGISTRY}
+    sudo docker tag ${RADARGUN_IMAGE} ${FULL_IMAGE}
+    sudo docker push ${FULL_IMAGE}
+    ./oc set image-lookup ${RADARGUN_IMAGE}
+}
+
+function new_project {
+    ./oc delete project ${TEST_PROJECT} || true
+    ( \
+        while ./oc get projects | grep -e ${TEST_PROJECT} > /dev/null; do \
+            echo "Waiting for deleted projects..."; \
+            sleep 5; \
+        done; \
+    )
+    ./oc new-project ${TEST_PROJECT} || true
+}
+
+function deploy_template {
+    ./oc create -f radargun-template.json
+    ./oc process radargun \
+           -p TOTAL_CONTAINER_MEM=${TOTAL_CONTAINER_MEM} \
+           -p NUMBER_OF_SLAVES=${NUMBER_OF_SLAVES} \
+           -p RADARGUN_MASTER=${RADARGUN_MASTER} \
+           -p RADARGUN_CONFIG=${RADARGUN_CONFIG} \
+           -p CUSTOM_JAVA_OPTS="${CUSTOM_JAVA_OPTS}" | oc create -f -
+}
+
+function create_config_map {
+    ./oc create configmap radargun-configs \
+    --from-file=${CONFIG_DIR}
+    ./oc label configmap radargun-configs template=radargun
+}
+
+function purge_project {
+    ./oc delete all,secrets,sa,templates,configmaps,daemonsets,clusterroles,rolebindings,serviceaccounts,statefulsets --selector=template=radargun || true
+    ./oc delete persistentvolumeclaims --selector=application=radargun-master
+    ./oc delete persistentvolumeclaims --selector=application=radargun-slave
+    ./oc delete template radargun || true
+}
+
+function get_results {
+    rm -rf radargun-data
+    NODES=`./oc get pods --selector=template=radargun -o jsonpath='{.items[*].metadata.name}{"\n"}'`
+    for node in $NODES; do
+        ./oc rsync ${node}:/opt/radargun-data .
+    done
+}
+
+download_oc_client
+
+## read in any command-line params
+while ! [ -z $1 ]
+do
+  case "$1" in
+    "-n"|"--newproject")
+        new_project
+    ;;
+    "-p"|"--purge")
+        purge_project
+    ;;
+    "-b"|"--build")
+        build_radargun_image
+    ;;
+    "-d"|"--deploy")
+        create_config_map
+        deploy_template 
+    ;;
+    "-m")
+        TOTAL_CONTAINER_MEM=$2
+        shift
+    ;;
+    "-n")
+        NUMBER_OF_SLAVES=$2
+        shift
+    ;;
+    "-cd"|"--config-dir")
+        CONFIG_DIR=$2
+        shift
+    ;;
+    "-cf"|"--config-file")
+        RADARGUN_CONFIG=$2
+        shift
+    ;;
+    "-r"|"--results")
+        get_results
+    ;;
+    "-J")
+        CUSTOM_JAVA_OPTS=$2
+        shift
+    ;;
+    "-L"|"--login")
+        LOGIN_COMMAND=$2
+        exec ./${LOGIN_COMMAND}
+        shift
+    ;;
+    *)
+      echo "Warning: unknown argument ${1}" 
+      help_and_exit
+      ;;
+  esac
+  shift
+done

--- a/openshift/radargun-template.json
+++ b/openshift/radargun-template.json
@@ -1,0 +1,340 @@
+{
+   "apiVersion": "v1",
+   "kind": "Template",
+   "labels": {
+      "template": "radargun"
+   },
+   "metadata": {
+      "annotations": {
+         "description": "RadarGun ....",
+         "tags": "radargun",
+         "openshift.io/display-name": "RadarGun ....",
+         "openshift.io/documentation-url": "http://radargun.github.io/radargun/",
+         "openshift.io/long-description": "RadarGun ...."
+      },
+      "name": "radargun"
+   },
+   "objects": [
+      {
+         "apiVersion": "v1",
+         "kind": "Service",
+         "metadata": {
+             "labels": {
+                "application": "radargun-slave"
+             },
+             "name": "radargun-slave-router"
+         },
+         "spec": {
+             "clusterIP": "None",
+             "ports": [
+                {
+                   "name": "ispn",
+                   "port": 7800,
+                   "protocol": "TCP",
+                   "targetPort": 7800
+                }
+             ],
+             "selector": {
+                 "application": "radargun-slave"
+             },
+             "sessionAffinity": "None",
+             "type": "ClusterIP"
+         },
+         "status": {
+             "loadBalancer": {}
+         }
+      },
+      {
+         "apiVersion": "v1",
+         "kind": "Service",
+         "metadata": {
+            "annotations": {
+               "description": "RadarGun Master service"
+            },
+            "labels": {
+               "application": "radargun-master"
+            },
+            "name": "radargun-master"
+         },
+         "spec": {
+            "ports": [
+               {
+                  "name": "radargun-master",
+                  "port": 2103,
+                  "targetPort": 2103
+               }
+            ],
+            "selector": {
+               "statefulSet": "radargun-master"
+            }
+         }
+      },
+      {
+         "apiVersion": "apps/v1beta1",
+         "kind": "StatefulSet",
+         "metadata": {
+            "labels": {
+               "application": "radargun-master"
+            },
+            "name": "radargun-master"
+         },
+         "spec": { 
+            "replicas": 1,
+            "strategy": {
+               "type": "Rolling",
+               "rollingParams": {
+                  "updatePeriodSeconds": 20,
+                  "intervalSeconds": 20,
+                  "timeoutSeconds": 1200,
+                  "maxUnavailable": 1,
+                  "maxSurge": 1
+               }
+            },
+            "template": {
+               "metadata": {
+                  "labels": {
+                     "application": "radargun-master",
+                     "statefulSet": "radargun-master",
+                     "template": "radargun"
+                  },
+                  "name": "radargun-master"
+               },
+               "spec": {
+                  "containers": [
+                     {
+                        "env": [
+                           {
+                              "name": "RADARGUN_CONFIG",
+                              "value": "${RADARGUN_CONFIG}"
+                           },
+                           {
+                              "name": "CUSTOM_JAVA_OPTS",
+                              "value": "${CUSTOM_JAVA_OPTS}"
+                           }
+                        ],
+                        "image": "radargun:latest",
+                        "name": "radargun-master",
+                        "command": [
+                           "/opt/radargun/run_master.sh"
+                        ],
+                        "volumeMounts": [
+                            {
+                                "name": "radargun-configs-volume",
+                                "mountPath": "/opt/radargun-configs"
+                            },
+                            {
+                                "name": "data",
+                                "mountPath": "/opt/radargun-data"
+                            }
+                        ],
+                        "ports": [
+                           {
+                              "containerPort": 2103,
+                              "name": "master-port",
+                              "protocol": "TCP"
+                           }
+                        ],
+                        "resources": {
+                           "requests": {
+                              "cpu": "0.5",
+                              "memory": "${TOTAL_CONTAINER_MEM}Mi"
+                           },
+                           "limits": {
+                              "memory": "${TOTAL_CONTAINER_MEM}Mi"
+                           }
+                        }
+                     }
+                  ],
+                  "volumes": [
+                     {
+                        "name": "radargun-configs-volume",
+                        "configMap": {
+                           "name": "radargun-configs"
+                        }
+                     }
+                  ],
+                  "terminationGracePeriodSeconds": 60
+               }
+            },
+            "triggers": [
+               {
+                  "type": "ConfigChange"
+               }
+            ],
+            "volumeClaimTemplates": [
+               {
+                  "metadata": {
+                     "name": "data",
+                     "labels": {
+                        "template": "radargun"
+                     }
+                  },
+                  "spec": {
+                     "accessModes": [
+                        "ReadWriteOnce"
+                     ],
+                     "resources": {
+                        "requests": {
+                           "storage": "1Gi"
+                        }
+                     }
+                  }
+               }
+            ]
+         }
+      },
+      {
+         "apiVersion": "apps/v1beta1",
+         "kind": "StatefulSet",
+         "metadata": {
+            "labels": {
+               "application": "radargun-slave",
+               "template": "radargun"
+            },
+            "name": "radargun-slave"
+         },
+         "spec": { 
+            "replicas": "${{NUMBER_OF_SLAVES}}",
+            "podManagementPolicy": "Parallel",
+            "strategy": {
+               "type": "Rolling",
+               "rollingParams": {
+                  "updatePeriodSeconds": 20,
+                  "intervalSeconds": 20,
+                  "timeoutSeconds": 1200,
+                  "maxUnavailable": 1,
+                  "maxSurge": 1
+               }
+            },
+            "template": {
+               "metadata": {
+                  "labels": {
+                     "application": "radargun-slave",
+                     "statefulSet": "radargun-slave",
+                     "template": "radargun"
+                  },
+                  "name": "radargun-slave"
+               },
+               "spec": {
+                  "containers": [
+                     {
+                        "env": [
+                           {
+                              "name": "RADARGUN_MASTER",
+                              "value": "${RADARGUN_MASTER}"
+                           },
+                           {
+                              "name": "CUSTOM_JAVA_OPTS",
+                              "value": "${CUSTOM_JAVA_OPTS}"
+                           }
+                        ],
+                        "image": "radargun:latest",
+                        "name": "radargun-slave",
+                        "command": [
+                           "/opt/radargun/run_slave.sh"
+                        ],
+                        "volumeMounts": [
+                            {
+                                "name": "radargun-configs-volume",
+                                "mountPath": "/opt/radargun-configs"
+                            },
+                            {
+                                "name": "data",
+                                "mountPath": "/opt/radargun-data"
+                            }
+                        ],
+                        "ports": [
+                           {
+                              "containerPort": 7800,
+                              "name": "clustering-port",
+                              "protocol": "TCP"
+                           }
+                        ],
+                        "resources": {
+                           "requests": {
+                              "cpu": "0.5",
+                              "memory": "${TOTAL_CONTAINER_MEM}Mi"
+                           },
+                           "limits": {
+                              "memory": "${TOTAL_CONTAINER_MEM}Mi"
+                           }
+                        }
+                     }
+                  ],
+                  "volumes": [
+                     {
+                        "name": "radargun-configs-volume",
+                        "configMap": {
+                           "name": "radargun-configs"
+                        }
+                     }
+                  ],
+                  "terminationGracePeriodSeconds": 60
+               }
+            },
+            "triggers": [
+               {
+                  "type": "ConfigChange"
+               }
+            ],
+            "volumeClaimTemplates": [
+               {
+                  "metadata": {
+                     "name": "data",
+                     "labels": {
+                        "template": "radargun"
+                     }
+                  },
+                  "spec": {
+                     "accessModes": [
+                        "ReadWriteOnce"
+                     ],
+                     "resources": {
+                        "requests": {
+                           "storage": "1Gi"
+                        }
+                     }
+                  }
+               }
+            ]
+         }
+      }
+   ],
+   "parameters": [
+      {
+         "description": "The hostname of radargun Master node.",
+         "name": "RADARGUN_MASTER",
+         "displayName": "RadarGun Master hostname",
+         "required": true,
+         "value": "radargun-master.myproject.svc"
+      },
+      {
+         "description": "RadarGun configuration/benchmark file",
+         "name": "RADARGUN_CONFIG",
+         "displayName": "RadarGun configuration file",
+         "required": true,
+         "value": "benchmark-dist.xml"
+      },
+      {
+         "description": "Number of instances in the cluster.",
+         "name": "NUMBER_OF_SLAVES",
+         "displayName": "Number of slaves",
+         "required": true,
+         "value": "1"
+      },
+      {
+         "description": "Total container memory in MiB.",
+         "displayName": "Total Memory",
+         "name": "TOTAL_CONTAINER_MEM",
+         "required": false,
+         "value": "512"
+      },
+      {
+         "description": "Custom Java opts",
+         "displayName": "Custom Java opts",
+         "name": "CUSTOM_JAVA_OPTS",
+         "required": false,
+         "value": ""
+      }
+   ]
+}

--- a/openshift/radargun-template.json
+++ b/openshift/radargun-template.json
@@ -6,11 +6,11 @@
    },
    "metadata": {
       "annotations": {
-         "description": "RadarGun ....",
+         "description": "RadarGun benchmarking framework for data grids and distributed caches",
          "tags": "radargun",
-         "openshift.io/display-name": "RadarGun ....",
+         "openshift.io/display-name": "RadarGun",
          "openshift.io/documentation-url": "http://radargun.github.io/radargun/",
-         "openshift.io/long-description": "RadarGun ...."
+         "openshift.io/long-description": "RadarGun benchmarking framework for data grids and distributed caches"
       },
       "name": "radargun"
    },
@@ -105,7 +105,7 @@
                         "env": [
                            {
                               "name": "RADARGUN_CONFIG",
-                              "value": "${RADARGUN_CONFIG}"
+                              "value": "/opt/radargun-configs/${RADARGUN_CONFIG}"
                            },
                            {
                               "name": "CUSTOM_JAVA_OPTS",

--- a/openshift/run_master.sh
+++ b/openshift/run_master.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+exec find . | grep "stdout_master.out" > /dev/null
+if [ $? -eq 0 ]; then
+    echo "RadarGun had previously run. Check out existing log files."
+    echo "Waiting for manual re-deployment..."
+    exec sleep infinity
+else
+    export JAVA_HOME=/usr/lib/jvm/java-1.8.0
+    exec /opt/radargun/bin/master.sh -c ${RADARGUN_CONFIG} -t -m 0.0.0.0:2103 -J "${CUSTOM_JAVA_OPTS}"
+fi

--- a/openshift/run_master.sh
+++ b/openshift/run_master.sh
@@ -6,6 +6,5 @@ if [ $? -eq 0 ]; then
     echo "Waiting for manual re-deployment..."
     exec sleep infinity
 else
-    export JAVA_HOME=/usr/lib/jvm/java-1.8.0
     exec /opt/radargun/bin/master.sh -c ${RADARGUN_CONFIG} -t -m 0.0.0.0:2103 -J "${CUSTOM_JAVA_OPTS}"
 fi

--- a/openshift/run_slave.sh
+++ b/openshift/run_slave.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+exec find . | grep "stdout_slave*" > /dev/null
+if [ $? -eq 0 ]; then
+    echo "RadarGun had previously run. Check out existing log files."
+    echo "Waiting for manual re-deployment..."
+    exec sleep infinity
+else
+    export JAVA_HOME=/usr/lib/jvm/java-1.8.0
+    export DNS_SERVER=`cat /etc/resolv.conf | grep nameserver | awk '{print $2}'`
+    export HOSTNAME=`hostname -i`
+    exec /opt/radargun/bin/slave.sh -t -m ${RADARGUN_MASTER}:2103 -J "${CUSTOM_JAVA_OPTS} -Ddns.address=${DNS_SERVER} -Dbind.address=${HOSTNAME}"
+fi
+

--- a/openshift/run_slave.sh
+++ b/openshift/run_slave.sh
@@ -6,7 +6,6 @@ if [ $? -eq 0 ]; then
     echo "Waiting for manual re-deployment..."
     exec sleep infinity
 else
-    export JAVA_HOME=/usr/lib/jvm/java-1.8.0
     export DNS_SERVER=`cat /etc/resolv.conf | grep nameserver | awk '{print $2}'`
     export HOSTNAME=`hostname -i`
     exec /opt/radargun/bin/slave.sh -t -m ${RADARGUN_MASTER}:2103 -J "${CUSTOM_JAVA_OPTS} -Ddns.address=${DNS_SERVER} -Dbind.address=${HOSTNAME}"


### PR DESCRIPTION
Please review this implementation. It works with Employee openshift but should work with any other instance.

* There are some TBDs. Please ignore them.
* WDYT about building RadarGun before creating the Docker image vs. including the build in the image itself?
* I've exposed port 7800 by default on all RG slaves. This is specific to JGroups but other plugins could re-use this port. I just wanted to make one port available for intra-cluster communication which is exposed by the Docker container and accessible from other pods. We can possible choose a different port number.
* The JVM opts needs to be tuned and described in readme (this is TBD)

I can provide config files for JGroups and ISPN that worked for me in OpenShift (upon request).

Don't integrate this yet. But thoughts are welcome.