### PR TITLE
don't try to monitor open files on Windows

### DIFF
--- a/core/src/main/java/org/radargun/stages/monitor/MonitorStartStage.java
+++ b/core/src/main/java/org/radargun/stages/monitor/MonitorStartStage.java
@@ -76,9 +76,12 @@ public class MonitorStartStage extends AbstractDistStage {
       monitors.addMonitor(new CpuUsageMonitor(jmxConnectionProvider, timeline));
       monitors.addMonitor(new MemoryUsageMonitor(jmxConnectionProvider, timeline));
       monitors.addMonitor(new GcMonitor(jmxConnectionProvider, timeline));
-      monitors.addMonitor(new OpenFilesMonitor(jmxConnectionProvider, timeline));
       if (SystemUtils.IS_LINUX) {
          monitors.addMonitor(new RssMonitor(timeline));
+      }
+      // We can't read open files on Windows
+      if (!System.getProperty("os.name").toLowerCase().contains("win")) {
+         monitors.addMonitor(new OpenFilesMonitor(jmxConnectionProvider, timeline));
       }
       if (interfaceName != null) {
          monitors.addMonitor(NetworkBytesMonitor.createReceiveMonitor(interfaceName, timeline));

--- a/core/src/main/java/org/radargun/stages/monitor/MonitorStartStage.java
+++ b/core/src/main/java/org/radargun/stages/monitor/MonitorStartStage.java
@@ -76,12 +76,11 @@ public class MonitorStartStage extends AbstractDistStage {
       monitors.addMonitor(new CpuUsageMonitor(jmxConnectionProvider, timeline));
       monitors.addMonitor(new MemoryUsageMonitor(jmxConnectionProvider, timeline));
       monitors.addMonitor(new GcMonitor(jmxConnectionProvider, timeline));
+      if (!SystemUtils.IS_WINDOWS) {
+         monitors.addMonitor(new OpenFilesMonitor(jmxConnectionProvider, timeline));
+      }
       if (SystemUtils.IS_LINUX) {
          monitors.addMonitor(new RssMonitor(timeline));
-      }
-      // We can't read open files on Windows
-      if (!System.getProperty("os.name").toLowerCase().contains("win")) {
-         monitors.addMonitor(new OpenFilesMonitor(jmxConnectionProvider, timeline));
       }
       if (interfaceName != null) {
          monitors.addMonitor(NetworkBytesMonitor.createReceiveMonitor(interfaceName, timeline));

--- a/core/src/main/java/org/radargun/utils/SystemUtils.java
+++ b/core/src/main/java/org/radargun/utils/SystemUtils.java
@@ -6,6 +6,7 @@ package org.radargun.utils;
 public class SystemUtils {
 
    public static final boolean IS_LINUX = System.getProperty("os.name").toLowerCase().startsWith("linux");
+   public static final boolean IS_WINDOWS = System.getProperty("os.name").toLowerCase().contains("win");
 
    private SystemUtils() {
    }


### PR DESCRIPTION
Hi,
I've been running radargun on Windows and many exceptions occurred with OpenFilesMonitor (https://gist.github.com/sparkoo/d26f359f20683e2b8bde4a218965bbe0). Issue is that java on windows can't do that. There is no windows version of unix's MXBean `UnixOperatingSystemMXBean`. So I've disabled this monitor for windows.
The if condition is not very nice. I can put it to `Utils` class, or `commons.lang` has nicer method `SystemUtils.IS_OS_WINDOWS`, but it's not dependency of `core` module at the moment.