### PR TITLE
Fix for issue 434

### DIFF
--- a/core/src/main/java/org/radargun/sysmonitor/AbstractMonitor.java
+++ b/core/src/main/java/org/radargun/sysmonitor/AbstractMonitor.java
@@ -1,0 +1,31 @@
+package org.radargun.sysmonitor;
+
+/**
+ * 
+ * AbstractMonitor is the base class for all system monitors. It manages the lifecycle of the
+ * monitor, so that no values are written to the reports before the benchmark starts or ends.
+ * 
+ */
+public abstract class AbstractMonitor implements Monitor {
+   protected volatile boolean shouldRun = false;
+
+   @Override
+   public void run() {
+      if (shouldRun) {
+         runMonitor();
+      }
+   }
+
+   @Override
+   public void start() {
+      shouldRun = true;
+   }
+
+   @Override
+   public void stop() {
+      shouldRun = false;
+   }
+
+   public abstract void runMonitor();
+
+}

--- a/core/src/main/java/org/radargun/sysmonitor/AbstractMonitors.java
+++ b/core/src/main/java/org/radargun/sysmonitor/AbstractMonitors.java
@@ -12,6 +12,7 @@ import org.radargun.logging.Log;
 import org.radargun.logging.LogFactory;
 import org.radargun.state.StateBase;
 import org.radargun.state.StateListener;
+import org.radargun.utils.Utils;
 
 /**
  * Base class for holding and maintaining various slave and master state
@@ -73,11 +74,9 @@ public abstract class AbstractMonitors<S extends StateBase<T>, T extends StateLi
       for (Monitor m : monitors) {
          m.stop();
       }
-      exec.shutdownNow();
-      try {
-         exec.awaitTermination(2 * period, TimeUnit.MILLISECONDS);
-      } catch (InterruptedException e) {
-         log.error("Failed to terminate local monitoring.");
+      Utils.shutdownAndWait(exec);
+      if (!exec.isTerminated()) {
+         log.warn("Failed to terminate monitor executor service.");
       }
       this.exec = null;
    }

--- a/core/src/main/java/org/radargun/sysmonitor/CpuUsageMonitor.java
+++ b/core/src/main/java/org/radargun/sysmonitor/CpuUsageMonitor.java
@@ -26,7 +26,7 @@ public class CpuUsageMonitor extends JmxMonitor {
       super(jmxConnectionProvider, timeline);
    }
 
-   public synchronized void run() {
+   public synchronized void runMonitor() {
       try {
          if (connection == null) {
             log.warn("MBean connection is not open, cannot read CPU stats");
@@ -35,7 +35,7 @@ public class CpuUsageMonitor extends JmxMonitor {
 
          long cpuTimeMultiplier = getCpuMultiplier(connection);
          OperatingSystemMXBean os = ManagementFactory.newPlatformMXBeanProxy(connection,
-            ManagementFactory.OPERATING_SYSTEM_MXBEAN_NAME, OperatingSystemMXBean.class);
+               ManagementFactory.OPERATING_SYSTEM_MXBEAN_NAME, OperatingSystemMXBean.class);
          int procCount = os.getAvailableProcessors();
 
          long jmxCpuTime = (Long) connection.getAttribute(OS_NAME, PROCESS_CPU_TIME_ATTR);

--- a/core/src/main/java/org/radargun/sysmonitor/GcMonitor.java
+++ b/core/src/main/java/org/radargun/sysmonitor/GcMonitor.java
@@ -18,8 +18,8 @@ import static java.lang.management.ManagementFactory.GARBAGE_COLLECTOR_MXBEAN_DO
 import static java.lang.management.ManagementFactory.newPlatformMXBeanProxy;
 
 /**
- * In each invocation of the {@link #run()} method, retrieves information
- * about garbage collection from JMX and reports it into the {@link Timeline}.
+ * In each invocation of the {@link #run()} method, retrieves information about garbage collection
+ * from JMX and reports it into the {@link Timeline}.
  *
  * @author Galder Zamarreno
  */
@@ -33,7 +33,7 @@ public class GcMonitor extends JmxMonitor implements Serializable {
       super(jmxConnectionProvider, timeline);
    }
 
