### PR TITLE
Fix infinispan jaxb-core missing dependency

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -60,12 +60,12 @@
       <dependency>
          <groupId>org.glassfish.jaxb</groupId>
          <artifactId>jaxb-core</artifactId>
-         <version>2.3.0.1</version>
+         <version>${version.glassfish.jaxb}</version>
       </dependency>
       <dependency>
          <groupId>org.glassfish.jaxb</groupId>
          <artifactId>jaxb-runtime</artifactId>
-         <version>2.3.0.1</version>
+         <version>${version.glassfish.jaxb}</version>
       </dependency>
       <dependency>
          <groupId>javax.activation</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -144,6 +144,7 @@
       <extension.rest />
       <extension.counter/>
       <extension.multimap/>
+      <version.glassfish.jaxb>2.3.0.1</version.glassfish.jaxb>
    </properties>
 
    <profiles>

--- a/plugins/infinispan-snapshot/pom.xml
+++ b/plugins/infinispan-snapshot/pom.xml
@@ -43,6 +43,18 @@
          <version>${project.version}</version>
       </dependency>
 
+      <!--
+      TODO
+      dependencyManagement for org.infinispan:infinispan-parent which overwrite the core/pom.xml jaxb-core dependency
+      Infinisnpan jaxb-core version 2.3.1 doesn't exists
+      Once fixed in infinispan/master, remove this workaround
+      -->
+      <dependency>
+         <groupId>org.glassfish.jaxb</groupId>
+         <artifactId>jaxb-core</artifactId>
+         <version>${version.glassfish.jaxb}</version>
+      </dependency>
+
       <dependency>
          <groupId>org.infinispan</groupId>
          <artifactId>infinispan-core</artifactId>


### PR DESCRIPTION
dependencyManagement for org.infinispan:infinispan-parent overwrite the core/pom.xml jaxb-core dependency
Infinisnpan jaxb-core version 2.3.1 doesn't exists
Once fixed in infinispan/master, remove this workaround