### PR TITLE
Xslt support for the file configuration

### DIFF
--- a/core/src/main/java/org/radargun/config/FileConverter.java
+++ b/core/src/main/java/org/radargun/config/FileConverter.java
@@ -1,0 +1,34 @@
+package org.radargun.config;
+
+import java.lang.reflect.Type;
+
+/**
+ * Allow the file be converter with different approaches
+ *
+ * @author Diego Lovison &lt;dlovison@redhat.com&gt;
+ */
+public class FileConverter implements Converter<String> {
+
+   // we don't need multiple instances
+   private static final XsltConverter XSLT_CONVERTER = new XsltConverter();
+
+   @Override
+   public String convert(String value, Type type) {
+      return convertToString(value);
+   }
+
+   @Override
+   public String convertToString(String value) {
+      if (value != null && !value.isEmpty()) {
+         if (XSLT_CONVERTER.isXsltAttribute(value)) {
+            value = XSLT_CONVERTER.convertToString(value);
+         }
+      }
+      return value;
+   }
+
+   @Override
+   public String allowedPattern(Type type) {
+      return ".*";
+   }
+}

--- a/core/src/main/java/org/radargun/config/XsltConverter.java
+++ b/core/src/main/java/org/radargun/config/XsltConverter.java
@@ -1,0 +1,149 @@
+package org.radargun.config;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+import javax.xml.transform.Source;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerConfigurationException;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.stream.StreamResult;
+import javax.xml.transform.stream.StreamSource;
+
+import org.radargun.logging.Log;
+import org.radargun.logging.LogFactory;
+
+/**
+ * Responsible to parse `xslt(file_path, xslt_path)` into a file.
+ *
+ * The xslt function could have a third parameter that is the path where the file will be store `xslt(file_path, xslt_path, output_path)`
+ *
+ *
+ * @author Diego Lovison &lt;dlovison@redhat.com&gt;
+ */
+public class XsltConverter implements Converter<String> {
+
+   private static final Log log = LogFactory.getLog(XsltConverter.class);
+
+   private static final String XSLT_SEPARATOR = ",";
+   private static final String XSLT_PREFIX = "xslt(";
+
+
+   /**
+    * Return true if the parameter is function to parse the XML using XSLT
+    * @param file
+    *    xslt(file_path, xslt_path) is an expression that parse the file using the XSLT. Return true
+    *    foo/bar.xml is a full path. Return false
+    * @return true if is an operation to parse the XML using XSLT
+    */
+   public boolean isXsltAttribute(String file) {
+      boolean xslt = false;
+      if (file != null && !file.trim().isEmpty()) {
+         xslt = file.toLowerCase().startsWith(XSLT_PREFIX);
+      }
+      return xslt;
+   }
+
+   /**
+    * Return file wrote with the result from XSLT transformation
+    * @param file Only support xslt(file_path, xslt_path). The method @isXsltAttribute should be called first
+    * @return file filled with the result from XSLT transformation
+    */
+   @Override
+   public String convert(String file, Type type) {
+      return convertToString(file);
+   }
+
+   /**
+    * Return file wrote with the result from XSLT transformation
+    * @param file Only support xslt(file_path, xslt_path). The method @isXsltAttribute should be called first
+    * @return file filled with the result from XSLT transformation
+    */
+   @Override
+   public String convertToString(String file) {
+      String[] data;
+      File inputFile;
+      File xsltFile;
+      File outputFile;
+
+      try {
+         data = file.substring(XSLT_PREFIX.length(), file.length() - 1).split(XSLT_SEPARATOR);
+      } catch (Exception e) {
+         throw new IllegalStateException(file + " does not match the pattern: xslt(file_path, xslt_path)", e);
+      }
+
+      inputFile = getFile(data[0]);
+      xsltFile = getFile(data[1]);
+      if (data.length == 3) {
+         outputFile = createOutputFile(getFile(data[2]).getAbsolutePath());
+      } else {
+         outputFile = createOutputFile(inputFile.getParentFile().getAbsolutePath());
+      }
+
+      log.info(String.format("The file '%s' will be transformed using the xslt '%s'", inputFile, xsltFile));
+
+      TransformerFactory factory = TransformerFactory.newInstance();
+      Source xslt = new StreamSource(xsltFile);
+      Transformer transformer;
+      try {
+         transformer = factory.newTransformer(xslt);
+      } catch (TransformerConfigurationException e) {
+         throw new IllegalStateException("Error creating transformer using file " + xsltFile, e);
+      }
+
+      Source text = new StreamSource(inputFile);
+      try {
+         transformer.transform(text, new StreamResult(outputFile));
+      } catch (TransformerException e) {
+         throw new IllegalStateException("Error transforming the xml file", e);
+      }
+      return outputFile.getAbsolutePath();
+   }
+
+   @Override
+   public String allowedPattern(Type type) {
+      return ".*";
+   }
+
+   /**
+    * Return the file first from the classpath evaluating the string first.
+    * It is public because of the test.
+    * @param filePath a full path of the file
+    * @return the file from path
+    */
+   public static File getFile(String filePath) {
+      filePath = Evaluator.parseString(filePath.trim());
+      try {
+         File file;
+         URL url = XsltConverter.class.getResource("/" + filePath);
+         if (url != null) {
+            file = new File(url.toURI());
+         } else {
+            file = new File(filePath);
+         }
+         return file;
+      } catch (URISyntaxException e) {
+         throw new IllegalStateException("Cannot get the file: " + filePath, e);
+      }
+   }
+
+   private static File createOutputFile(String parent) {
+      File parentFolder = new File(parent);
+      parentFolder.mkdirs();
+
+      File outputFile = new File(parentFolder, "output.xml");
+      if (outputFile.exists()) {
+         outputFile.delete();
+      }
+      try {
+         outputFile.createNewFile();
+      } catch (IOException e) {
+         throw new IllegalStateException("File '" + outputFile.getAbsolutePath() + "'not created", e);
+      }
+      return outputFile;
+   }
+}