-   public synchronized void run() {
+   public synchronized void runMonitor() {
       try {
          if (connection == null) {
             log.warn("MBean connection is not open, cannot read GC stats");
@@ -41,7 +41,7 @@ public class GcMonitor extends JmxMonitor implements Serializable {
          }
 
          OperatingSystemMXBean os = ManagementFactory.newPlatformMXBeanProxy(connection,
-            ManagementFactory.OPERATING_SYSTEM_MXBEAN_NAME, OperatingSystemMXBean.class);
+               ManagementFactory.OPERATING_SYSTEM_MXBEAN_NAME, OperatingSystemMXBean.class);
          int procCount = os.getAvailableProcessors();
 
          List<GarbageCollectorMXBean> gcMbeans = getGarbageCollectorMXBeans(connection);

--- a/core/src/main/java/org/radargun/sysmonitor/InternalsMonitor.java
+++ b/core/src/main/java/org/radargun/sysmonitor/InternalsMonitor.java
@@ -11,7 +11,7 @@ import org.radargun.utils.TimeService;
  *
  * @author Radim Vansa &lt;rvansa@redhat.com&gt;
  */
-public class InternalsMonitor implements Monitor {
+public class InternalsMonitor extends AbstractMonitor {
    private final InternalsExposition internalsExposition;
    private final Timeline timeline;
 
@@ -21,15 +21,7 @@ public class InternalsMonitor implements Monitor {
    }
 
    @Override
-   public void start() {
-   }
-
-   @Override
-   public void stop() {
-   }
-
-   @Override
-   public void run() {
+   public void runMonitor() {
       long now = TimeService.currentTimeMillis();
       for (Map.Entry<String, Number> entry : internalsExposition.getValues().entrySet()) {
          timeline.addValue(Timeline.Category.customCategory(entry.getKey()), new Timeline.Value(now, entry.getValue()));

--- a/core/src/main/java/org/radargun/sysmonitor/JmxMonitor.java
+++ b/core/src/main/java/org/radargun/sysmonitor/JmxMonitor.java
@@ -19,7 +19,7 @@ import org.radargun.traits.JmxConnectionProvider;
  *
  * @author Mircea Markus &lt;Mircea.Markus@jboss.com&gt;
  */
-public abstract class JmxMonitor implements Monitor {
+public abstract class JmxMonitor extends AbstractMonitor {
    protected final Log log = LogFactory.getLog(getClass());
 
    static final ObjectName OS_NAME = getOSName();
@@ -66,6 +66,7 @@ public abstract class JmxMonitor implements Monitor {
 
    @Override
    public synchronized void start() {
+      super.start();
       if (jmxConnectionProvider == null) {
          connection = ManagementFactory.getPlatformMBeanServer();
       } else {
@@ -82,6 +83,7 @@ public abstract class JmxMonitor implements Monitor {
 
    @Override
    public synchronized void stop() {
+      super.stop();
       if (connector != null) {
          try {
             connector.close();

--- a/core/src/main/java/org/radargun/sysmonitor/MemoryUsageMonitor.java
+++ b/core/src/main/java/org/radargun/sysmonitor/MemoryUsageMonitor.java
@@ -9,8 +9,8 @@ import org.radargun.reporting.Timeline;
 import org.radargun.traits.JmxConnectionProvider;
 
 /**
- * In each invocation of the {@link #run()} method, retrieves information
- * about memory size and usage from JMX and reports it into the {@link Timeline}.
+ * In each invocation of the {@link #run()} method, retrieves information about memory size and
+ * usage from JMX and reports it into the {@link Timeline}.
  *
  * @author Galder Zamarreno
  */
@@ -27,21 +27,21 @@ public class MemoryUsageMonitor extends JmxMonitor {
       super(jmxConnectionProvider, timeline);
    }
 
-   public synchronized void run() {
+   public synchronized void runMonitor() {
       try {
          if (connection == null) {
             log.warn("MBean connection is not open, cannot read memory stats");
             return;
          }
 
-         MemoryMXBean memMbean = ManagementFactory.newPlatformMXBeanProxy(connection, ManagementFactory.MEMORY_MXBEAN_NAME,
-            MemoryMXBean.class);
+         MemoryMXBean memMbean = ManagementFactory.newPlatformMXBeanProxy(connection,
+               ManagementFactory.MEMORY_MXBEAN_NAME, MemoryMXBean.class);
          MemoryUsage mem = memMbean.getHeapMemoryUsage();
 
          timeline.addValue(Timeline.Category.sysCategory(MEMORY_USAGE), new Timeline.Value(mem.getUsed() / 1048576));
 
-         log.trace("Memory usage: used=" + formatDecimal(mem.getUsed()) + " B, size=" + formatDecimal(mem.getCommitted())
-            + " B, max=" + formatDecimal(mem.getMax()));
+         log.trace("Memory usage: used=" + formatDecimal(mem.getUsed()) + " B, size="
+               + formatDecimal(mem.getCommitted()) + " B, max=" + formatDecimal(mem.getMax()));
       } catch (Exception e) {
          log.error("Error in JMX memory stats retrieval", e);
       }

--- a/core/src/main/java/org/radargun/sysmonitor/NetworkBytesMonitor.java
+++ b/core/src/main/java/org/radargun/sysmonitor/NetworkBytesMonitor.java
@@ -16,7 +16,7 @@ import org.radargun.reporting.Timeline;
  *
  * @author Alan Field &lt;afield@redhat.com&gt;
  */
-public class NetworkBytesMonitor implements Monitor {
+public class NetworkBytesMonitor extends AbstractMonitor {
 
    private static final int TRANSMIT_BYTES_INDEX = 8;
    private static final int RECEIVE_BYTES_INDEX = 0;
@@ -46,8 +46,9 @@ public class NetworkBytesMonitor implements Monitor {
       return new NetworkBytesMonitor(iface, TRANSMIT_BYTES_INDEX, timeline);
    }
 
-   public void run() {
-      try (FileInputStream inputStream = new FileInputStream("/proc/net/dev"); BufferedReader br = new BufferedReader(new InputStreamReader(inputStream))) {
+   public void runMonitor() {
+      try (FileInputStream inputStream = new FileInputStream("/proc/net/dev");
+         BufferedReader br = new BufferedReader(new InputStreamReader(inputStream))) {
          try {
             String line = br.readLine();
             while (line != null) {
@@ -79,28 +80,23 @@ public class NetworkBytesMonitor implements Monitor {
    }
 
    private Timeline.Category getCategory() {
-      return Timeline.Category.sysCategory(String.format("Network %s on %s [bytes per second]", valueIndex == TRANSMIT_BYTES_INDEX ? "TX" : "RX", iface));
-   }
-
-   @Override
-   public void start() {
-      // nothing to do
-   }
-
-   @Override
-   public void stop() {
-      // nothing to do
+      return Timeline.Category.sysCategory(String.format("Network %s on %s [bytes per second]",
+            valueIndex == TRANSMIT_BYTES_INDEX ? "TX" : "RX", iface));
    }
 
    @Override
    public boolean equals(Object o) {
-      if (this == o) return true;
-      if (o == null || getClass() != o.getClass()) return false;
+      if (this == o)
+         return true;
+      if (o == null || getClass() != o.getClass())
+         return false;
 
       NetworkBytesMonitor that = (NetworkBytesMonitor) o;
 
-      if (valueIndex != that.valueIndex) return false;
-      if (!iface.equals(that.iface)) return false;
+      if (valueIndex != that.valueIndex)
+         return false;
+      if (!iface.equals(that.iface))
+         return false;
 
       return true;
    }

--- a/core/src/main/java/org/radargun/sysmonitor/OpenFilesMonitor.java
+++ b/core/src/main/java/org/radargun/sysmonitor/OpenFilesMonitor.java
@@ -20,15 +20,15 @@ public class OpenFilesMonitor extends JmxMonitor {
       super(jmxConnectionProvider, timeline);
    }
 
-   public synchronized void run() {
+   public synchronized void runMonitor() {
       try {
          if (connection == null) {
             log.warn("MBean connection is not open, cannot read open files stats");
             return;
          }
 
-         OperatingSystemMXBean osBean = ManagementFactory.newPlatformMXBeanProxy(connection, ManagementFactory.OPERATING_SYSTEM_MXBEAN_NAME,
-            OperatingSystemMXBean.class);
+         OperatingSystemMXBean osBean = ManagementFactory.newPlatformMXBeanProxy(connection,
+               ManagementFactory.OPERATING_SYSTEM_MXBEAN_NAME, OperatingSystemMXBean.class);
          Long openFiles = (Long) connection.getAttribute(osBean.getObjectName(), OPEN_FILE_DESCRIPTOR_COUNT);
          Long maxOpenFiles = (Long) connection.getAttribute(osBean.getObjectName(), MAX_FILE_DESCRIPTOR_COUNT);
          if (openFiles != null) {
@@ -52,4 +52,3 @@ public class OpenFilesMonitor extends JmxMonitor {
       timeline.addValue(Timeline.Category.sysCategory(OPEN_FILES), new Timeline.Value(0));
    }
 }
-

--- a/core/src/main/java/org/radargun/sysmonitor/RssMonitor.java
+++ b/core/src/main/java/org/radargun/sysmonitor/RssMonitor.java
@@ -9,7 +9,7 @@ import java.io.Reader;
 import org.radargun.reporting.Timeline;
 import org.radargun.utils.Utils;
 
-public class RssMonitor implements Monitor {
+public class RssMonitor extends AbstractMonitor {
 
    private static final String RSS_MEMORY_USAGE = "RSS Memory usage";
    private final Timeline timeline;
@@ -19,22 +19,15 @@ public class RssMonitor implements Monitor {
    }
 
    @Override
-   public void start() {
-   }
-
-   @Override
-   public void stop() {
-   }
-
-   @Override
-   public void run() {
+   public void runMonitor() {
       Process process = null;
       try {
          process = createProcess();
          Long rssUsage = getRssUsageFrom(process);
          timeline.addValue(Timeline.Category.sysCategory(RSS_MEMORY_USAGE), new Timeline.Value(rssUsage));
       } finally {
-         if (process != null) process.destroy();
+         if (process != null)
+            process.destroy();
       }
    }
 
@@ -49,8 +42,8 @@ public class RssMonitor implements Monitor {
    private Long getRssUsageFrom(Process process) {
       Long rssUsage;
       try (InputStream inputStream = process.getInputStream();
-           Reader inputStreamReader = new InputStreamReader(inputStream);
-           BufferedReader bufferedReader = new BufferedReader(inputStreamReader)) {
+         Reader inputStreamReader = new InputStreamReader(inputStream);
+         BufferedReader bufferedReader = new BufferedReader(inputStreamReader)) {
          rssUsage = Long.valueOf(bufferedReader.readLine());
       } catch (Exception e) {
          throw new IllegalStateException("Error in rss stats retrieval", e);

--- a/core/src/main/java/org/radargun/utils/Utils.java
+++ b/core/src/main/java/org/radargun/utils/Utils.java
@@ -173,13 +173,16 @@ public class Utils {
    }
 
    public static void shutdownAndWait(ExecutorService executor) {
-      executor.shutdownNow();
-      try {
-         if (!executor.awaitTermination(10, TimeUnit.SECONDS)) {
-            log.error("Failed to terminate executor.");
+      List<Runnable> tasks = executor.shutdownNow();
+      if (!tasks.isEmpty()) {
+         log.info(String.format("Waiting for '%s' tasks to terminate.", tasks.size()));
+         try {
+            if (!executor.awaitTermination(30, TimeUnit.SECONDS)) {
+               log.error("Failed to terminate executor.");
+            }
+         } catch (InterruptedException e) {
+            log.error("Interrupted when waiting for the executor to finish.");
          }
-      } catch (InterruptedException e) {
-         log.error("Interrupted when waiting for the executor to finish.");
       }
    }
 


### PR DESCRIPTION
https://github.com/radargun/radargun/issues/434

I've addressed this issue with three changes:

1) Increase the timeout in `Utils.shutdownAndWait()` to 30 seconds

2) Call `Utils.shutdownAndWait()` on the `ExecutorService` used by
statistics and monitors

3) Restructure the monitors code to add no more entries to the
TimelineDocument after `stop()` is called

I've verified that this fix stops the
`java.util.ConcurrentModificationException` from happening