### PR TITLE
Return empty CacheManagerInfo if serverNG is busy

### DIFF
--- a/core/src/main/java/org/radargun/Master.java
+++ b/core/src/main/java/org/radargun/Master.java
@@ -136,8 +136,7 @@ public class Master {
          log.info("Executed all benchmarks in " + Utils.getMillisDurationString(TimeService.currentTimeMillis() - benchmarkStart) + ", reporting...");
          for (Reporter reporter : reporters) {
             try {
-               log.info("Running reporter " + reporter);
-               reporter.run(masterConfig, Collections.unmodifiableList(reports));
+               reporter.run(masterConfig, Collections.unmodifiableList(reports), returnCode);
             } catch (Exception e) {
                log.error("Error in reporter " + reporter, e);
                returnCode = 127;

--- a/core/src/main/java/org/radargun/reporting/AbstractReporter.java
+++ b/core/src/main/java/org/radargun/reporting/AbstractReporter.java
@@ -1,0 +1,30 @@
+package org.radargun.reporting;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.radargun.config.MasterConfig;
+import org.radargun.config.Property;
+import org.radargun.logging.Log;
+import org.radargun.logging.LogFactory;
+
+public abstract class AbstractReporter implements Reporter {
+
+   private static Log log = LogFactory.getLog(AbstractReporter.class);
+
+   @Property(doc = "Which master return code should make the report run. Default is all. Comma separated.")
+   private List<Integer> masterReturnCodes;
+
+   public void run(MasterConfig masterConfig, Collection<Report> reports, int masterReturnCode) {
+      String className = this.getClass().getSimpleName();
+      if (masterReturnCodes == null || masterReturnCodes.isEmpty() || masterReturnCodes.contains(masterReturnCode)) {
+         log.info("Running reporter " + className);
+         run(masterConfig, reports);
+      } else {
+         log.info(String.format("Skipping report %s. Return codes are %s and the master return code is %d",
+               className, masterReturnCodes, masterReturnCode));
+      }
+   }
+
+   public abstract void run(MasterConfig masterConfig, Collection<Report> reports);
+}

--- a/core/src/main/java/org/radargun/reporting/AbstractReporter.java
+++ b/core/src/main/java/org/radargun/reporting/AbstractReporter.java
@@ -1,28 +1,42 @@
 package org.radargun.reporting;
 
 import java.util.Collection;
-import java.util.List;
 
 import org.radargun.config.MasterConfig;
 import org.radargun.config.Property;
 import org.radargun.logging.Log;
 import org.radargun.logging.LogFactory;
 
+/**
+ * Control the report generation based on the stage failure
+ *
+ * @author Diego Lovison &lt;dlovison@redhat.com&gt;
+ */
 public abstract class AbstractReporter implements Reporter {
 
    private static Log log = LogFactory.getLog(AbstractReporter.class);
 
-   @Property(doc = "Which master return code should make the report run. Default is all. Comma separated.")
-   private List<Integer> masterReturnCodes;
+   @Property(doc = "Set it to true if the report should be skipped when one stage failed. Default is false.")
+   private boolean skipOnStageFailures;
 
-   public void run(MasterConfig masterConfig, Collection<Report> reports, int masterReturnCode) {
+   public AbstractReporter() {
+   }
+
+   public AbstractReporter(boolean skipOnStageFailures) {
+      this.skipOnStageFailures = skipOnStageFailures;
+   }
+
+   @Override
+   public boolean run(MasterConfig masterConfig, Collection<Report> reports, int returnCode) {
       String className = this.getClass().getSimpleName();
-      if (masterReturnCodes == null || masterReturnCodes.isEmpty() || masterReturnCodes.contains(masterReturnCode)) {
+      boolean generateReport = skipOnStageFailures ? returnCode == 0 : true;
+      if (generateReport) {
          log.info("Running reporter " + className);
          run(masterConfig, reports);
+         return true;
       } else {
-         log.info(String.format("Skipping report %s. Return codes are %s and the master return code is %d",
-               className, masterReturnCodes, masterReturnCode));
+         log.info(String.format("Skipping report %s. Return code is %d", className, returnCode));
+         return false;
       }
    }
 

--- a/core/src/main/java/org/radargun/reporting/Reporter.java
+++ b/core/src/main/java/org/radargun/reporting/Reporter.java
@@ -1,6 +1,7 @@
 package org.radargun.reporting;
 
 import java.util.Collection;
+
 import org.radargun.config.MasterConfig;
 
 /**
@@ -10,5 +11,5 @@ import org.radargun.config.MasterConfig;
  */
 public interface Reporter {
 
-   void run(MasterConfig masterConfig, Collection<Report> reports, int masterReturnCode);
+   boolean run(MasterConfig masterConfig, Collection<Report> reports, int returnCode);
 }

--- a/core/src/main/java/org/radargun/reporting/Reporter.java
+++ b/core/src/main/java/org/radargun/reporting/Reporter.java
@@ -9,5 +9,6 @@ import org.radargun.config.MasterConfig;
  * It is expected that the implementation of this class will use @Property annotations to fill in the properties.
  */
 public interface Reporter {
-   void run(MasterConfig masterConfig, Collection<Report> reports);
+
+   void run(MasterConfig masterConfig, Collection<Report> reports, int masterReturnCode);
 }

--- a/core/src/main/resources/log4j.xml
+++ b/core/src/main/resources/log4j.xml
@@ -71,6 +71,10 @@
       <priority value="WARN"/>
    </category>
 
+   <category name="org.radargun.reporting.AbstractReporter">
+      <priority value="INFO"/>
+   </category>
+
    <category name="net.sf.ehcache">
       <priority value="WARN"/>
    </category>

--- a/core/src/main/resources/log4j2.xml
+++ b/core/src/main/resources/log4j2.xml
@@ -27,6 +27,10 @@
          <AppenderRef ref="CONSOLE"/>
       </Logger>
 
+      <Logger name="org.radargun.reporting.AbstractReporter" level="INFO" additivity="false">
+         <AppenderRef ref="CONSOLE"/>
+      </Logger>
+
       <Logger name="com.arjuna.ats.arjuna" level="WARN" additivity="false">
          <AppenderRef ref="CONSOLE"/>
       </Logger>

--- a/core/src/test/java/org/radargun/reporting/AbstractReporterTest.java
+++ b/core/src/test/java/org/radargun/reporting/AbstractReporterTest.java
@@ -1,0 +1,37 @@
+package org.radargun.reporting;
+
+import static org.testng.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertFalse;
+
+import java.util.Collection;
+
+import org.radargun.config.MasterConfig;
+import org.testng.annotations.Test;
+
+/**
+ *
+ * @author Diego Lovison &lt;dlovison@redhat.com&gt;
+ */
+@Test
+public class AbstractReporterTest {
+
+   public void skipOnStageFailure() {
+      // default behavior, always generate
+      assertTrue(createDummyAbstractReporter(false).run(null, null, 0));
+      assertTrue(createDummyAbstractReporter(false).run(null, null, 1));
+
+      // configure to skip, return code is 0, then it will generate the report
+      assertTrue(createDummyAbstractReporter(true).run(null, null, 0));
+
+      // configure to skip, return code is a failure, then it will skip the report generation
+      assertFalse(createDummyAbstractReporter(true).run(null, null, 1));
+   }
+
+   private AbstractReporter createDummyAbstractReporter(boolean skipOnStageFailures) {
+      return new AbstractReporter(skipOnStageFailures) {
+         @Override
+         public void run(MasterConfig masterConfig, Collection<Report> reports) {
+         }
+      };
+   }
+}

--- a/plugins/infinispan100/src/main/java/org/radargun/service/CacheManagerInfo.java
+++ b/plugins/infinispan100/src/main/java/org/radargun/service/CacheManagerInfo.java
@@ -145,6 +145,14 @@ public class CacheManagerInfo {
       this.clusterSize = clusterSize;
    }
 
+   @Override
+   public String toString() {
+      return "CacheManagerInfo{" +
+            "clusterMembers=" + clusterMembers +
+            ", clusterSize=" + clusterSize +
+            '}';
+   }
+
    static class BasicCacheInfo {
       String name;
       boolean started;

--- a/plugins/infinispan100/src/main/java/org/radargun/service/Infinispan100ServerService.java
+++ b/plugins/infinispan100/src/main/java/org/radargun/service/Infinispan100ServerService.java
@@ -48,7 +48,6 @@ public class Infinispan100ServerService extends Infinispan80ServerService {
    public void init() {
 
       executor = new ScheduledThreadPoolExecutor(executorPoolSize);
-      clustered = new Infinispan100ServerClustered(this, defaultServerPort);
       lifecycle = new InfinispanServerLifecycle(this) {
 
          @Override
@@ -66,6 +65,7 @@ public class Infinispan100ServerService extends Infinispan80ServerService {
             return STOPPED.getPattern();
          }
       };
+      clustered = new Infinispan100ServerClustered(this, defaultServerPort);
 
       try {
 

--- a/plugins/infinispan100/src/main/java/org/radargun/service/ServerLogPattern.java
+++ b/plugins/infinispan100/src/main/java/org/radargun/service/ServerLogPattern.java
@@ -9,7 +9,7 @@ import java.util.regex.Pattern;
 public enum ServerLogPattern {
 
    START_OK(".*\\[org\\.infinispan\\.SERVER\\].*started in.*"),
-   START_ERROR(".*\\[org\\.infinispan\\.SERVER\\].*Infinispan Server stopping.*"),
+   START_ERROR(".*\\[org\\.infinispan\\.SERVER\\].*Server failed to start.*"),
    STOPPED(".*\\[org\\.infinispan\\.SERVER\\].*stopped.*");
 
    String pattern;

--- a/plugins/infinispan52/src/main/java/org/radargun/service/InfinispanCacheManagerInfo.java
+++ b/plugins/infinispan52/src/main/java/org/radargun/service/InfinispanCacheManagerInfo.java
@@ -5,6 +5,11 @@ public class InfinispanCacheManagerInfo {
    private String membersString;
    private String nodeAddress;
 
+   public InfinispanCacheManagerInfo() {
+      this.membersString = "";
+      this.nodeAddress = "";
+   }
+
    public InfinispanCacheManagerInfo(String membersString, String nodeAddress) {
       this.membersString = membersString;
       this.nodeAddress = nodeAddress;

--- a/plugins/infinispan52/src/main/java/org/radargun/service/InfinispanServerLifecycle.java
+++ b/plugins/infinispan52/src/main/java/org/radargun/service/InfinispanServerLifecycle.java
@@ -39,17 +39,16 @@ public class InfinispanServerLifecycle extends ProcessLifecycle<InfinispanServer
             service.unregisterAction(getStartOK());
             service.unregisterAction(getStartError());
             fireAfterStart();
-
          }
       });
       service.registerAction(getStartError(), new ProcessService.OutputListener() {
          @Override
          public void run(Matcher m) {
             log.warn("Server started with errors");
-            setServerStarted();
+            setServerStopped();
             service.unregisterAction(getStartOK());
             service.unregisterAction(getStartError());
-            fireAfterStart();
+            kill();
          }
       });
       service.registerAction(getStoped(), new ProcessService.OutputListener() {
@@ -62,7 +61,6 @@ public class InfinispanServerLifecycle extends ProcessLifecycle<InfinispanServer
             service.unregisterAction(getStartError());
             service.unregisterAction(getStoped());
             fireAfterStop(gracefulStop);
-
          }
       });
       if (isRunning()) {

--- a/plugins/infinispan52/src/main/java/org/radargun/service/InfinispanServerService.java
+++ b/plugins/infinispan52/src/main/java/org/radargun/service/InfinispanServerService.java
@@ -178,7 +178,13 @@ public class InfinispanServerService extends JavaProcessService {
    }
 
    protected void schedule(Runnable task, long period) {
-      executor.scheduleAtFixedRate(task, 0, period, TimeUnit.MILLISECONDS);
+      executor.scheduleAtFixedRate(() -> {
+         try {
+            task.run();
+         } catch (Exception e) {
+            log.error("Error while executing Infinispan Server Task", e);
+         }
+      }, 0, period, TimeUnit.MILLISECONDS);
    }
 
    protected String getRadargunInstalationFolder() {

--- a/reporters/reporter-default/src/main/java/org/radargun/reporting/csv/CsvReporter.java
+++ b/reporters/reporter-default/src/main/java/org/radargun/reporting/csv/CsvReporter.java
@@ -25,8 +25,8 @@ import org.radargun.config.MasterConfig;
 import org.radargun.config.Property;
 import org.radargun.logging.Log;
 import org.radargun.logging.LogFactory;
+import org.radargun.reporting.AbstractReporter;
 import org.radargun.reporting.Report;
-import org.radargun.reporting.Reporter;
 import org.radargun.reporting.Timeline;
 import org.radargun.stats.Statistics;
 import org.radargun.stats.representation.DataThroughput;
@@ -41,7 +41,7 @@ import org.radargun.utils.Utils;
  *
  * @author Radim Vansa &lt;rvansa@redhat.com&gt;
  */
-public class CsvReporter implements Reporter {
+public class CsvReporter extends AbstractReporter {
 
    protected static final Log log = LogFactory.getLog(CsvReporter.class);
    protected static final String SLAVE_INDEX = "SlaveIndex";

--- a/reporters/reporter-default/src/main/java/org/radargun/reporting/html/HtmlReporter.java
+++ b/reporters/reporter-default/src/main/java/org/radargun/reporting/html/HtmlReporter.java
@@ -29,8 +29,8 @@ import org.radargun.config.Property;
 import org.radargun.config.PropertyDelegate;
 import org.radargun.logging.Log;
 import org.radargun.logging.LogFactory;
+import org.radargun.reporting.AbstractReporter;
 import org.radargun.reporting.Report;
-import org.radargun.reporting.Reporter;
 import org.radargun.reporting.Timeline;
 import org.radargun.reporting.commons.TestAggregations;
 
@@ -40,7 +40,7 @@ import org.radargun.reporting.commons.TestAggregations;
  *
  * @author Radim Vansa &lt;rvansa@redhat.com&gt;
  */
-public class HtmlReporter implements Reporter {
+public class HtmlReporter extends AbstractReporter {
    private static final Log log = LogFactory.getLog(HtmlReporter.class);
    /**
     * Shared executor used for long-running tasks when the report is generated.

--- a/reporters/reporter-default/src/main/java/org/radargun/reporting/serialized/SerializedReporter.java
+++ b/reporters/reporter-default/src/main/java/org/radargun/reporting/serialized/SerializedReporter.java
@@ -21,6 +21,7 @@ import org.radargun.config.Property;
 import org.radargun.config.ReporterConfiguration;
 import org.radargun.logging.Log;
 import org.radargun.logging.LogFactory;
+import org.radargun.reporting.AbstractReporter;
 import org.radargun.reporting.Report;
 import org.radargun.reporting.Reporter;
 import org.radargun.reporting.ReporterHelper;
@@ -30,7 +31,7 @@ import org.radargun.reporting.ReporterHelper;
  *
  * @author Radim Vansa &lt;rvansa@redhat.com&gt;
  */
-public class SerializedReporter implements Reporter {
+public class SerializedReporter extends AbstractReporter {
    private static final Log log = LogFactory.getLog(SerializedReporter.class);
 
    @Property(doc = "Directory where the results should be stored. Default is results/serialized.")
@@ -99,7 +100,7 @@ public class SerializedReporter implements Reporter {
             try {
                reporter = ReporterHelper.createReporter(rc.type, rcr.getProperties());
                if (reporter instanceof SerializedReporter) continue;
-               reporter.run(config, reports);
+               reporter.run(config, reports, 0);
             } catch (Exception e) {
                System.err.println("Failed to run reporter " + rc.type);
                e.printStackTrace();

--- a/reporters/reporter-perfrepo/src/main/java/org/radargun/reporting/perfrepo/PerfrepoReporter.java
+++ b/reporters/reporter-perfrepo/src/main/java/org/radargun/reporting/perfrepo/PerfrepoReporter.java
@@ -20,8 +20,8 @@ import org.radargun.config.Property;
 import org.radargun.config.PropertyHelper;
 import org.radargun.logging.Log;
 import org.radargun.logging.LogFactory;
+import org.radargun.reporting.AbstractReporter;
 import org.radargun.reporting.Report;
-import org.radargun.reporting.Reporter;
 import org.radargun.stats.Statistics;
 import org.radargun.stats.StatsUtils;
 import org.radargun.stats.representation.RepresentationType;
@@ -42,7 +42,7 @@ import org.radargun.utils.Utils;
  *
  * @author Matej Cimbora
  */
-public class PerfrepoReporter implements Reporter {
+public class PerfrepoReporter extends AbstractReporter {
 
    private static final Log log = LogFactory.getLog(PerfrepoReporter.class);
 


### PR DESCRIPTION
With this PR I am going to fix 4 situations:

1) When serverNG is busy we should return an empty ISPN Cache Manager Info because when we have Cluster Split Verify enabled, a long timeout, in this case, 10secs ( 1 sec X 10 times ) "means" that something is wrong in the cluster. GC is busy or another kind of situation.

2) The regex for the server startup was wrong. See https://github.com/infinispan/infinispan/pull/7449

3) When `scheduleAtFixedRate` is called and throw an exception a subsequent call won't be executed

4) Only report data if all stages have a custom return code.
Example
```
<perfrepo xmlns="urn:radargun:reporters:reporter-perfrepo:3.0" master-return-codes="0">
```