### PR TITLE
Etcd fixes and avoid cache manager exception

### DIFF
--- a/plugins/etcd/src/main/java/org/radargun/service/EtcdServerLifecycle.java
+++ b/plugins/etcd/src/main/java/org/radargun/service/EtcdServerLifecycle.java
@@ -17,6 +17,7 @@ public class EtcdServerLifecycle extends ProcessLifecycle<EtcdServerService> {
             Utils.unzip(service.distributionZip, service.distributionDir);
             // the extraction erases the executable bits
             Utils.setPermissions(service.distributionDir + "/etcd", "rwxr-xr-x");
+            Utils.setPermissions(service.distributionDir + "/etcdctl", "rwxr-xr-x");
          }
       } catch (IOException e) {
          throw new RuntimeException("Failed to prepare etcd distribution!", e);


### PR DESCRIPTION
For etcd, allow String and byte[] as a cache key