### PR TITLE
Fixing jaxb-core missing dependency

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -89,11 +89,20 @@
          <timezone>Brazil</timezone>
       </developer>
 
+      <developer>
+         <name>Gustavo Lira</name>
+         <roles>
+            <role>Developer</role>
+         </roles>
+         <timezone>UTC-3</timezone>
+      </developer>
+
    </developers>
    <properties>
       <maven.compiler.target>1.8</maven.compiler.target>
       <maven.compiler.source>1.8</maven.compiler.source>
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+      <version.glassfish.jaxb>2.2.11.jbossorg-1</version.glassfish.jaxb>
       <plugins.chm/>
       <plugins.couchbase/>
       <plugins.couchbase-latest/>
@@ -838,6 +847,11 @@
          <artifactId>powermock-module-testng</artifactId>
          <version>1.6.2</version>
          <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.glassfish.jaxb</groupId>
+         <artifactId>jaxb-core</artifactId>
+         <version>${version.glassfish.jaxb}</version>
       </dependency>
    </dependencies>
 

--- a/plugins/jdg80/pom.xml
+++ b/plugins/jdg80/pom.xml
@@ -146,7 +146,6 @@
          <groupId>org.infinispan</groupId>
          <artifactId>infinispan-persistence-soft-index</artifactId>
       </dependency>
-
    </dependencies>
 
    <dependencyManagement>


### PR DESCRIPTION
jaxb-core dependency could be overriden setting `version.glassfish.jaxb` parameter