--- a/core/src/test/java/org/radargun/config/XsltConverterTest.java
+++ b/core/src/test/java/org/radargun/config/XsltConverterTest.java
@@ -1,0 +1,68 @@
+package org.radargun.config;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Test @{@link XsltConverter}
+ *
+ * @author Diego Lovison &lt;dlovison@redhat.com&gt;
+ */
+public class XsltConverterTest {
+
+   @Test
+   public void testIsXsltAttribute() {
+      Assert.assertTrue(new XsltConverter().isXsltAttribute("xslt(foo, bar)"));
+      Assert.assertFalse(new XsltConverter().isXsltAttribute("xslt/foo.xml"));
+      Assert.assertFalse(new XsltConverter().isXsltAttribute("foo/bar.xml"));
+      Assert.assertFalse(new XsltConverter().isXsltAttribute(null));
+   }
+
+   @Test
+   public void testTransform() throws IOException {
+      String outputFile = new XsltConverter().convertToString("xslt(input.xml, transform.xslt)");
+      assertOutput(XsltConverter.getFile("expected-output.xml"), new File(outputFile));
+   }
+
+   @Test
+   public void testEvaluatorPath() throws URISyntaxException, IOException {
+      File inputFile = new File(XsltConverter.class.getResource("/input.xml").toURI());
+      File xsltFile = new File(XsltConverter.class.getResource("/transform.xslt").toURI());
+      System.setProperty("INPUT_FILE_PATH", inputFile.getParent());
+      System.setProperty("XSLT_FILE_PATH", xsltFile.getParent());
+      String outputFile = new XsltConverter().convertToString("xslt(${INPUT_FILE_PATH}/input.xml, ${XSLT_FILE_PATH}/transform.xslt)");
+      assertOutput(XsltConverter.getFile("expected-output.xml"), new File(outputFile));
+   }
+
+   @Test
+   public void testCustomOutputDir() throws IOException {
+      String tmpDir = File.createTempFile("test", "Xslt").getParentFile().getAbsolutePath();
+      File outputFile = new File(new XsltConverter().convertToString("xslt(input.xml, transform.xslt, "+ tmpDir +")"));
+      assertOutput(XsltConverter.getFile("expected-output.xml"), outputFile);
+      Assert.assertEquals(tmpDir, outputFile.getParentFile().getAbsolutePath());
+   }
+
+   @Test
+   public void testOutputDirDoesNotExists() throws IOException {
+      String tmpDir = File.createTempFile("test", "Xslt").getParentFile().getAbsolutePath() + File.separatorChar + "foo" + File.separatorChar + "bar";
+      File outputFile = new File(new XsltConverter().convertToString("xslt(input.xml, transform.xslt, "+ tmpDir +")"));
+      assertOutput(XsltConverter.getFile("expected-output.xml"), outputFile);
+      Assert.assertEquals(tmpDir, outputFile.getParentFile().getAbsolutePath());
+   }
+
+   private void assertOutput(File expectedOuputFile, File currentOutputFile) throws IOException {
+      String expectedOutput = readContent(expectedOuputFile);
+      String currentOutput = readContent(currentOutputFile);
+      Assert.assertEquals(expectedOutput, currentOutput);
+   }
+
+   private String readContent(File file) throws IOException {
+      return new String(Files.readAllBytes(Paths.get(file.getAbsolutePath())));
+   }
+}

