### PR TITLE
Removed duplicated infinispan-multimap

### DIFF
--- a/plugins/jdg72/pom.xml
+++ b/plugins/jdg72/pom.xml
@@ -152,13 +152,6 @@
          <optional>true</optional>
       </dependency>
 
-      <dependency>
-         <groupId>org.infinispan</groupId>
-         <artifactId>infinispan-multimap</artifactId>
-         <version>${version.infinispan}</version>
-         <optional>true</optional>
-      </dependency>
-
    </dependencies>
 
 </project>


### PR DESCRIPTION
When running `mvn ....  -pl \!plugins/infinispan100` it will fail because of the duplicated dependency. This PR fix that issue