### PR TITLE
Flight Recorder for Java Process

### DIFF
--- a/core/src/main/java/org/radargun/config/FlightRecorder.java
+++ b/core/src/main/java/org/radargun/config/FlightRecorder.java
@@ -1,0 +1,43 @@
+package org.radargun.config;
+
+import java.util.List;
+
+import static org.radargun.config.VmArgUtils.ensureArg;
+import static org.radargun.config.VmArgUtils.replace;
+
+public class FlightRecorder implements VmArg {
+   @Property(doc = "Start flight recording for the benchmark.", optional = false)
+   private boolean enabled = false;
+
+   @Property(doc = "File for the recording.")
+   private String filename;
+
+   @Property(doc = "Settings file with recording configuration.")
+   private String settings;
+
+   @Override
+   public void setArgs(List<String> args) {
+      if (!enabled)
+         return;
+      StringBuilder recordingParams = new StringBuilder("=compress=false,delay=10s,duration=24h");
+      if (filename != null)
+         recordingParams.append(",filename=").append(filename);
+      if (settings != null)
+         recordingParams.append(",settings=").append(settings);
+      ensureArg(args, "-XX:+UnlockCommercialFeatures");
+      ensureArg(args, "-XX:+FlightRecorder");
+      replace(args, "-XX:StartFlightRecording", recordingParams.toString());
+   }
+
+   public boolean isEnabled() {
+      return enabled;
+   }
+
+   public String getFilename() {
+      return filename;
+   }
+
+   public String getSettings() {
+      return settings;
+   }
+}

--- a/core/src/main/java/org/radargun/config/VmArg.java
+++ b/core/src/main/java/org/radargun/config/VmArg.java
@@ -1,0 +1,9 @@
+package org.radargun.config;
+
+import java.io.Serializable;
+import java.util.List;
+
+public interface VmArg extends Serializable {
+   /* Override arguments */
+   void setArgs(List<String> args);
+}

--- a/core/src/main/java/org/radargun/config/VmArgUtils.java
+++ b/core/src/main/java/org/radargun/config/VmArgUtils.java
@@ -1,0 +1,26 @@
+package org.radargun.config;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+
+public class VmArgUtils {
+
+   private VmArgUtils() {
+   }
+
+   static void ensureArg(Collection<String> args, String arg) {
+      if (!args.contains(arg))
+         args.add(arg);
+   }
+
+   static void replace(List<String> args, String prefix, String value) {
+      for (Iterator<String> it = args.iterator(); it.hasNext();) {
+         String arg = it.next();
+         if (arg.startsWith(prefix)) {
+            it.remove();
+         }
+      }
+      args.add(prefix + value);
+   }
+}

--- a/docs/stages/core.md
+++ b/docs/stages/core.md
@@ -112,6 +112,27 @@ Remember to set up JVM args: "-agentpath:/path/to/libjprofilerti.so=offline,id=1
 > slaves (**optional**) - Specifies on which slaves this stage should actively run. The result set is intersection of specified slaves, groups and roles. Default is all slaves.  
 > snapshot-directory (**optional**) - Directory where the snapshot should be written (for SAVE_SNAPSHOT).  
 
+### jgroups-probe-monitor-start
+Starts collecting jgroups statistics locally in each slave node.
+> address (**optional**) - Diagnostic address to send queries to. Default is 224.0.75.75.  
+> exit-on-failure (**optional**) - If true, then the benchmark stops when the stage returns an error. If false, then the stages in the current scenario are skipped, and the next scenario starts executing. Default is false.  
+> expected-response-count (**mandatory**) - Minimum number of responses to wait for. Default is -1 don't wait for responses.  
+> groups (**optional**) - Specifies in which groups this stage should actively run. The result set is intersection of specified slaves, groups and roles. Default is all groups.  
+> period (**optional**) - Period of statistics collection. The default is 60 seconds.  
+> port (**optional**) - Diagnostic port. Default is 7500.  
+> print-results-as-info (**optional**) - Print results of operation to log (INFO level). By default trace logging needs to be enabled.  
+> queries (**mandatory**) - List of queries to be performed.  
+> roles (**optional**) - Specifies on which slaves this stage should actively run, by their roles. The result set is intersection of specified slaves, groups and roles. Supported roles are [COORDINATOR]. Default is all roles.  
+> slaves (**optional**) - Specifies on which slaves this stage should actively run. The result set is intersection of specified slaves, groups and roles. Default is all slaves.  
+> timeout (**optional**) - Maximum time to wait for query responses. Default is 60 seconds. Valid only when used in conjunction with expectedResponseCount parameter.  
+
+### jgroups-probe-monitor-stop
+Stop collecting jgroups statistics locally in each slave node.
+> exit-on-failure (**optional**) - If true, then the benchmark stops when the stage returns an error. If false, then the stages in the current scenario are skipped, and the next scenario starts executing. Default is false.  
+> groups (**optional**) - Specifies in which groups this stage should actively run. The result set is intersection of specified slaves, groups and roles. Default is all groups.  
+> roles (**optional**) - Specifies on which slaves this stage should actively run, by their roles. The result set is intersection of specified slaves, groups and roles. Supported roles are [COORDINATOR]. Default is all roles.  
+> slaves (**optional**) - Specifies on which slaves this stage should actively run. The result set is intersection of specified slaves, groups and roles. Default is all slaves.  
+
 ### jmx-invocation
 Allows to invoke JMX-exposed methods and attributes.
 > continue-on-failure (**optional**) - Continue method invocations if an exception occurs. Default is false.  


### PR DESCRIPTION
Dynamically enable Flight Recorder using an environment variable.
Here is the example:


```xml
      <config name="dist">
         <setup group="server" plugin="${env.PLUGINNAME}">
            <server>
               <flight-recorder>
                  <enabled>${env.ENABLE_SERVER_FLIGHT_RECORDER:false}</enabled>
                  <settings>/${WORKSPACE}/jdg-qe-profile.jfc</settings>
                  <filename>${WORKSPACE}/jfr_server_${slave.index}.jfr</filename>
               </flight-recorder>
            </server>
         </setup>
         <setup group="client" plugin="${env.PLUGINNAME}">
            <hotrod xmlns="urn:radargun:plugins:${env.PLUGINNAME}:3.0" cache="hotrodDist">
               <servers>127.0.0.1:11222</servers>
            </hotrod>
         </setup>
      </config>
```