--- a/core/src/test/resources/expected-output.xml
+++ b/core/src/test/resources/expected-output.xml
@@ -1,0 +1,19 @@
+<html>
+<body>
+<h2>CD Collection</h2>
+<table>
+<tr>
+<th>Title</th><th>Artist</th>
+</tr>
+<tr>
+<td>Empire Burlesque</td><td>Bob Dylan</td>
+</tr>
+<tr>
+<td>Hide your heart</td><td>Bonnie Tyler</td>
+</tr>
+<tr>
+<td>Greatest Hits</td><td>Dolly Parton</td>
+</tr>
+</table>
+</body>
+</html>

--- a/core/src/test/resources/input.xml
+++ b/core/src/test/resources/input.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<catalog>
+   <cd>
+      <title>Empire Burlesque</title>
+      <artist>Bob Dylan</artist>
+      <country>USA</country>
+      <company>Columbia</company>
+      <price>10.90</price>
+      <year>1985</year>
+   </cd>
+   <cd>
+      <title>Hide your heart</title>
+      <artist>Bonnie Tyler</artist>
+      <country>UK</country>
+      <company>CBS Records</company>
+      <price>9.90</price>
+      <year>1988</year>
+   </cd>
+   <cd>
+      <title>Greatest Hits</title>
+      <artist>Dolly Parton</artist>
+      <country>USA</country>
+      <company>RCA</company>
+      <price>9.90</price>
+      <year>1982</year>
+   </cd>
+</catalog>

--- a/core/src/test/resources/transform.xslt
+++ b/core/src/test/resources/transform.xslt
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+
+<xsl:stylesheet version="1.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+   <xsl:template match="/">
+      <html>
+         <body>
+            <h2>CD Collection</h2>
+            <table>
+               <tr>
+                  <th>Title</th>
+                  <th>Artist</th>
+               </tr>
+               <xsl:for-each select="catalog/cd">
+                  <tr>
+                     <td><xsl:value-of select="title"/></td>
+                     <td><xsl:value-of select="artist"/></td>
+                  </tr>
+               </xsl:for-each>
+            </table>
+         </body>
+      </html>
+   </xsl:template>
+
+</xsl:stylesheet>

--- a/plugins/infinispan52/src/main/java/org/radargun/service/InfinispanServerService.java
+++ b/plugins/infinispan52/src/main/java/org/radargun/service/InfinispanServerService.java
@@ -1,13 +1,9 @@
 package org.radargun.service;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.InputStream;
-import java.net.URL;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -15,6 +11,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+
 import javax.management.MBeanServerConnection;
 import javax.management.remote.JMXConnector;
 
@@ -100,27 +97,9 @@ public class InfinispanServerService extends JavaProcessService {
             // the extraction erases the executable bits
             Utils.setPermissions(FileSystems.getDefault().getPath(home, "bin", getStartScriptPrefix() + (windows ? "bat" : "sh")).toString(), "rwxr-xr-x");
          }
