### PR TITLE
Coordinated omission using sync mode

### DIFF
--- a/core/src/main/java/org/radargun/stages/test/TestStage.java
+++ b/core/src/main/java/org/radargun/stages/test/TestStage.java
@@ -61,11 +61,14 @@ public abstract class TestStage extends BaseTestStage {
    @Property(doc = "Delay to let all threads start executing operations. Default is 0.", converter = TimeConverter.class)
    public long rampUp = 0;
 
-   @Property(converter = TimeConverter.class, doc = "Time between consecutive requests of one stressor thread. Default is 0.")
-   protected long delayBetweenRequests = 0;
+   @Property(converter = TimeConverter.class, doc = "Time between consecutive requests of one stressor thread. Default is 0.", deprecatedName = "delayBetweenRequests")
+   protected long thinkTime = 0;
 
    @Property(doc = "Whether an error from transaction commit/rollback should be logged as error. Default is true.")
    public boolean logTransactionExceptions = true;
+
+   @Property(converter = TimeConverter.class, doc = "Intended time between each request. Default is 0.")
+   protected long cycleTime = 0;
 
    @InjectTrait
    protected Transactional transactional;
@@ -90,6 +93,7 @@ public abstract class TestStage extends BaseTestStage {
       if (totalThreads > 0 && numThreadsPerNode > 0)
          throw new IllegalStateException("You have to set only one ot total-threads, num-threads-per-node");
       if (totalThreads < 0 || numThreadsPerNode < 0) throw new IllegalStateException("Number of threads can't be < 0");
+      if (cycleTime > 0 && thinkTime > 0) throw new IllegalStateException("We cannot mix cycleTime and thinkTime");
    }
 
    public DistStageAck executeOnSlave() {
@@ -252,7 +256,7 @@ public abstract class TestStage extends BaseTestStage {
 
       List<Stressor> stressors = new ArrayList<>();
       for (int threadIndex = stressors.size(); threadIndex < myNumThreads; threadIndex++) {
-         Stressor stressor = new Stressor(this, getLogic(), myFirstThread + threadIndex, threadIndex, logTransactionExceptions, threadCountDown, delayBetweenRequests);
+         Stressor stressor = new Stressor(this, getLogic(), myFirstThread + threadIndex, threadIndex, threadCountDown);
          stressors.add(stressor);
          stressor.start();
       }

--- a/core/src/main/java/org/radargun/stats/Message.java
+++ b/core/src/main/java/org/radargun/stats/Message.java
@@ -46,4 +46,8 @@ public final class Message {
    public long totalTime() {
       return TimeUnit.MILLISECONDS.toNanos(receiveCompleteTime - sendStartTime);
    }
+
+   public long getReceiveCompleteTime() {
+      return receiveCompleteTime;
+   }
 }

--- a/core/src/main/java/org/radargun/stats/Request.java
+++ b/core/src/main/java/org/radargun/stats/Request.java
@@ -22,8 +22,12 @@ public final class Request {
    private boolean successful = true;
 
    public Request(Statistics statistics) {
+      this(statistics, TimeService.nanoTime());
+   }
+
+   public Request(Statistics statistics, long requestStartTime) {
       this.statistics = statistics;
-      this.requestStartTime = TimeService.nanoTime();
+      this.requestStartTime = requestStartTime;
    }
 
    public void exec(Operation operation, Runnable runnable) {
@@ -62,7 +66,7 @@ public final class Request {
          successful = false;
          throw t;
       } finally {
-         statistics.record(this, operation);
+         record(operation);
       }
       return value;
    }
@@ -73,14 +77,12 @@ public final class Request {
 //   public void responseStarted() {}
 
    public void succeeded(Operation operation) {
-      this.responseCompleteTime = TimeService.nanoTime();
-      statistics.record(this, operation);
+      record(operation);
    }
 
    public void failed(Operation operation) {
-      this.responseCompleteTime = TimeService.nanoTime();
       this.successful = false;
-      statistics.record(this, operation);
+      record(operation);
    }
 
    public void discard() {
@@ -108,5 +110,10 @@ public final class Request {
     */
    public long duration() {
       return responseCompleteTime - requestStartTime;
+   }
+
+   private void record(Operation operation) {
+      this.responseCompleteTime = TimeService.nanoTime();
+      statistics.record(this, operation);
    }
 }

--- a/core/src/main/java/org/radargun/stats/RequestSet.java
+++ b/core/src/main/java/org/radargun/stats/RequestSet.java
@@ -58,4 +58,8 @@ public final class RequestSet {
    public boolean isSuccessful() {
       return successful;
    }
+
+   public long getEnd() {
+      return end;
+   }
 }

--- a/core/src/main/java/org/radargun/stats/Statistics.java
+++ b/core/src/main/java/org/radargun/stats/Statistics.java
@@ -74,6 +74,10 @@ public interface Statistics extends Serializable {
       return new Request(this);
    }
 
+   default Request startRequest(long requestStartTime) {
+      return new Request(this, requestStartTime);
+   }
+
    /**
     * Create an object for tracking non-rpc-like operations.
     */

--- a/core/src/main/java/org/radargun/utils/Utils.java
+++ b/core/src/main/java/org/radargun/utils/Utils.java
@@ -396,6 +396,7 @@ public class Utils {
       int hours = duration.indexOf('H');
       int minutes = duration.indexOf('M');
       int seconds = duration.indexOf('S');
+      int millis = duration.indexOf('L');
       int lastIndex = 0;
       try {
          if (days > 0) {
@@ -413,6 +414,10 @@ public class Utils {
          if (seconds > 0) {
             durationMillis += TimeUnit.SECONDS.toMillis(Long.parseLong(duration.substring(lastIndex, seconds).trim()));
             lastIndex = seconds + 1;
+         }
+         if (millis > 0) {
+            durationMillis += TimeUnit.MILLISECONDS.toMillis(Long.parseLong(duration.substring(lastIndex, millis).trim()));
+            lastIndex = millis + 1;
          }
          if (lastIndex < duration.length()) {
             durationMillis += Long.parseLong(duration.substring(lastIndex));

--- a/docs/other_docs/failover_tests.md
+++ b/docs/other_docs/failover_tests.md
@@ -8,7 +8,7 @@ This page should describe the operations executed using **BackgroundOperationsMa
 
 ### BackgroundStressorLogic and LogValues
 
-Initially we have used tactics known now as BackgroundStressorLogic: we spawn several threads issuing a put/get operation every 100 ms (check property delayBetweenRequests scoped into GeneralConfiguration) - those threads are not terminated after the end of the stage but kept working on the background. There are another threads to retrieve and record statistics. In order to check whether the cache has all entries, we have used CheckCacheDataStage. 
+Initially we have used tactics known now as BackgroundStressorLogic: we spawn several threads issuing a put/get operation every 100 ms (check property thinkTime scoped into GeneralConfiguration) - those threads are not terminated after the end of the stage but kept working on the background. There are another threads to retrieve and record statistics. In order to check whether the cache has all entries, we have used CheckCacheDataStage.
 
 This approach works for checking the lag of response times, see how the throughput drops when one node crashes etc. That makes use of this 'BackgroundStressorLogic' valid for cases, where we want to check the performance during failover.
 

--- a/docs/stages/cache.md
+++ b/docs/stages/cache.md
@@ -122,7 +122,7 @@ Test using BasicOperations
 > cache-selector (**optional**) - Selects which caches will be used in the test. By default the selector is retrieved from slave state.  
 > commit-transactions (**optional**) - Specifies whether the transactions should be committed (true) or rolled back (false). Default is true  
 > contains-ratio (**optional**) - Ratio of CONTAINS requests. Default is 0.  
-> delay-between-requests (**optional**) - Time between consecutive requests of one stressor thread. Default is 0.  
+> cycle-time (**optional**) - Intended time between each request. Default is 0.  
 > duration (**optional**) - Benchmark duration. You have to set either this or 'totalNumOperations'.  
 > entry-size (**optional**) - Size of the value in bytes. Default is 1000.  
 > exit-on-failure (**optional**) - If true, then the benchmark stops when the stage returns an error. If false, then the stages in the current scenario are skipped, and the next scenario starts executing. Default is false.  
@@ -146,6 +146,7 @@ Test using BasicOperations
 > statistics (**optional**) - Type of gathered statistics. Default are the 'default' statistics (fixed size memory footprint for each operation).  
 > synchronous-requests (**optional**) - Local threads synchronize on starting each round of requests. Note that with requestPeriod > 0, there is still the random ramp-up delay. Default is false.  
 > test-name (**optional**) - Name of the test as used for reporting. Default is 'Test'.  
+> think-time (**optional**) - Time between consecutive requests of one stressor thread. Default is 0.  
 > timeout (**optional**) - Max duration of the test. Default is infinite.  
 > total-threads (**optional**) - Total number of threads across whole cluster. You have to set either this or 'num-threads-per-node'. No default.  
 > transaction-size (**optional**) - Number of requests in one transaction. Default is 1.  
@@ -158,7 +159,7 @@ Executes operations from BulkOperations trait.
 > bulk-size (**optional**) - Number of keys inserted/retrieved within one operation. Applicable only when the cache wrapper supports bulk operations. Default is 10.  
 > cache-selector (**optional**) - Selects which caches will be used in the test. By default the selector is retrieved from slave state.  
 > commit-transactions (**optional**) - Specifies whether the transactions should be committed (true) or rolled back (false). Default is true  
-> delay-between-requests (**optional**) - Time between consecutive requests of one stressor thread. Default is 0.  
+> cycle-time (**optional**) - Intended time between each request. Default is 0.  
 > duration (**optional**) - Benchmark duration. You have to set either this or 'totalNumOperations'.  
 > entry-size (**optional**) - Size of the value in bytes. Default is 1000.  
 > exit-on-failure (**optional**) - If true, then the benchmark stops when the stage returns an error. If false, then the stages in the current scenario are skipped, and the next scenario starts executing. Default is false.  
@@ -183,6 +184,7 @@ Executes operations from BulkOperations trait.
 > statistics (**optional**) - Type of gathered statistics. Default are the 'default' statistics (fixed size memory footprint for each operation).  
 > synchronous-requests (**optional**) - Local threads synchronize on starting each round of requests. Note that with requestPeriod > 0, there is still the random ramp-up delay. Default is false.  
 > test-name (**optional**) - Name of the test as used for reporting. Default is 'Test'.  
+> think-time (**optional**) - Time between consecutive requests of one stressor thread. Default is 0.  
 > timeout (**optional**) - Max duration of the test. Default is infinite.  
 > total-threads (**optional**) - Total number of threads across whole cluster. You have to set either this or 'num-threads-per-node'. No default.  
 > transaction-size (**optional**) - Number of requests in one transaction. Default is 1.  
@@ -263,7 +265,7 @@ Tests (atomic) conditional operations. Note that there is no put-if-absent-ratio
 > amend-test (**optional**) - By default, each stage creates a new test. If this property is set to true,results are amended to existing test (as iterations). Default is false.  
 > cache-selector (**optional**) - Selects which caches will be used in the test. By default the selector is retrieved from slave state.  
 > commit-transactions (**optional**) - Specifies whether the transactions should be committed (true) or rolled back (false). Default is true  
-> delay-between-requests (**optional**) - Time between consecutive requests of one stressor thread. Default is 0.  
+> cycle-time (**optional**) - Intended time between each request. Default is 0.  
 > duration (**optional**) - Benchmark duration. You have to set either this or 'totalNumOperations'.  
 > entry-size (**optional**) - Size of the value in bytes. Default is 1000.  
 > exit-on-failure (**optional**) - If true, then the benchmark stops when the stage returns an error. If false, then the stages in the current scenario are skipped, and the next scenario starts executing. Default is false.  
@@ -287,6 +289,7 @@ Tests (atomic) conditional operations. Note that there is no put-if-absent-ratio
 > statistics (**optional**) - Type of gathered statistics. Default are the 'default' statistics (fixed size memory footprint for each operation).  
 > synchronous-requests (**optional**) - Local threads synchronize on starting each round of requests. Note that with requestPeriod > 0, there is still the random ramp-up delay. Default is false.  
 > test-name (**optional**) - Name of the test as used for reporting. Default is 'Test'.  
+> think-time (**optional**) - Time between consecutive requests of one stressor thread. Default is 0.  
 > timeout (**optional**) - Max duration of the test. Default is infinite.  
 > total-threads (**optional**) - Total number of threads across whole cluster. You have to set either this or 'num-threads-per-node'. No default.  
 > transaction-size (**optional**) - Number of requests in one transaction. Default is 1.  
@@ -326,7 +329,7 @@ Iterates through all entries.
 > container-name (**optional**) - Name of the container (e.g. cache, DB table etc.) that should be iterated. Default is the default container.  
 > converter-class (**optional**) - Full class name of the converter. Default is no converter (Map.Entry<K, V> is returned).  
 > converter-param (**optional**) - Parameter for the converter (used to resolve its properties). No defaults.  
-> delay-between-requests (**optional**) - Time between consecutive requests of one stressor thread. Default is 0.  
+> cycle-time (**optional**) - Intended time between each request. Default is 0.  
 > duration (**optional**) - Benchmark duration. You have to set either this or 'totalNumOperations'.  
 > exit-on-failure (**optional**) - If true, then the benchmark stops when the stage returns an error. If false, then the stages in the current scenario are skipped, and the next scenario starts executing. Default is false.  
 > fail-on-failed-iteration (**optional**) - Fail the stage if some of the stressors has failed. Default is true.  
@@ -348,6 +351,7 @@ Iterates through all entries.
 > statistics (**optional**) - Type of gathered statistics. Default are the 'default' statistics (fixed size memory footprint for each operation).  
 > synchronous-requests (**optional**) - Local threads synchronize on starting each round of requests. Note that with requestPeriod > 0, there is still the random ramp-up delay. Default is false.  
 > test-name (**optional**) - Name of the test as used for reporting. Default is 'Test'.  
+> think-time (**optional**) - Time between consecutive requests of one stressor thread. Default is 0.  
 > timeout (**optional**) - Max duration of the test. Default is infinite.  
 > total-threads (**optional**) - Total number of threads across whole cluster. You have to set either this or 'num-threads-per-node'. No default.  
 > transaction-size (**optional**) - Number of requests in one transaction. Default is 1.  
@@ -358,7 +362,7 @@ During execution, keys expire (entries are removed from the cache) and new keys 
 > amend-test (**optional**) - By default, each stage creates a new test. If this property is set to true,results are amended to existing test (as iterations). Default is false.  
 > cache-selector (**optional**) - Selects which caches will be used in the test. By default the selector is retrieved from slave state.  
 > commit-transactions (**optional**) - Specifies whether the transactions should be committed (true) or rolled back (false). Default is true  
-> delay-between-requests (**optional**) - Time between consecutive requests of one stressor thread. Default is 0.  
+> cycle-time (**optional**) - Intended time between each request. Default is 0.  
 > duration (**optional**) - Benchmark duration. You have to set either this or 'totalNumOperations'.  
 > entry-lifespan (**optional**) - With fixedKeys=false, maximum lifespan of an entry. Default is 1 hour.  
 > entry-size (**optional**) - Size of the value in bytes. Default is 1000.  
@@ -382,6 +386,7 @@ During execution, keys expire (entries are removed from the cache) and new keys 
 > statistics (**optional**) - Type of gathered statistics. Default are the 'default' statistics (fixed size memory footprint for each operation).  
 > synchronous-requests (**optional**) - Local threads synchronize on starting each round of requests. Note that with requestPeriod > 0, there is still the random ramp-up delay. Default is false.  
 > test-name (**optional**) - Name of the test as used for reporting. Default is 'Test'.  
+> think-time (**optional**) - Time between consecutive requests of one stressor thread. Default is 0.  
 > timeout (**optional**) - Max duration of the test. Default is infinite.  
 > total-threads (**optional**) - Total number of threads across whole cluster. You have to set either this or 'num-threads-per-node'. No default.  
 > transaction-size (**optional**) - Number of requests in one transaction. Default is 1.  
@@ -508,7 +513,7 @@ Streaming operations test stage
 > buffer-size (**optional**) - Streaming operations buffer size in bytes, default is 100  
 > cache-selector (**optional**) - Selects which caches will be used in the test. By default the selector is retrieved from slave state.  
 > commit-transactions (**optional**) - Specifies whether the transactions should be committed (true) or rolled back (false). Default is true  
-> delay-between-requests (**optional**) - Time between consecutive requests of one stressor thread. Default is 0.  
+> cycle-time (**optional**) - Intended time between each request. Default is 0.  
 > duration (**optional**) - Benchmark duration. You have to set either this or 'totalNumOperations'.  
 > entry-size (**optional**) - Size of the value in bytes. Default is 1000.  
 > exit-on-failure (**optional**) - If true, then the benchmark stops when the stage returns an error. If false, then the stages in the current scenario are skipped, and the next scenario starts executing. Default is false.  
@@ -529,6 +534,7 @@ Streaming operations test stage
 > statistics (**optional**) - Type of gathered statistics. Default are the 'default' statistics (fixed size memory footprint for each operation).  
 > synchronous-requests (**optional**) - Local threads synchronize on starting each round of requests. Note that with requestPeriod > 0, there is still the random ramp-up delay. Default is false.  
 > test-name (**optional**) - Name of the test as used for reporting. Default is 'Test'.  
+> think-time (**optional**) - Time between consecutive requests of one stressor thread. Default is 0.  
 > timeout (**optional**) - Max duration of the test. Default is infinite.  
 > total-threads (**optional**) - Total number of threads across whole cluster. You have to set either this or 'num-threads-per-node'. No default.  
 > transaction-size (**optional**) - Number of requests in one transaction. Default is 1.  
@@ -540,7 +546,7 @@ Test using TemporalOperations
 > amend-test (**optional**) - By default, each stage creates a new test. If this property is set to true,results are amended to existing test (as iterations). Default is false.  
 > cache-selector (**optional**) - Selects which caches will be used in the test. By default the selector is retrieved from slave state.  
 > commit-transactions (**optional**) - Specifies whether the transactions should be committed (true) or rolled back (false). Default is true  
-> delay-between-requests (**optional**) - Time between consecutive requests of one stressor thread. Default is 0.  
+> cycle-time (**optional**) - Intended time between each request. Default is 0.  
 > duration (**optional**) - Benchmark duration. You have to set either this or 'totalNumOperations'.  
 > entry-size (**optional**) - Size of the value in bytes. Default is 1000.  
 > exit-on-failure (**optional**) - If true, then the benchmark stops when the stage returns an error. If false, then the stages in the current scenario are skipped, and the next scenario starts executing. Default is false.  
@@ -568,6 +574,7 @@ Test using TemporalOperations
 > statistics (**optional**) - Type of gathered statistics. Default are the 'default' statistics (fixed size memory footprint for each operation).  
 > synchronous-requests (**optional**) - Local threads synchronize on starting each round of requests. Note that with requestPeriod > 0, there is still the random ramp-up delay. Default is false.  
 > test-name (**optional**) - Name of the test as used for reporting. Default is 'Test'.  
+> think-time (**optional**) - Time between consecutive requests of one stressor thread. Default is 0.  
 > timeout (**optional**) - Max duration of the test. Default is infinite.  
 > total-threads (**optional**) - Total number of threads across whole cluster. You have to set either this or 'num-threads-per-node'. No default.  
 > transaction-size (**optional**) - Number of requests in one transaction. Default is 1.  

--- a/docs/stages/counter.md
+++ b/docs/stages/counter.md
@@ -20,7 +20,7 @@ Tests a clustered/distributed counter
 > amend-test (**optional**) - By default, each stage creates a new test. If this property is set to true,results are amended to existing test (as iterations). Default is false.  
 > commit-transactions (**optional**) - Specifies whether the transactions should be committed (true) or rolled back (false). Default is true  
 > counter-name (**mandatory**) - Counter name.  
-> delay-between-requests (**optional**) - Time between consecutive requests of one stressor thread. Default is 0.  
+> cycle-time (**optional**) - Intended time between each request. Default is 0.  
 > delta (**optional**) - Delta to add for addAndGet operation. Default is 1.  
 > duration (**optional**) - Benchmark duration. You have to set either this or 'totalNumOperations'.  
 > exit-on-failure (**optional**) - If true, then the benchmark stops when the stage returns an error. If false, then the stages in the current scenario are skipped, and the next scenario starts executing. Default is false.  
@@ -39,6 +39,7 @@ Tests a clustered/distributed counter
 > statistics (**optional**) - Type of gathered statistics. Default are the 'default' statistics (fixed size memory footprint for each operation).  
 > synchronous-requests (**optional**) - Local threads synchronize on starting each round of requests. Note that with requestPeriod > 0, there is still the random ramp-up delay. Default is false.  
 > test-name (**optional**) - Name of the test as used for reporting. Default is 'Test'.  
+> think-time (**optional**) - Time between consecutive requests of one stressor thread. Default is 0.  
 > timeout (**optional**) - Max duration of the test. Default is infinite.  
 > total-threads (**optional**) - Total number of threads across whole cluster. You have to set either this or 'num-threads-per-node'. No default.  
 > transaction-size (**optional**) - Number of requests in one transaction. Default is 1.  

--- a/docs/stages/legacy.md
+++ b/docs/stages/legacy.md
@@ -12,7 +12,7 @@ Test using BasicOperations
 > cache-selector (**optional**) - Selects which caches will be used in the test. By default the selector is retrieved from slave state.  
 > commit-transactions (**optional**) - Specifies whether the transactions should be committed (true) or rolled back (false). Default is true  
 > contains-ratio (**optional**) - Ratio of CONTAINS requests. Default is 0.  
-> delay-between-requests (**optional**) - Time between consecutive requests of one stressor thread. Default is 0.  
+> cycle-time (**optional**) - Intended time between each request. Default is 0.  
 > duration (**optional**) - Benchmark duration. You have to set either this or 'totalNumOperations'.  
 > entry-size (**optional**) - Size of the value in bytes. Default is 1000.  
 > exit-on-failure (**optional**) - If true, then the benchmark stops when the stage returns an error. If false, then the stages in the current scenario are skipped, and the next scenario starts executing. Default is false.  
@@ -36,6 +36,7 @@ Test using BasicOperations
 > statistics (**optional**) - Type of gathered statistics. Default are the 'default' statistics (fixed size memory footprint for each operation).  
 > synchronous-requests (**optional**) - Local threads synchronize on starting each round of requests. Note that with requestPeriod > 0, there is still the random ramp-up delay. Default is false.  
 > test-name (**optional**) - Name of the test as used for reporting. Default is 'Test'.  
+> think-time (**optional**) - Time between consecutive requests of one stressor thread. Default is 0.  
 > timeout (**optional**) - Max duration of the test. Default is infinite.  
 > total-threads (**optional**) - Total number of threads across whole cluster. You have to set either this or 'num-threads-per-node'. No default.  
 > transaction-size (**optional**) - Number of requests in one transaction. Default is 1.  
@@ -48,7 +49,7 @@ Executes operations from BulkOperations trait.
 > bulk-size (**optional**) - Number of keys inserted/retrieved within one operation. Applicable only when the cache wrapper supports bulk operations. Default is 10.  
 > cache-selector (**optional**) - Selects which caches will be used in the test. By default the selector is retrieved from slave state.  
 > commit-transactions (**optional**) - Specifies whether the transactions should be committed (true) or rolled back (false). Default is true  
-> delay-between-requests (**optional**) - Time between consecutive requests of one stressor thread. Default is 0.  
+> cycle-time (**optional**) - Intended time between each request. Default is 0.  
 > duration (**optional**) - Benchmark duration. You have to set either this or 'totalNumOperations'.  
 > entry-size (**optional**) - Size of the value in bytes. Default is 1000.  
 > exit-on-failure (**optional**) - If true, then the benchmark stops when the stage returns an error. If false, then the stages in the current scenario are skipped, and the next scenario starts executing. Default is false.  
@@ -73,6 +74,7 @@ Executes operations from BulkOperations trait.
 > statistics (**optional**) - Type of gathered statistics. Default are the 'default' statistics (fixed size memory footprint for each operation).  
 > synchronous-requests (**optional**) - Local threads synchronize on starting each round of requests. Note that with requestPeriod > 0, there is still the random ramp-up delay. Default is false.  
 > test-name (**optional**) - Name of the test as used for reporting. Default is 'Test'.  
+> think-time (**optional**) - Time between consecutive requests of one stressor thread. Default is 0.  
 > timeout (**optional**) - Max duration of the test. Default is infinite.  
 > total-threads (**optional**) - Total number of threads across whole cluster. You have to set either this or 'num-threads-per-node'. No default.  
 > transaction-size (**optional**) - Number of requests in one transaction. Default is 1.  
@@ -84,7 +86,7 @@ Tests (atomic) conditional operations. Note that there is no put-if-absent-ratio
 > amend-test (**optional**) - By default, each stage creates a new test. If this property is set to true,results are amended to existing test (as iterations). Default is false.  
 > cache-selector (**optional**) - Selects which caches will be used in the test. By default the selector is retrieved from slave state.  
 > commit-transactions (**optional**) - Specifies whether the transactions should be committed (true) or rolled back (false). Default is true  
-> delay-between-requests (**optional**) - Time between consecutive requests of one stressor thread. Default is 0.  
+> cycle-time (**optional**) - Intended time between each request. Default is 0.  
 > duration (**optional**) - Benchmark duration. You have to set either this or 'totalNumOperations'.  
 > entry-size (**optional**) - Size of the value in bytes. Default is 1000.  
 > exit-on-failure (**optional**) - If true, then the benchmark stops when the stage returns an error. If false, then the stages in the current scenario are skipped, and the next scenario starts executing. Default is false.  
@@ -108,6 +110,7 @@ Tests (atomic) conditional operations. Note that there is no put-if-absent-ratio
 > statistics (**optional**) - Type of gathered statistics. Default are the 'default' statistics (fixed size memory footprint for each operation).  
 > synchronous-requests (**optional**) - Local threads synchronize on starting each round of requests. Note that with requestPeriod > 0, there is still the random ramp-up delay. Default is false.  
 > test-name (**optional**) - Name of the test as used for reporting. Default is 'Test'.  
+> think-time (**optional**) - Time between consecutive requests of one stressor thread. Default is 0.  
 > timeout (**optional**) - Max duration of the test. Default is infinite.  
 > total-threads (**optional**) - Total number of threads across whole cluster. You have to set either this or 'num-threads-per-node'. No default.  
 > transaction-size (**optional**) - Number of requests in one transaction. Default is 1.  
@@ -119,7 +122,7 @@ During execution, keys expire (entries are removed from the cache) and new keys 
 > amend-test (**optional**) - By default, each stage creates a new test. If this property is set to true,results are amended to existing test (as iterations). Default is false.  
 > cache-selector (**optional**) - Selects which caches will be used in the test. By default the selector is retrieved from slave state.  
 > commit-transactions (**optional**) - Specifies whether the transactions should be committed (true) or rolled back (false). Default is true  
-> delay-between-requests (**optional**) - Time between consecutive requests of one stressor thread. Default is 0.  
+> cycle-time (**optional**) - Intended time between each request. Default is 0.  
 > duration (**optional**) - Benchmark duration. You have to set either this or 'totalNumOperations'.  
 > entry-lifespan (**optional**) - With fixedKeys=false, maximum lifespan of an entry. Default is 1 hour.  
 > entry-size (**optional**) - Size of the value in bytes. Default is 1000.  
@@ -143,6 +146,7 @@ During execution, keys expire (entries are removed from the cache) and new keys 
 > statistics (**optional**) - Type of gathered statistics. Default are the 'default' statistics (fixed size memory footprint for each operation).  
 > synchronous-requests (**optional**) - Local threads synchronize on starting each round of requests. Note that with requestPeriod > 0, there is still the random ramp-up delay. Default is false.  
 > test-name (**optional**) - Name of the test as used for reporting. Default is 'Test'.  
+> think-time (**optional**) - Time between consecutive requests of one stressor thread. Default is 0.  
 > timeout (**optional**) - Max duration of the test. Default is infinite.  
 > total-threads (**optional**) - Total number of threads across whole cluster. You have to set either this or 'num-threads-per-node'. No default.  
 > transaction-size (**optional**) - Number of requests in one transaction. Default is 1.  
@@ -155,7 +159,7 @@ Streaming operations test stage
 > buffer-size (**optional**) - Streaming operations buffer size in bytes, default is 100  
 > cache-selector (**optional**) - Selects which caches will be used in the test. By default the selector is retrieved from slave state.  
 > commit-transactions (**optional**) - Specifies whether the transactions should be committed (true) or rolled back (false). Default is true  
-> delay-between-requests (**optional**) - Time between consecutive requests of one stressor thread. Default is 0.  
+> cycle-time (**optional**) - Intended time between each request. Default is 0.  
 > duration (**optional**) - Benchmark duration. You have to set either this or 'totalNumOperations'.  
 > entry-size (**optional**) - Size of the value in bytes. Default is 1000.  
 > exit-on-failure (**optional**) - If true, then the benchmark stops when the stage returns an error. If false, then the stages in the current scenario are skipped, and the next scenario starts executing. Default is false.  
@@ -176,6 +180,7 @@ Streaming operations test stage
 > statistics (**optional**) - Type of gathered statistics. Default are the 'default' statistics (fixed size memory footprint for each operation).  
 > synchronous-requests (**optional**) - Local threads synchronize on starting each round of requests. Note that with requestPeriod > 0, there is still the random ramp-up delay. Default is false.  
 > test-name (**optional**) - Name of the test as used for reporting. Default is 'Test'.  
+> think-time (**optional**) - Time between consecutive requests of one stressor thread. Default is 0.  
 > timeout (**optional**) - Max duration of the test. Default is infinite.  
 > total-threads (**optional**) - Total number of threads across whole cluster. You have to set either this or 'num-threads-per-node'. No default.  
 > transaction-size (**optional**) - Number of requests in one transaction. Default is 1.  
@@ -187,7 +192,7 @@ Test using TemporalOperations
 > amend-test (**optional**) - By default, each stage creates a new test. If this property is set to true,results are amended to existing test (as iterations). Default is false.  
 > cache-selector (**optional**) - Selects which caches will be used in the test. By default the selector is retrieved from slave state.  
 > commit-transactions (**optional**) - Specifies whether the transactions should be committed (true) or rolled back (false). Default is true  
-> delay-between-requests (**optional**) - Time between consecutive requests of one stressor thread. Default is 0.  
+> cycle-time (**optional**) - Intended time between each request. Default is 0.  
 > duration (**optional**) - Benchmark duration. You have to set either this or 'totalNumOperations'.  
 > entry-size (**optional**) - Size of the value in bytes. Default is 1000.  
 > exit-on-failure (**optional**) - If true, then the benchmark stops when the stage returns an error. If false, then the stages in the current scenario are skipped, and the next scenario starts executing. Default is false.  
@@ -215,6 +220,7 @@ Test using TemporalOperations
 > statistics (**optional**) - Type of gathered statistics. Default are the 'default' statistics (fixed size memory footprint for each operation).  
 > synchronous-requests (**optional**) - Local threads synchronize on starting each round of requests. Note that with requestPeriod > 0, there is still the random ramp-up delay. Default is false.  
 > test-name (**optional**) - Name of the test as used for reporting. Default is 'Test'.  
+> think-time (**optional**) - Time between consecutive requests of one stressor thread. Default is 0.  
 > timeout (**optional**) - Max duration of the test. Default is infinite.  
 > total-threads (**optional**) - Total number of threads across whole cluster. You have to set either this or 'num-threads-per-node'. No default.  
 > transaction-size (**optional**) - Number of requests in one transaction. Default is 1.  

--- a/docs/stages/multimap.md
+++ b/docs/stages/multimap.md
@@ -14,7 +14,7 @@ Test using MiltimapCacheOperations
 > contains-entry-ratio (**optional**) - Ratio of CONTAINS_ENTRY requests. Default is 0.  
 > contains-key-ratio (**optional**) - Ratio of CONTAINS_KEY requests. Default is 0.  
 > contains-value-ratio (**optional**) - Ratio of CONTAINS_VALUE requests. Default is 0.  
-> delay-between-requests (**optional**) - Time between consecutive requests of one stressor thread. Default is 0.  
+> cycle-time (**optional**) - Intended time between each request. Default is 0.  
 > duration (**optional**) - Benchmark duration. You have to set either this or 'totalNumOperations'.  
 > entry-size (**optional**) - Size of the value in bytes. Default is 1000.  
 > exit-on-failure (**optional**) - If true, then the benchmark stops when the stage returns an error. If false, then the stages in the current scenario are skipped, and the next scenario starts executing. Default is false.  
@@ -41,6 +41,7 @@ Test using MiltimapCacheOperations
 > statistics (**optional**) - Type of gathered statistics. Default are the 'default' statistics (fixed size memory footprint for each operation).  
 > synchronous-requests (**optional**) - Local threads synchronize on starting each round of requests. Note that with requestPeriod > 0, there is still the random ramp-up delay. Default is false.  
 > test-name (**optional**) - Name of the test as used for reporting. Default is 'Test'.  
+> think-time (**optional**) - Time between consecutive requests of one stressor thread. Default is 0.  
 > timeout (**optional**) - Max duration of the test. Default is infinite.  
 > total-threads (**optional**) - Total number of threads across whole cluster. You have to set either this or 'num-threads-per-node'. No default.  
 > transaction-size (**optional**) - Number of requests in one transaction. Default is 1.  

--- a/docs/stages/query.md
+++ b/docs/stages/query.md
@@ -35,7 +35,7 @@ Stage which executes a query.
 > class (**mandatory**) - Full class name of the object that should be queried. Mandatory.  
 > commit-transactions (**optional**) - Specifies whether the transactions should be committed (true) or rolled back (false). Default is true  
 > conditions (**mandatory**) - Conditions used in the query  
-> delay-between-requests (**optional**) - Time between consecutive requests of one stressor thread. Default is 0.  
+> cycle-time (**optional**) - Intended time between each request. Default is 0.  
 > duration (**optional**) - Benchmark duration. You have to set either this or 'totalNumOperations'.  
 > exit-on-failure (**optional**) - If true, then the benchmark stops when the stage returns an error. If false, then the stages in the current scenario are skipped, and the next scenario starts executing. Default is false.  
 > exposed-attributes (**optional**) - Full names of the attribute queried from InternalsExposition. Expecting values parse-able as long values. Default are none.  
@@ -61,6 +61,7 @@ Stage which executes a query.
 > statistics (**optional**) - Type of gathered statistics. Default are the 'default' statistics (fixed size memory footprint for each operation).  
 > synchronous-requests (**optional**) - Local threads synchronize on starting each round of requests. Note that with requestPeriod > 0, there is still the random ramp-up delay. Default is false.  
 > test-name (**optional**) - Name of the test as used for reporting. Default is 'Test'.  
+> think-time (**optional**) - Time between consecutive requests of one stressor thread. Default is 0.  
 > timeout (**optional**) - Max duration of the test. Default is infinite.  
 > total-threads (**optional**) - Total number of threads across whole cluster. You have to set either this or 'num-threads-per-node'. No default.  
 > transaction-size (**optional**) - Number of requests in one transaction. Default is 1.  

--- a/docs/stages/rest.md
+++ b/docs/stages/rest.md
@@ -11,7 +11,7 @@ Stage for starting REST operations in the background
 > amend-test (**optional**) - By default, each stage creates a new test. If this property is set to true,results are amended to existing test (as iterations). Default is false.  
 > commit-transactions (**optional**) - Specifies whether the transactions should be committed (true) or rolled back (false). Default is true  
 > context-path (**optional**) - The context path for this REST stage. Defaults to empty string.  
-> delay-between-requests (**optional**) - Time between consecutive requests of one stressor thread. Default is 0.  
+> cycle-time (**optional**) - Intended time between each request. Default is 0.  
 > duration (**optional**) - Benchmark duration. You have to set either this or 'totalNumOperations'.  
 > exit-on-failure (**optional**) - If true, then the benchmark stops when the stage returns an error. If false, then the stages in the current scenario are skipped, and the next scenario starts executing. Default is false.  
 > get-ratio (**optional**) - Ratio of GET requests. Default is 1 (100%).  
@@ -28,6 +28,7 @@ Stage for starting REST operations in the background
 > statistics (**optional**) - Type of gathered statistics. Default are the 'default' statistics (fixed size memory footprint for each operation).  
 > synchronous-requests (**optional**) - Local threads synchronize on starting each round of requests. Note that with requestPeriod > 0, there is still the random ramp-up delay. Default is false.  
 > test-name (**optional**) - Name of the test as used for reporting. Default is 'Test'.  
+> think-time (**optional**) - Time between consecutive requests of one stressor thread. Default is 0.  
 > timeout (**optional**) - Max duration of the test. Default is infinite.  
 > total-threads (**optional**) - Total number of threads across whole cluster. You have to set either this or 'num-threads-per-node'. No default.  
 > transaction-size (**optional**) - Number of requests in one transaction. Default is 1.  
@@ -38,7 +39,7 @@ Stage for stopping REST operations running in the background
 > amend-test (**optional**) - By default, each stage creates a new test. If this property is set to true,results are amended to existing test (as iterations). Default is false.  
 > commit-transactions (**optional**) - Specifies whether the transactions should be committed (true) or rolled back (false). Default is true  
 > context-path (**optional**) - The context path for this REST stage. Defaults to empty string.  
-> delay-between-requests (**optional**) - Time between consecutive requests of one stressor thread. Default is 0.  
+> cycle-time (**optional**) - Intended time between each request. Default is 0.  
 > duration (**optional**) - Benchmark duration. You have to set either this or 'totalNumOperations'.  
 > exit-on-failure (**optional**) - If true, then the benchmark stops when the stage returns an error. If false, then the stages in the current scenario are skipped, and the next scenario starts executing. Default is false.  
 > get-ratio (**optional**) - Ratio of GET requests. Default is 1 (100%).  
@@ -56,6 +57,7 @@ Stage for stopping REST operations running in the background
 > synchronous-requests (**optional**) - Local threads synchronize on starting each round of requests. Note that with requestPeriod > 0, there is still the random ramp-up delay. Default is false.  
 > test-name (**optional**) - Name of the test as used for reporting. Default is 'Test'.  
 > test-name-to-stop (**optional**) - Name of the background operations to be stopped. Default is 'Test'.  
+> think-time (**optional**) - Time between consecutive requests of one stressor thread. Default is 0.  
 > timeout (**optional**) - Max duration of the test. Default is infinite.  
 > total-threads (**optional**) - Total number of threads across whole cluster. You have to set either this or 'num-threads-per-node'. No default.  
 > transaction-size (**optional**) - Number of requests in one transaction. Default is 1.  
@@ -66,7 +68,7 @@ Test using RESTOperations with specific URL
 > amend-test (**optional**) - By default, each stage creates a new test. If this property is set to true,results are amended to existing test (as iterations). Default is false.  
 > commit-transactions (**optional**) - Specifies whether the transactions should be committed (true) or rolled back (false). Default is true  
 > context-path (**optional**) - The context path for this REST stage. Defaults to empty string.  
-> delay-between-requests (**optional**) - Time between consecutive requests of one stressor thread. Default is 0.  
+> cycle-time (**optional**) - Intended time between each request. Default is 0.  
 > duration (**optional**) - Benchmark duration. You have to set either this or 'totalNumOperations'.  
 > exit-on-failure (**optional**) - If true, then the benchmark stops when the stage returns an error. If false, then the stages in the current scenario are skipped, and the next scenario starts executing. Default is false.  
 > get-ratio (**optional**) - Ratio of GET requests. Default is 1 (100%).  
@@ -83,6 +85,7 @@ Test using RESTOperations with specific URL
 > statistics (**optional**) - Type of gathered statistics. Default are the 'default' statistics (fixed size memory footprint for each operation).  
 > synchronous-requests (**optional**) - Local threads synchronize on starting each round of requests. Note that with requestPeriod > 0, there is still the random ramp-up delay. Default is false.  
 > test-name (**optional**) - Name of the test as used for reporting. Default is 'Test'.  
+> think-time (**optional**) - Time between consecutive requests of one stressor thread. Default is 0.  
 > timeout (**optional**) - Max duration of the test. Default is infinite.  
 > total-threads (**optional**) - Total number of threads across whole cluster. You have to set either this or 'num-threads-per-node'. No default.  
 > transaction-size (**optional**) - Number of requests in one transaction. Default is 1.  


### PR DESCRIPTION
**I am asking for a review in the following topics:**

1.  Testing modes
- When `opsPerSec` is equals to 0. It means that the current behavior won't change. We will continue having the maximum throughput [1a]
- When `opsPerSec` is greater than 0. This mode is for benchmarking response time under load. [1b]

2. Notion of schedule
- Basically, the thread will sleep. In this case if we set `opsPerSec` equals 1, only one request per second will be generated.

[1a]
Throughput: latency == service time, response/wait time not recorded. Maximum throughput is an important test mode for flushing out CPU bottlenecks and contention. It may help in exposing IO configuration issues as well. It is not however a good predictor of response time distribution as no attempt is made to estimate independent request timing (i.e uncoordinated measurement). The maximum throughput number is valuable to batch processing etc, but I'd caution against using it for the sizing of a responsive system. If a system has responsiveness SLAs it is better to use the 'fixed' test mode and run for significant periods to determine the load under which response times SLA can be met.

[1b]
Fixed  ("-rate fixed=1000/s"): latency == response time, service/response/wait time recorded. This mode is for benchmarking response time under load. The partitions/second parameter is used to determine the fixed rate scheduled of the requests. The hdr log can be used to visualize latencies over time or aggregate latencies for any segment down to the logging frequency. The logs contain response/wait/ service components that can be extracted and handled separately.

All the information comes from: https://psy-lob-saw.blogspot.com.br/2016/07/fixing-co-in-cstress.html