### PR TITLE
Narayana is required for Infinispan 94x

### DIFF
--- a/plugins/infinispan-snapshot/pom.xml
+++ b/plugins/infinispan-snapshot/pom.xml
@@ -62,7 +62,7 @@
       <dependency>
          <groupId>org.jboss.narayana.jta</groupId>
          <artifactId>narayana-jta</artifactId>
-         <optional>true</optional>
+         <scope>compile</scope>
          <exclusions>
             <exclusion>
                <groupId>org.jboss.logging</groupId>

--- a/plugins/infinispan94/pom.xml
+++ b/plugins/infinispan94/pom.xml
@@ -26,7 +26,7 @@
             </property>
          </activation>
          <properties>
-            <version.infinispan>9.4.0.Final</version.infinispan>
+            <version.infinispan>9.4.1-SNAPSHOT</version.infinispan>
          </properties>
       </profile>
    </profiles>
@@ -76,7 +76,7 @@
       <dependency>
          <groupId>org.jboss.narayana.jta</groupId>
          <artifactId>narayana-jta</artifactId>
-         <optional>true</optional>
+         <scope>compile</scope>
          <exclusions>
             <exclusion>
                <groupId>org.jboss.logging</groupId>


### PR DESCRIPTION
After https://github.com/infinispan/infinispan/pull/6361 narayana is required when building the infinispan-plugin for the version 94x