-         URL resource = getClass().getResource("/" + file);
-         Path filesystemFile = FileSystems.getDefault().getPath(file);
-         Path target = FileSystems.getDefault().getPath(home, "standalone", "configuration", "radargun-" + ServiceHelper.getContext().getSlaveIndex() + ".xml");
-         
-         if (resource != null) {
-            try (InputStream is = resource.openStream()) {
-               log.info("Found " + file + " as a resource");
-               Files.copy(is, target, StandardCopyOption.REPLACE_EXISTING);
-            }
-         } else if (filesystemFile.toFile().exists()) {
-            log.info("Found " + file + " in plugin directory");
-            Files.copy(filesystemFile, target, StandardCopyOption.REPLACE_EXISTING);
-         } else if (FileSystems.getDefault().getPath(home, "standalone", "configuration", file).toFile().exists()) {
-            log.info("Found " + file + " in server configuration directory");
-            filesystemFile = FileSystems.getDefault().getPath(home, "standalone", "configuration", file);
-            // Set the file variable to the full path to the file to satisfy AbstractConfigurationProvider
-            file = filesystemFile.toString();
-            Files.copy(filesystemFile, target, StandardCopyOption.REPLACE_EXISTING);
-         } else {
-            throw new FileNotFoundException("File " + file + " not found neither as resource not in filesystem.");
-         }
+
+         evaluateFile(home, "standalone", "configuration");
+
       } catch (IOException e) {
          log.error("Failed to prepare the server directory", e);
          throw new RuntimeException(e);

--- a/plugins/infinispan52/src/main/java/org/radargun/service/ServerConfigurationProvider.java
+++ b/plugins/infinispan52/src/main/java/org/radargun/service/ServerConfigurationProvider.java
@@ -22,7 +22,7 @@ public class ServerConfigurationProvider extends AbstractConfigurationProvider {
 
    @Override
    public String getConfigFile() {
-      return service.file;
+      return service.getFile();
    }
 
    @Override

--- a/plugins/tomcat8/src/main/java/org/radargun/service/TomcatConfigurationProvider.java
+++ b/plugins/tomcat8/src/main/java/org/radargun/service/TomcatConfigurationProvider.java
@@ -30,7 +30,7 @@ public class TomcatConfigurationProvider implements ConfigurationProvider {
    public Map<String, byte[]> getOriginalConfigs() {
       Map<String, byte[]> configs = new HashMap<String, byte[]>();
       try {
-         Utils.loadConfigFile(service.file, configs);
+         Utils.loadConfigFile(service.getFile(), configs);
       } catch (Exception e) {
          log.error("Error while reading original configuration files", e);
       }

--- a/plugins/tomcat8/src/main/java/org/radargun/service/TomcatServerService.java
+++ b/plugins/tomcat8/src/main/java/org/radargun/service/TomcatServerService.java
@@ -2,19 +2,13 @@ package org.radargun.service;
 
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
-import java.nio.file.FileSystems;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
@@ -85,31 +79,8 @@ public class TomcatServerService extends JavaProcessService {
       log.info("Java home: " + java);
 
       lifecycle = new TomcatServerLifecycle(this);
-      try {
-         URL resource = getClass().getResource("/" + file);
-         Path filesystemFile = FileSystems.getDefault().getPath(file);
-         Path target = FileSystems.getDefault().getPath(catalinaBase, "conf", "radargun-tomcat-" + ServiceHelper.getContext().getSlaveIndex() + ".xml");
-         if (resource != null) {
-            try (InputStream is = resource.openStream()) {
-               log.info("Found " + file + " as a resource");
-               Files.copy(is, target, StandardCopyOption.REPLACE_EXISTING);
-            }
-         } else if (filesystemFile.toFile().exists()) {
-            log.info("Found " + file + " in plugin directory");
-            Files.copy(filesystemFile, target, StandardCopyOption.REPLACE_EXISTING);
-         } else if (FileSystems.getDefault().getPath(catalinaBase, "conf", file).toFile().exists()) {
-            log.info("Found " + file + " in server conf/ directory");
-            filesystemFile = FileSystems.getDefault().getPath(catalinaBase, "conf", file);
-            // Set the file variable to the full path to the file to satisfy AbstractConfigurationProvider
-            file = filesystemFile.toString();
-            Files.copy(filesystemFile, target, StandardCopyOption.REPLACE_EXISTING);
-         } else {
-            throw new FileNotFoundException("File " + file + " not found neither as resource nor in filesystem.");
-         }
-      } catch (IOException e) {
-         log.error("Failed to copy file", e);
-         throw new RuntimeException(e);
-      }
+
+      evaluateFile(catalinaHome, "conf");
    }
 
    @Override


### PR DESCRIPTION
Example of the benchmark configuration
```xml
<config name="dist">
  <setup group="server" plugin="${env.PLUGINNAME}">
    <server xmlns="urn:radargun:plugins:${env.PLUGINNAME}:3.0" file="xslt(file_path, xslt_path)" jmx-domain="jboss.datagrid-infinispan" cache-manager-name="clustered" start-timeout="120000" />
  </setup>
</config>
```